### PR TITLE
ci: use dedicated `arm64` runner

### DIFF
--- a/.github/workflows/build-push-docker.yaml
+++ b/.github/workflows/build-push-docker.yaml
@@ -9,13 +9,15 @@ env:
 
 jobs:
   build:
-    runs-on: ubuntu-latest
     strategy:
       fail-fast: false
       matrix:
-        platform:
-          - linux/amd64
-          - linux/arm64
+        include:
+          - platform: linux/amd64
+            runs-on: ubuntu-latest
+          - platform: linux/arm64
+            runs-on: linux-arm64_4-core-16gb
+    runs-on: ${{ matrix.runs-on }}
     steps:
       - name: Prepare
         run: |


### PR DESCRIPTION
# Description of change
By using a dedicated [GitHub-hosted runner for Arm64](https://github.blog/2024-06-03-arm64-on-github-actions-powering-faster-more-efficient-build-systems/) Docker image builds should speed up drastically since there is no more virtualization (QEMU) required.

## Links to any relevant issues
n/a

## How the change has been tested
n/a

## Definition of Done checklist
Add an `x` to the boxes that are relevant to your changes.

- [x] I have followed the contribution guidelines for this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes