### PR TITLE
fix: add randomized `pre-authorized_code`, `access_token` and `c_nonce`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -77,6 +77,7 @@ dependencies = [
  "rand 0.8.5",
  "serde",
  "serde_json",
+ "serial_test",
  "thiserror",
  "time",
  "tokio",
@@ -826,6 +827,19 @@ dependencies = [
  "darling_core",
  "quote",
  "syn 2.0.41",
+]
+
+[[package]]
+name = "dashmap"
+version = "5.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "978747c1d849a7d2ee5e8adc0159961c48fb7e5db2f06af6723b80123bb53856"
+dependencies = [
+ "cfg-if",
+ "hashbrown 0.14.3",
+ "lock_api",
+ "once_cell",
+ "parking_lot_core 0.9.9",
 ]
 
 [[package]]
@@ -3324,6 +3338,31 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "93634eb5f75a2323b16de4748022ac4297f9e76b6dced2be287a099f41b5e788"
 dependencies = [
  "darling",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.41",
+]
+
+[[package]]
+name = "serial_test"
+version = "3.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "953ad9342b3aaca7cb43c45c097dd008d4907070394bd0751a0aa8817e5a018d"
+dependencies = [
+ "dashmap",
+ "futures",
+ "lazy_static",
+ "log",
+ "parking_lot 0.12.1",
+ "serial_test_derive",
+]
+
+[[package]]
+name = "serial_test_derive"
+version = "3.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b93fb4adc70021ac1b47f7d45e8cc4169baaa7ea58483bc5b721d19a26202212"
+dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.41",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -74,6 +74,7 @@ dependencies = [
  "oid4vc-core",
  "oid4vc-manager",
  "oid4vci",
+ "rand 0.8.5",
  "serde",
  "serde_json",
  "thiserror",

--- a/agent_api_rest/src/credential_issuer/token.rs
+++ b/agent_api_rest/src/credential_issuer/token.rs
@@ -75,7 +75,7 @@ mod tests {
         body::Body,
         http::{self, Request},
     };
-    use serde_json::{json, Value};
+    use serde_json::Value;
     use tower::ServiceExt;
 
     #[tokio::test]
@@ -111,13 +111,8 @@ mod tests {
 
         let body = hyper::body::to_bytes(response.into_body()).await.unwrap();
         let body: Value = serde_json::from_slice(&body).unwrap();
-        assert_eq!(
-            body,
-            json!({
-                "access_token": "unsafe_access_token",
-                "token_type": "bearer",
-                "c_nonce": "unsafe_c_nonce"
-            })
-        );
+        assert!(body["access_token"].as_str().is_some());
+        assert_eq!(body["token_type"], "bearer");
+        assert!(body["c_nonce"].as_str().is_some());
     }
 }

--- a/agent_issuance/Cargo.toml
+++ b/agent_issuance/Cargo.toml
@@ -17,6 +17,7 @@ derivative = "2.2"
 did-key = "0.2"
 jsonschema = "0.17"
 jsonwebtoken = "8.2"
+rand = "0.8"
 serde.workspace = true
 serde_json.workspace = true
 thiserror.workspace = true

--- a/agent_issuance/Cargo.toml
+++ b/agent_issuance/Cargo.toml
@@ -28,4 +28,5 @@ uuid.workspace = true
 
 [dev-dependencies]
 lazy_static.workspace = true
+serial_test = "3.0"
 tokio = { version = "1", features = ["full"] }

--- a/agent_issuance/src/model/aggregate.rs
+++ b/agent_issuance/src/model/aggregate.rs
@@ -31,8 +31,8 @@ const UNSAFE_ISSUER_KEY: &str = "this-is-a-very-UNSAFE-issuer-key";
 fn generate_random_string() -> String {
     let mut rng = rand::thread_rng();
 
-    // Generate 16 random bytes (128 bits)
-    let random_bytes: [u8; 16] = rng.gen();
+    // Generate 32 random bytes (256 bits)
+    let random_bytes: [u8; 32] = rng.gen();
 
     // Convert the random bytes to a hexadecimal string
     let random_string: String = random_bytes.iter().fold(String::new(), |mut acc, byte| {

--- a/agent_issuance/src/model/aggregate.rs
+++ b/agent_issuance/src/model/aggregate.rs
@@ -20,6 +20,7 @@ use oid4vci::{
     token_response::TokenResponse,
     VerifiableCredentialJwt,
 };
+use rand::Rng;
 use serde::{Deserialize, Serialize};
 use serde_json::json;
 use std::sync::Arc;
@@ -28,7 +29,26 @@ use std::sync::Arc;
 const UNSAFE_ACCESS_TOKEN: &str = "unsafe_access_token";
 const UNSAFE_C_NONCE: &str = "unsafe_c_nonce";
 const UNSAFE_ISSUER_KEY: &str = "this-is-a-very-UNSAFE-issuer-key";
-const UNSAFE_PRE_AUTHORIZED_CODE: &str = "unsafe_pre_authorized_code";
+
+fn pre_authorized_code() -> String {
+    let mut rng = rand::thread_rng();
+
+    // Generate a random pre-authorized_code with 16 bytes (128 bits)
+    let pre_authorized_code_bytes: [u8; 16] = rng.gen();
+
+    // Convert the pre-authorized_code bytes to a hexadecimal string
+    let pre_authorized_code: String = pre_authorized_code_bytes
+        .iter()
+        .map(|byte| format!("{:02x}", byte))
+        .collect();
+
+    pre_authorized_code
+}
+
+#[test]
+fn test_pre_authorized_code() {
+    println!("pre_authorized_code: {}", pre_authorized_code());
+}
 
 #[derive(Debug, Clone, Serialize, Deserialize, Default)]
 pub struct OID4VCIData {
@@ -170,7 +190,7 @@ impl Aggregate for IssuanceData {
                     events.push(IssuanceEvent::SubjectCreated {
                         subject: IssuanceSubject {
                             id: subject_id.clone(),
-                            pre_authorized_code: UNSAFE_PRE_AUTHORIZED_CODE.to_string(),
+                            pre_authorized_code: pre_authorized_code(),
                             ..Default::default()
                         },
                     });
@@ -586,6 +606,7 @@ mod tests {
         ))
         .unwrap()];
         static ref ISSUANCE_SUBJECT_ID: uuid::Uuid = uuid::Uuid::new_v4();
+        static ref UNSAFE_PRE_AUTHORIZED_CODE: &'static str = "unsafe_pre_authorized_code";
         static ref ISSUANCE_SUBJECT: IssuanceSubject = IssuanceSubject {
             id: ISSUANCE_SUBJECT_ID.to_string(),
             pre_authorized_code: UNSAFE_PRE_AUTHORIZED_CODE.to_string(),

--- a/agent_issuance/src/model/aggregate.rs
+++ b/agent_issuance/src/model/aggregate.rs
@@ -37,10 +37,10 @@ fn pre_authorized_code() -> String {
     let pre_authorized_code_bytes: [u8; 16] = rng.gen();
 
     // Convert the pre-authorized_code bytes to a hexadecimal string
-    let pre_authorized_code: String = pre_authorized_code_bytes
-        .iter()
-        .map(|byte| format!("{:02x}", byte))
-        .collect();
+    let pre_authorized_code: String = pre_authorized_code_bytes.iter().fold(String::new(), |mut acc, byte| {
+        acc.push_str(&format!("{:02x}", byte));
+        acc
+    });
 
     pre_authorized_code
 }


### PR DESCRIPTION
# Description of change
Due to the use of static values for `pre-authorized_code`, `access_token` and `c_nonce`, the ssi_agent did not properly support management of multiple 'subjects'. It resulted in not properly identifying subjects in the oid4vci pre-authorized flow which in turn resulted in sometimes returning credentials that not belong to the wallet/subject that initiated the (oid4vci) flow. 

This fix introduces the randomization of `pre-authorized_code`, `access_token` and `c_nonce`.

## Links to any relevant issues
n/a

## How the change has been tested
The unit tests in `aggregate.rs` are improved by adding functionality to support multiple subjects.

## Definition of Done checklist
Add an `x` to the boxes that are relevant to your changes.

- [x] I have followed the contribution guidelines for this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes