### PR TITLE
fix: add `state` to `AuthorizationResponseVerified` events

### DIFF
--- a/agent_verification/src/connection/event.rs
+++ b/agent_verification/src/connection/event.rs
@@ -3,8 +3,8 @@ use serde::{Deserialize, Serialize};
 
 #[derive(Clone, Debug, Deserialize, PartialEq, Serialize)]
 pub enum ConnectionEvent {
-    SIOPv2AuthorizationResponseVerified { id_token: String },
-    OID4VPAuthorizationResponseVerified { vp_token: String },
+    SIOPv2AuthorizationResponseVerified { id_token: String, state: Option<String> },
+    OID4VPAuthorizationResponseVerified { vp_token: String, state: Option<String> },
 }
 
 impl DomainEvent for ConnectionEvent {

--- a/agent_verification/src/connection/queries.rs
+++ b/agent_verification/src/connection/queries.rs
@@ -11,6 +11,7 @@ pub type SIOPv2AuthorizationRequest = oid4vc_core::authorization_request::Author
 pub struct ConnectionView {
     id_token: Option<String>,
     vp_token: Option<String>,
+    state: Option<String>,
 }
 
 impl View<Connection> for ConnectionView {
@@ -18,11 +19,13 @@ impl View<Connection> for ConnectionView {
         use crate::connection::event::ConnectionEvent::*;
 
         match &event.payload {
-            SIOPv2AuthorizationResponseVerified { id_token } => {
+            SIOPv2AuthorizationResponseVerified { id_token, state } => {
                 self.id_token.replace(id_token.clone());
+                self.state.clone_from(state);
             }
-            OID4VPAuthorizationResponseVerified { vp_token } => {
+            OID4VPAuthorizationResponseVerified { vp_token, state } => {
                 self.vp_token.replace(vp_token.clone());
+                self.state.clone_from(state);
             }
         }
     }


### PR DESCRIPTION
# Description of change
The `state` needs to be contained in the events published to the outside in order to enable consumers to track flows in their own logic.

## Links to any relevant issues
n/a

## How the change has been tested
n/a

## Definition of Done checklist
Add an `x` to the boxes that are relevant to your changes.

- [x] I have followed the contribution guidelines for this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes