### PR TITLE
feat: enable `CorsLayer` (permissive) based on env variable

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,6 +1,7 @@
 AGENT_CONFIG_LOG_FORMAT=json
 AGENT_CONFIG_EVENT_STORE=postgres
 AGENT_APPLICATION_URL=https://my-domain.example.org
+AGENT_APPLICATION_ENABLE_CORS=false
 AGENT_ISSUANCE_CREDENTIAL_NAME="Demo Credential"
 AGENT_ISSUANCE_CREDENTIAL_LOGO_URL=https://my-domain.example.org/credential_logo.png
 AGENT_SECRET_MANAGER_STRONGHOLD_PATH="test.stronghold"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -36,7 +36,7 @@ serde_with = "3.7"
 serde_yaml = "0.9"
 thiserror = "1.0"
 tokio = { version = "1", features = ["full"] }
-tower-http = { version = "0.5", features = ["trace"] }
+tower-http = { version = "0.5", features = ["cors", "trace"] }
 tracing = { version = "0.1" }
 tracing-subscriber = { version = "0.3", features = ["json", "env-filter"] }
 tracing-test = { version = "0.2" }

--- a/agent_api_rest/README.md
+++ b/agent_api_rest/README.md
@@ -9,3 +9,7 @@ docker run --rm -p 9090:8080 -e SWAGGER_JSON=/tmp/openapi.yaml -v $(pwd):/tmp sw
 ```
 
 Browse to http://localhost:9090
+
+### CORS
+
+If you want to access UniCore's API from a browser, you can set the `AGENT_APPLICATION_ENABLE_CORS` environment variable to `true`. This will enable a permissive CORS policy (allow all).


### PR DESCRIPTION
# Description of change
Enabling CORS allows browser-based access to the REST API.

## Links to any relevant issues
n/a

## How the change has been tested
Postman

## Definition of Done checklist
Add an `x` to the boxes that are relevant to your changes.

- [x] I have followed the contribution guidelines for this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes