### PR TITLE
ci: allow manual Docker builds

### DIFF
--- a/.github/workflows/build-push-docker.yaml
+++ b/.github/workflows/build-push-docker.yaml
@@ -2,6 +2,7 @@
 name: Build and push Docker image
 
 on:
+  workflow_dispatch:
   push:
     branches: ["dev"]
 


### PR DESCRIPTION
# Description of change
Temporarily allow manually triggered Docker builds. Useful for testing versions for unmerged branches.

## Links to any relevant issues
n/a

## How the change has been tested
n/a

## Definition of Done checklist
Add an `x` to the boxes that are relevant to your changes.

- [x] I have followed the contribution guidelines for this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] I have successfully tested this change in a docker environment 
