### PR TITLE
docs: use Docusaurus admonitions syntax

### DIFF
--- a/agent_application/CONFIGURATION.md
+++ b/agent_application/CONFIGURATION.md
@@ -2,11 +2,13 @@
 
 A configuration file is used to configure UniCore. It is expected to be present in `agent_application/config.yaml`. An example can be found in [example-config.yaml](example-config.yaml). Values can also be set through the environment, preferably used to inject sensitive values or environment-specific values.
 
-> [!NOTE]
-> Environment variables **override** values specified in the configuration file.
+:::info
+Environment variables **override** values specified in the configuration file.
+:::
 
-> [!IMPORTANT]
-> All environment variables need to be prefixed with `UNICORE__` to prevent conflicts with existing variables.
+:::note
+All environment variables need to be prefixed with `UNICORE__` to prevent conflicts with other unrelated variables.
+:::
 
 ## General
 
@@ -39,7 +41,8 @@ A configuration file is used to configure UniCore. It is expected to be present 
 
 ## Look and Feel
 
-> [!NOTE]
-> Setting display values is currently not supported through environment variables. Please refer to `config.yaml`.
+:::info
+Setting display values is currently not supported through environment variables. Please refer to `config.yaml`.
+:::
 
 <!-- TODO: DISPLAY_0_NAME: even configured through env vars? -->


### PR DESCRIPTION
# Description of change
Since docs are preferrably viewed in a deployed Docusaurus, we want to use its [admonitions](https://docusaurus.io/docs/markdown-features/admonitions) style over the GitHub style.

## Links to any relevant issues
n/a

## How the change has been tested
n/a

## Definition of Done checklist
Add an `x` to the boxes that are relevant to your changes.

- [x] I have followed the contribution guidelines for this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] I have successfully tested this change in a docker environment 
