### PR TITLE
feat: add `AGENT_ISSUANCE_CREDENTIAL_LOGO_URL` and `test` feature flag

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,4 +1,6 @@
 AGENT_CONFIG_LOG_FORMAT=json
 AGENT_CONFIG_EVENT_STORE=postgres
 AGENT_APPLICATION_HOST=my-domain.example.org
+AGENT_ISSUANCE_CREDENTIAL_NAME="Demo Credential"
+AGENT_ISSUANCE_CREDENTIAL_LOGO_URL=https://my-domain.example.org/credential_logo.png
 AGENT_STORE_DB_CONNECTION_STRING=postgresql://demo_user:demo_pass@localhost:5432/demo

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -22,6 +22,7 @@ name = "agent_api_rest"
 version = "0.1.0"
 dependencies = [
  "agent_issuance",
+ "agent_shared",
  "agent_store",
  "axum",
  "axum-auth",

--- a/agent_api_rest/Cargo.toml
+++ b/agent_api_rest/Cargo.toml
@@ -19,6 +19,7 @@ serde_json.workspace = true
 tracing.workspace = true
 
 [dev-dependencies]
+agent_shared = { path = "../agent_shared", features = ["test"] }
 agent_store = { path = "../agent_store" }
 
 lazy_static.workspace = true

--- a/agent_api_rest/src/credential_issuer/well_known/openid_credential_issuer.rs
+++ b/agent_api_rest/src/credential_issuer/well_known/openid_credential_issuer.rs
@@ -35,12 +35,23 @@ mod tests {
         startup_commands::{create_credentials_supported, load_credential_issuer_metadata},
         state::{initialize, CQRS},
     };
+    use agent_shared::config;
     use agent_store::in_memory;
     use axum::{
         body::Body,
         http::{self, Request},
     };
-    use serde_json::{json, Value};
+    use oid4vci::{
+        credential_format_profiles::{
+            w3c_verifiable_credentials::jwt_vc_json::{CredentialDefinition, JwtVcJson},
+            CredentialFormats, Parameters,
+        },
+        credential_issuer::{
+            credential_issuer_metadata::CredentialIssuerMetadata, credentials_supported::CredentialsSupportedObject,
+        },
+        ProofType,
+    };
+    use serde_json::json;
     use tower::ServiceExt;
 
     #[tokio::test]
@@ -73,31 +84,41 @@ mod tests {
         assert_eq!(response.status(), StatusCode::OK);
 
         let body = hyper::body::to_bytes(response.into_body()).await.unwrap();
-        let body: Value = serde_json::from_slice(&body).unwrap();
+        let cfredential_issuer_metadata: CredentialIssuerMetadata = serde_json::from_slice(&body).unwrap();
         assert_eq!(
-            body,
-            json!({
-                "credential_issuer": "https://example.com/",
-                "credential_endpoint": "https://example.com/openid4vci/credential",
-                "credentials_supported": [{
-                    "format": "jwt_vc_json",
-                    "cryptographic_binding_methods_supported": [
-                        "did:key"
-                    ],
-                    "cryptographic_suites_supported": [
-                        "EdDSA"
-                    ],
-                    "credential_definition":{
-                        "type": [
-                            "VerifiableCredential",
-                            "OpenBadgeCredential"
-                        ]
-                    },
-                    "proof_types_supported": [
-                        "jwt"
-                    ]
-                }]
-            })
+            cfredential_issuer_metadata,
+            CredentialIssuerMetadata {
+                credential_issuer: BASE_URL.clone(),
+                authorization_server: None,
+                credential_endpoint: BASE_URL.join("openid4vci/credential").unwrap(),
+                batch_credential_endpoint: None,
+                deferred_credential_endpoint: None,
+                credentials_supported: vec![CredentialsSupportedObject {
+                    id: None,
+                    credential_format: CredentialFormats::JwtVcJson(Parameters {
+                        format: JwtVcJson,
+                        parameters: (
+                            CredentialDefinition {
+                                type_: vec!["VerifiableCredential".to_string(), "OpenBadgeCredential".to_string()],
+                                credential_subject: None,
+                            },
+                            None,
+                        )
+                            .into(),
+                    }),
+                    scope: None,
+                    cryptographic_binding_methods_supported: Some(vec!["did:key".to_string()]),
+                    cryptographic_suites_supported: Some(vec!["EdDSA".to_string()]),
+                    proof_types_supported: Some(vec![ProofType::Jwt]),
+                    display: Some(vec![json!({
+                       "name": config!("credential_name").unwrap(),
+                       "logo": {
+                            "url": config!("credential_logo_url").unwrap()
+                       }
+                    })]),
+                }],
+                display: None,
+            }
         );
     }
 }

--- a/agent_api_rest/src/credential_issuer/well_known/openid_credential_issuer.rs
+++ b/agent_api_rest/src/credential_issuer/well_known/openid_credential_issuer.rs
@@ -84,9 +84,9 @@ mod tests {
         assert_eq!(response.status(), StatusCode::OK);
 
         let body = hyper::body::to_bytes(response.into_body()).await.unwrap();
-        let cfredential_issuer_metadata: CredentialIssuerMetadata = serde_json::from_slice(&body).unwrap();
+        let credential_issuer_metadata: CredentialIssuerMetadata = serde_json::from_slice(&body).unwrap();
         assert_eq!(
-            cfredential_issuer_metadata,
+            credential_issuer_metadata,
             CredentialIssuerMetadata {
                 credential_issuer: BASE_URL.clone(),
                 authorization_server: None,

--- a/agent_issuance/Cargo.toml
+++ b/agent_issuance/Cargo.toml
@@ -17,6 +17,7 @@ derivative = "2.2"
 did-key = "0.2"
 jsonschema = "0.17"
 jsonwebtoken = "8.2"
+lazy_static.workspace = true
 serde.workspace = true
 serde_json.workspace = true
 thiserror.workspace = true

--- a/agent_issuance/Cargo.toml
+++ b/agent_issuance/Cargo.toml
@@ -17,7 +17,6 @@ derivative = "2.2"
 did-key = "0.2"
 jsonschema = "0.17"
 jsonwebtoken = "8.2"
-lazy_static.workspace = true
 serde.workspace = true
 serde_json.workspace = true
 thiserror.workspace = true

--- a/agent_issuance/src/queries.rs
+++ b/agent_issuance/src/queries.rs
@@ -72,9 +72,9 @@ impl View<IssuanceData> for IssuanceDataView {
                     .replace(credential_offer.clone());
             }
             UnsignedCredentialCreated { subject_id, credential } => {
-                if let Some(subject) = self.subjects
-                    .iter_mut()
-                    .find(|subject| subject.id == *subject_id) { subject.credentials.replace(credential.clone()); }
+                if let Some(subject) = self.subjects.iter_mut().find(|subject| subject.id == *subject_id) {
+                    subject.credentials.replace(credential.clone());
+                }
             }
             PreAuthorizedCodeUpdated {
                 subject_id,

--- a/agent_issuance/src/startup_commands.rs
+++ b/agent_issuance/src/startup_commands.rs
@@ -85,8 +85,3 @@ pub fn create_credentials_supported() -> IssuanceCommand {
         }],
     }
 }
-
-#[test]
-fn test_startup_commands() {
-    dbg!(create_credentials_supported());
-}

--- a/agent_issuance/src/startup_commands.rs
+++ b/agent_issuance/src/startup_commands.rs
@@ -1,3 +1,4 @@
+use agent_shared::config;
 use oid4vci::{
     credential_format_profiles::{
         w3c_verifiable_credentials::jwt_vc_json::{CredentialDefinition, JwtVcJson},
@@ -9,6 +10,7 @@ use oid4vci::{
     },
     ProofType,
 };
+use serde_json::json;
 
 use crate::command::IssuanceCommand;
 
@@ -74,7 +76,17 @@ pub fn create_credentials_supported() -> IssuanceCommand {
             cryptographic_binding_methods_supported: Some(vec!["did:key".to_string()]),
             cryptographic_suites_supported: Some(vec!["EdDSA".to_string()]),
             proof_types_supported: Some(vec![ProofType::Jwt]),
-            display: None,
+            display: Some(vec![json!({
+               "name": config!("credential_name").unwrap(),
+               "logo": {
+                    "url": config!("credential_logo_url").unwrap()
+               }
+            })]),
         }],
     }
+}
+
+#[test]
+fn test_startup_commands() {
+    dbg!(create_credentials_supported());
 }

--- a/agent_issuance/src/startup_commands.rs
+++ b/agent_issuance/src/startup_commands.rs
@@ -12,10 +12,6 @@ use oid4vci::{
 
 use crate::command::IssuanceCommand;
 
-lazy_static! {
-    static ref BASE_URL: url::Url = format!("http://{}:3033/", config!("host").unwrap()).parse().unwrap();
-}
-
 /// Returns the startup commands for the application.
 pub fn startup_commands(host: url::Url) -> Vec<IssuanceCommand> {
     vec![

--- a/agent_issuance/src/startup_commands.rs
+++ b/agent_issuance/src/startup_commands.rs
@@ -13,7 +13,7 @@ use oid4vci::{
 use crate::command::IssuanceCommand;
 
 lazy_static! {
-    pub static ref BASE_URL: url::Url = format!("http://{}:3033/", config!("host").unwrap()).parse().unwrap();
+    static ref BASE_URL: url::Url = format!("http://{}:3033/", config!("host").unwrap()).parse().unwrap();
 }
 
 /// Returns the startup commands for the application.

--- a/agent_issuance/src/startup_commands.rs
+++ b/agent_issuance/src/startup_commands.rs
@@ -12,6 +12,10 @@ use oid4vci::{
 
 use crate::command::IssuanceCommand;
 
+lazy_static! {
+    pub static ref BASE_URL: url::Url = format!("http://{}:3033/", config!("host").unwrap()).parse().unwrap();
+}
+
 /// Returns the startup commands for the application.
 pub fn startup_commands(host: url::Url) -> Vec<IssuanceCommand> {
     vec![

--- a/agent_issuance/src/startup_commands.rs
+++ b/agent_issuance/src/startup_commands.rs
@@ -76,12 +76,15 @@ pub fn create_credentials_supported() -> IssuanceCommand {
             cryptographic_binding_methods_supported: Some(vec!["did:key".to_string()]),
             cryptographic_suites_supported: Some(vec!["EdDSA".to_string()]),
             proof_types_supported: Some(vec![ProofType::Jwt]),
-            display: Some(vec![json!({
-               "name": config!("credential_name").unwrap(),
-               "logo": {
-                    "url": config!("credential_logo_url").unwrap()
-               }
-            })]),
+            display: match (config!("credential_name"), config!("credential_logo_url")) {
+                (Ok(name), Ok(logo_url)) => Some(vec![json!({
+                    "name": name,
+                    "logo": {
+                        "url": logo_url
+                    }
+                })]),
+                _ => None,
+            },
         }],
     }
 }

--- a/agent_shared/Cargo.toml
+++ b/agent_shared/Cargo.toml
@@ -7,3 +7,6 @@ edition = "2021"
 config = { version = "0.13" }
 dotenvy = { version = "0.15" }
 tracing.workspace = true
+
+[features]
+test = []

--- a/agent_shared/src/config.rs
+++ b/agent_shared/src/config.rs
@@ -2,17 +2,31 @@ use tracing::info;
 
 /// Read environment variables
 pub fn config(package_name: &str) -> config::Config {
-    // Load global .env file
-    dotenvy::dotenv().ok();
+    let config = if cfg!(feature = "test") {
+        test_config()
+    } else {
+        dotenvy::dotenv().ok();
 
-    // Build configuration
-    let config = config::Config::builder()
-        .add_source(config::Environment::with_prefix(package_name))
-        .add_source(config::Environment::with_prefix("AGENT_CONFIG"))
-        .build()
-        .unwrap();
+        config::Config::builder()
+            .add_source(config::Environment::with_prefix(package_name))
+            .add_source(config::Environment::with_prefix("AGENT_CONFIG"))
+            .build()
+            .unwrap()
+    };
 
     info!("{:?}", config);
 
     config
+}
+
+/// Read environment variables for tests that can be used across packages
+#[cfg(feature = "test")]
+fn test_config() -> config::Config {
+    dotenvy::from_filename("agent_shared/tests/.env.test").ok();
+
+    config::Config::builder()
+        .add_source(config::Environment::with_prefix("TEST"))
+        .add_source(config::Environment::with_prefix("AGENT_CONFIG"))
+        .build()
+        .unwrap()
 }

--- a/agent_shared/src/config.rs
+++ b/agent_shared/src/config.rs
@@ -1,7 +1,6 @@
 use tracing::info;
 
 /// Read environment variables
-#[cfg(feature = "test")] // Only allow unused code when testing
 #[allow(unused)]
 pub fn config(package_name: &str) -> config::Config {
     #[cfg(feature = "test")]

--- a/agent_shared/src/config.rs
+++ b/agent_shared/src/config.rs
@@ -1,10 +1,14 @@
 use tracing::info;
 
 /// Read environment variables
+#[cfg(feature = "test")] // Only allow unused code when testing
+#[allow(unused)]
 pub fn config(package_name: &str) -> config::Config {
-    let config = if cfg!(feature = "test") {
-        test_config()
-    } else {
+    #[cfg(feature = "test")]
+    let config = test_config();
+
+    #[cfg(not(feature = "test"))]
+    let config = {
         dotenvy::dotenv().ok();
 
         config::Config::builder()

--- a/agent_shared/tests/.env.test
+++ b/agent_shared/tests/.env.test
@@ -1,3 +1,5 @@
-AGENT_SHARED_VARIABLE=env_value
+TEST_VARIABLE=env_value
 AGENT_CONFIG_GLOBAL_VARIABLE=global_env_value
 AGENT_OTHER_OTHER_VARIABLE=other_env_value
+TEST_CREDENTIAL_NAME="Demo Credential"
+TEST_CREDENTIAL_LOGO_URL=https://my-domain.example.org/credential_logo.png

--- a/agent_shared/tests/config.rs
+++ b/agent_shared/tests/config.rs
@@ -1,9 +1,8 @@
 use agent_shared::config;
 
+#[cfg(feature = "test")]
 #[test]
 fn test_config() {
-    dotenvy::from_filename("tests/.env.test").ok();
-
     assert_eq!(config!("variable").unwrap(), "env_value");
     assert_eq!(config!("global_variable").unwrap(), "global_env_value");
     // Reading from an environment variable that belongs to another package should fail.


### PR DESCRIPTION
# Description of change
Adds the option to add a logo uri to credentials by utilizing a new `AGENT_ISSUANCE_CREDENTIAL_LOGO_URL` environment variable (and an optional credential name by utilizing `AGENT_ISSUANCE_CREDENTIAL_NAME`. For example:

```env
AGENT_ISSUANCE_CREDENTIAL_NAME="Impierce Credential"
AGENT_ISSUANCE_CREDENTIAL_LOGO_URL=https://avatars.githubusercontent.com/u/122438622?s=200&v=4
```

## Links to any relevant issues
n/a

## How the change has been tested
The `config!` macro had to be slightly altered in order for it to be useful in unit tests outside of the `agent_shared` crate. This is solved by introducing a `test` feature flag for that crate that allows outside crates (for testing purposes) to read environment variables from `agent_shared/tests/.env.test` instead of the global `.env` file.

This allowed for adding a value for the display field in the `test_oauth_authorization_server_endpoint` test:
```rust
                    display: Some(vec![json!({
                       "name": config!("credential_name").unwrap(),
                       "logo": {
                            "url": config!("credential_logo_url").unwrap()
                       }
                    })]),
```

## Definition of Done checklist
Add an `x` to the boxes that are relevant to your changes.

- [x] I have followed the contribution guidelines for this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes