### PR TITLE
fix: fix panic on missing `issuer_key_id` in `agent_issuance`

### DIFF
--- a/agent_application/docker/README.md
+++ b/agent_application/docker/README.md
@@ -17,14 +17,16 @@ Inside the folder `/agent_application/docker`:
    - `AGENT_ISSUANCE_CREDENTIAL_NAME`: To set the name of the credentials that will be issued.
    - `AGENT_ISSUANCE_CREDENTIAL_LOGO_URL`: To set the URL of the logo that will be used in the credentials.
 > [!IMPORTANT] 
-> 3. By default, UniCore will automatically generate a temporary secure Stronghold file which will be used to sign
->    authorization requests and credentials. Note that using this default option, this Stronghold file will NOT be
->    persisted. If you want to ensure that the key material that is used for signing data will always be consistent, you
->    will need to supply an existing Stronghold file. This can be done by mounting the Stronghold file in the `docker-compose.yml` file. Example:
->   ```yaml
->   volumes:
->     - /path/to/stronghold:/app/res/stronghold
->   ```
+> 3. By default, UniCore currently uses a default Stronghold file which is used for storing secrets. Using this default
+>    Stronghold is for testing purposes only and should not be used in production. To use your own Stronghold file, you
+>    need to mount it in the `docker-compose.yml` file by replacing the default volume. Example:
+> ```yaml
+>  volumes:
+>    # - ../../agent_secret_manager/tests/res/test.stronghold:/app/res/stronghold # Default Stronghold file
+>    - /path/to/stronghold:/app/res/stronghold
+>  ```
+>    It is recommended to not change the target path `/app/res/stronghold`.
+> 
 >   You will also need to set the following environment variables: 
 >   - `AGENT_SECRET_MANAGER_STRONGHOLD_PATH`: The path to the Stronghold file. This value must correspond to the path to which
 >     the Stronghold is mounted. Set to `/app/res/stronghold` by default. It

--- a/agent_application/docker/docker-compose.yml
+++ b/agent_application/docker/docker-compose.yml
@@ -41,6 +41,7 @@ services:
       AGENT_STORE_DB_CONNECTION_STRING: postgresql://demo_user:demo_pass@cqrs-postgres-db:5432/demo
       AGENT_SECRET_MANAGER_STRONGHOLD_PATH: /app/res/stronghold
       AGENT_SECRET_MANAGER_STRONGHOLD_PASSWORD: "secure_password"
+      AGENT_SECRET_MANAGER_ISSUER_KEY_ID: "9O66nzWqYYy1LmmiOudOlh2SMIaUWoTS"
     volumes:
-      # - /path/to/stronghold:/app/res/stronghold
+      - ../../agent_secret_manager/tests/res/test.stronghold:/app/res/stronghold
       - ../../agent_event_publisher_http/config.yml:/app/agent_event_publisher_http/config.yml


### PR DESCRIPTION
# Description of change
There was a panic in `agent_issuance` when the 'optional' `AGENT_SECRET_MANAGER_ISSUER_KEY_ID` environment variable was not set. This change fixes that by setting it by default and mount the `test.stronghold` file by default.

## Links to any relevant issues
- #41

## How the change has been tested
Manually tested and tested using the Postman Collection.

## Definition of Done checklist
Add an `x` to the boxes that are relevant to your changes.

- [x] I have followed the contribution guidelines for this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes