### PR TITLE
feat: allow querying all offers and all credentials of issuer

### DIFF
--- a/agent_api_rest/postman/ssi-agent.postman_collection.json
+++ b/agent_api_rest/postman/ssi-agent.postman_collection.json
@@ -142,21 +142,9 @@
 							}
 						}
 					],
-					"protocolProfileBehavior": {
-						"disableBodyPruning": true
-					},
 					"request": {
 						"method": "GET",
 						"header": [],
-						"body": {
-							"mode": "raw",
-							"raw": "{\n    \"offerId\":\"{{OFFER_ID}}\",\n    \"credentialConfigurationId\": \"w3c_vc_credential\",\n    \"credential\": {\n        \"credentialSubject\": {\n            \"first_name\": \"Ferris\",\n            \"last_name\": \"Crabman\",\n            \"dob\": \"1982-01-01\"\n        }\n    }\n}",
-							"options": {
-								"raw": {
-									"language": "json"
-								}
-							}
-						},
 						"url": {
 							"raw": "{{HOST}}/v0/credentials",
 							"host": [
@@ -253,21 +241,9 @@
 							}
 						}
 					],
-					"protocolProfileBehavior": {
-						"disableBodyPruning": true
-					},
 					"request": {
 						"method": "GET",
 						"header": [],
-						"body": {
-							"mode": "raw",
-							"raw": "{\n    \"offerId\": \"{{OFFER_ID}}\"\n}",
-							"options": {
-								"raw": {
-									"language": "json"
-								}
-							}
-						},
 						"url": {
 							"raw": "{{HOST}}/v0/offers",
 							"host": [

--- a/agent_api_rest/postman/ssi-agent.postman_collection.json
+++ b/agent_api_rest/postman/ssi-agent.postman_collection.json
@@ -1,9 +1,9 @@
 {
 	"info": {
-		"_postman_id": "3b1e6396-3bf7-43aa-bc3b-21056fb21dfa",
+		"_postman_id": "6fd9c208-ee8c-4e20-ab0a-346e2c92ba1a",
 		"name": "ssi-agent",
 		"schema": "https://schema.getpostman.com/json/collection/v2.1.0/collection.json",
-		"_exporter_id": "24972330"
+		"_exporter_id": "37402219"
 	},
 	"item": [
 		{
@@ -26,6 +26,16 @@
 								"type": "text/javascript",
 								"packages": {}
 							}
+						},
+						{
+							"listen": "prerequest",
+							"script": {
+								"exec": [
+									""
+								],
+								"type": "text/javascript",
+								"packages": {}
+							}
 						}
 					],
 					"request": {
@@ -33,7 +43,7 @@
 						"header": [],
 						"body": {
 							"mode": "raw",
-							"raw": "{\n    \"offerId\":\"{{OFFER_ID}}\",\n    \"credentialConfigurationId\": \"openbadge_credential\",\n    \"credential\": {\n        \"credentialSubject\": {\n            \"type\": [ \"AchievementSubject\" ],\n            \"achievement\": {\n                \"id\": \"https://example.com/achievements/21st-century-skills/teamwork\",\n                \"type\": \"Achievement\",\n                \"criteria\": {\n                    \"narrative\": \"Team members are nominated for this badge by their peers and recognized upon review by Example Corp management.\"\n                },\n                \"description\": \"This badge recognizes the development of the capacity to collaborate within a group environment.\",\n                \"name\": \"Teamwork\"\n            }\n        }\n    }\n}",
+							"raw": "{\n       \"offerId\": {{OFFER_ID}},\n       \"credentialConfigurationId\": \"openbadge_credential\",\n       \"credential\":{\n           \"credentialSubject\":{\n               \"type\":[\"AchievementSubject\"],\n               \"achievement\": {\n                       \"id\": \"https://demo.edubadges.nl/public/assertions/DAO4oUapQ_eJr9VwMz6jIQ\",\n                       \"type\": \"Achievement\",\n                       \"criteria\":{\"narrative\": \"testtesttesttesttesttesttest\"},\n                       \"description\": \"testtesttesttesttesttesttesttest\",\n                       \"name\": \"Geschiedenis van de Oudheid\",\n                       \"image\":{\n                           \"id\": \"https://api-demo.edubadges.nl/media/uploads/badges/issuer_badgeclass_3e51ca72-ee9b-493b-b787-fd89f2df3189.png\",\n                           \"type\": \"Image\"\n                       }\n                   }\n               }\n           }\n       }",
 							"options": {
 								"raw": {
 									"language": "json"
@@ -74,8 +84,11 @@
 						{
 							"listen": "prerequest",
 							"script": {
-								"exec": [],
-								"type": "text/javascript"
+								"exec": [
+									""
+								],
+								"type": "text/javascript",
+								"packages": {}
 							}
 						}
 					],
@@ -85,6 +98,114 @@
 						"body": {
 							"mode": "raw",
 							"raw": "{\n    \"offerId\":\"{{OFFER_ID}}\",\n    \"credentialConfigurationId\": \"w3c_vc_credential\",\n    \"credential\": {\n        \"credentialSubject\": {\n            \"first_name\": \"Ferris\",\n            \"last_name\": \"Crabman\",\n            \"dob\": \"1982-01-01\"\n        }\n    }\n}",
+							"options": {
+								"raw": {
+									"language": "json"
+								}
+							}
+						},
+						"url": {
+							"raw": "{{HOST}}/v0/credentials",
+							"host": [
+								"{{HOST}}"
+							],
+							"path": [
+								"v0",
+								"credentials"
+							]
+						}
+					},
+					"response": []
+				},
+				{
+					"name": "all_credentials",
+					"event": [
+						{
+							"listen": "test",
+							"script": {
+								"exec": [
+									"const location = pm.response.headers.get(\"LOCATION\");",
+									"",
+									"if(location){",
+									"    pm.collectionVariables.set(\"CREDENTIAL_LOCATION\",location)",
+									"}",
+									""
+								],
+								"type": "text/javascript",
+								"packages": {}
+							}
+						},
+						{
+							"listen": "prerequest",
+							"script": {
+								"exec": [
+									""
+								],
+								"type": "text/javascript",
+								"packages": {}
+							}
+						}
+					],
+					"request": {
+						"method": "POST",
+						"header": [],
+						"body": {
+							"mode": "raw",
+							"raw": "{\n    \"offerId\":\"{{OFFER_ID}}\",\n    \"credentialConfigurationId\": \"w3c_vc_credential\",\n    \"credential\": {\n        \"credentialSubject\": {\n            \"first_name\": \"Ferris\",\n            \"last_name\": \"Crabman\",\n            \"dob\": \"1982-01-01\"\n        }\n    }\n}",
+							"options": {
+								"raw": {
+									"language": "json"
+								}
+							}
+						},
+						"url": {
+							"raw": "{{HOST}}/v0/credentials",
+							"host": [
+								"{{HOST}}"
+							],
+							"path": [
+								"v0",
+								"credentials"
+							]
+						}
+					},
+					"response": []
+				},
+				{
+					"name": "temp_thuiswinkel_credential",
+					"event": [
+						{
+							"listen": "test",
+							"script": {
+								"exec": [
+									"const location = pm.response.headers.get(\"LOCATION\");",
+									"",
+									"if(location){",
+									"    pm.collectionVariables.set(\"CREDENTIAL_LOCATION\",location)",
+									"}",
+									""
+								],
+								"type": "text/javascript",
+								"packages": {}
+							}
+						},
+						{
+							"listen": "prerequest",
+							"script": {
+								"exec": [
+									""
+								],
+								"type": "text/javascript",
+								"packages": {}
+							}
+						}
+					],
+					"request": {
+						"method": "POST",
+						"header": [],
+						"body": {
+							"mode": "raw",
+							"raw": "{\n    \"offerId\":\"{{OFFER_ID}}\",\n    \"credentialConfigurationId\": \"w3c_vc_credential\",\n    \"credential\": {\n        \"credentialSubject\": {\n            \"id\": \"https://ecommerce.impierce.com/\",\n            \"image\": \"https://www.thuiswinkel.org/Images/logo-thuiswinkel_waarborg.svg\",\n            \"name\": \"Impierce Bar\",\n            \"certificaat\": {\n                \"type\": \"ThuiswinkelWaarborg\",\n                \"certificeringsDatum\": \"2024-06-26\",\n                \"geldigheidsPeriode\": \"1 jaar\",\n                \"garanties\": [\n                    \"Het bedrijf is echt en bereikbaar.\",\n                    \"Voldoet aan de Thuiswinkel Algemene Voorwaarden.\",\n                    \"14 dagen bedenktijd.\",\n                    \"Veilige betaalmethoden.\",\n                    \"Duidelijke product/servicebeschrijvingen.\",\n                    \"Transparant bestelproces.\",\n                    \"Duidelijke prijzen.\",\n                    \"Veilige betaalomgeving.\",\n                    \"Veilige omgang met persoonlijke gegevens.\",\n                    \"Effectieve klachtenafhandeling en onafhankelijke geschillenbemiddeling.\"\n                ]\n            }\n        }\n    }\n}",
 							"options": {
 								"raw": {
 									"language": "json"
@@ -120,6 +241,65 @@
 				},
 				{
 					"name": "offers",
+					"event": [
+						{
+							"listen": "test",
+							"script": {
+								"exec": [
+									"const credential_offer = responseBody;",
+									"",
+									"const decodedString = decodeURIComponent(credential_offer);",
+									"",
+									"// Split the string on the first '=' character and take the second item",
+									"const [, secondItem] = decodedString.split('=', 2);",
+									"",
+									"var jsonObject = JSON.parse(secondItem);",
+									"const pre_authorized_code = jsonObject.grants['urn:ietf:params:oauth:grant-type:pre-authorized_code']['pre-authorized_code'];",
+									"",
+									"if(pre_authorized_code){",
+									"    pm.collectionVariables.set(\"PRE_AUTHORIZED_CODE\",pre_authorized_code)",
+									"}",
+									""
+								],
+								"type": "text/javascript",
+								"packages": {}
+							}
+						},
+						{
+							"listen": "prerequest",
+							"script": {
+								"exec": [],
+								"type": "text/javascript"
+							}
+						}
+					],
+					"request": {
+						"method": "POST",
+						"header": [],
+						"body": {
+							"mode": "raw",
+							"raw": "{\n    \"offerId\": \"{{OFFER_ID}}\"\n}",
+							"options": {
+								"raw": {
+									"language": "json"
+								}
+							}
+						},
+						"url": {
+							"raw": "{{HOST}}/v0/offers",
+							"host": [
+								"{{HOST}}"
+							],
+							"path": [
+								"v0",
+								"offers"
+							]
+						}
+					},
+					"response": []
+				},
+				{
+					"name": "all_offers",
 					"event": [
 						{
 							"listen": "test",
@@ -649,8 +829,11 @@
 						{
 							"listen": "prerequest",
 							"script": {
-								"exec": [],
-								"type": "text/javascript"
+								"exec": [
+									""
+								],
+								"type": "text/javascript",
+								"packages": {}
 							}
 						}
 					],
@@ -666,25 +849,6 @@
 								"v0",
 								"holder",
 								"offers"
-							]
-						}
-					},
-					"response": []
-				},
-				{
-					"name": "credentials",
-					"request": {
-						"method": "GET",
-						"header": [],
-						"url": {
-							"raw": "{{HOST}}/v0/holder/credentials",
-							"host": [
-								"{{HOST}}"
-							],
-							"path": [
-								"v0",
-								"holder",
-								"credentials"
 							]
 						}
 					},
@@ -727,6 +891,105 @@
 								"offers",
 								"{{RECEIVED_OFFER_ID}}",
 								"reject"
+							]
+						}
+					},
+					"response": []
+				},
+				{
+					"name": "credentials",
+					"request": {
+						"method": "GET",
+						"header": [],
+						"url": {
+							"raw": "{{HOST}}/v0/holder/credentials",
+							"host": [
+								"{{HOST}}"
+							],
+							"path": [
+								"v0",
+								"holder",
+								"credentials"
+							]
+						}
+					},
+					"response": []
+				},
+				{
+					"name": "presentations",
+					"request": {
+						"method": "GET",
+						"header": [],
+						"url": {
+							"raw": "{{HOST}}/v0/holder/presentations",
+							"host": [
+								"{{HOST}}"
+							],
+							"path": [
+								"v0",
+								"holder",
+								"presentations"
+							]
+						}
+					},
+					"response": []
+				},
+				{
+					"name": "presentations",
+					"request": {
+						"method": "POST",
+						"header": [],
+						"body": {
+							"mode": "raw",
+							"raw": "{\n    \"credentialIds\": [\"credential_id\"]\n}",
+							"options": {
+								"raw": {
+									"language": "json"
+								}
+							}
+						},
+						"url": {
+							"raw": "{{HOST}}/v0/holder/presentations",
+							"host": [
+								"{{HOST}}"
+							],
+							"path": [
+								"v0",
+								"holder",
+								"presentations"
+							]
+						}
+					},
+					"response": []
+				}
+			]
+		},
+		{
+			"name": "Identity",
+			"item": [
+				{
+					"name": "services/linked-vp",
+					"request": {
+						"method": "POST",
+						"header": [],
+						"body": {
+							"mode": "raw",
+							"raw": "{\n    \"presentationId\": \"presentation_id\"\n}",
+							"options": {
+								"raw": {
+									"language": "json"
+								}
+							}
+						},
+						"url": {
+							"raw": "{{HOST}}/v0/services/linked-vp",
+							"host": [
+								"{{HOST}}"
+							],
+							"path": [
+								"v0",
+								"services",
+								"linked-vp"
 							]
 						}
 					},

--- a/agent_api_rest/postman/ssi-agent.postman_collection.json
+++ b/agent_api_rest/postman/ssi-agent.postman_collection.json
@@ -1,9 +1,9 @@
 {
 	"info": {
-		"_postman_id": "6fd9c208-ee8c-4e20-ab0a-346e2c92ba1a",
+		"_postman_id": "3b1e6396-3bf7-43aa-bc3b-21056fb21dfa",
 		"name": "ssi-agent",
 		"schema": "https://schema.getpostman.com/json/collection/v2.1.0/collection.json",
-		"_exporter_id": "37402219"
+		"_exporter_id": "24972330"
 	},
 	"item": [
 		{
@@ -26,16 +26,6 @@
 								"type": "text/javascript",
 								"packages": {}
 							}
-						},
-						{
-							"listen": "prerequest",
-							"script": {
-								"exec": [
-									""
-								],
-								"type": "text/javascript",
-								"packages": {}
-							}
 						}
 					],
 					"request": {
@@ -43,7 +33,7 @@
 						"header": [],
 						"body": {
 							"mode": "raw",
-							"raw": "{\n       \"offerId\": {{OFFER_ID}},\n       \"credentialConfigurationId\": \"openbadge_credential\",\n       \"credential\":{\n           \"credentialSubject\":{\n               \"type\":[\"AchievementSubject\"],\n               \"achievement\": {\n                       \"id\": \"https://demo.edubadges.nl/public/assertions/DAO4oUapQ_eJr9VwMz6jIQ\",\n                       \"type\": \"Achievement\",\n                       \"criteria\":{\"narrative\": \"testtesttesttesttesttesttest\"},\n                       \"description\": \"testtesttesttesttesttesttesttest\",\n                       \"name\": \"Geschiedenis van de Oudheid\",\n                       \"image\":{\n                           \"id\": \"https://api-demo.edubadges.nl/media/uploads/badges/issuer_badgeclass_3e51ca72-ee9b-493b-b787-fd89f2df3189.png\",\n                           \"type\": \"Image\"\n                       }\n                   }\n               }\n           }\n       }",
+							"raw": "{\n    \"offerId\":\"{{OFFER_ID}}\",\n    \"credentialConfigurationId\": \"openbadge_credential\",\n    \"credential\": {\n        \"credentialSubject\": {\n            \"type\": [ \"AchievementSubject\" ],\n            \"achievement\": {\n                \"id\": \"https://example.com/achievements/21st-century-skills/teamwork\",\n                \"type\": \"Achievement\",\n                \"criteria\": {\n                    \"narrative\": \"Team members are nominated for this badge by their peers and recognized upon review by Example Corp management.\"\n                },\n                \"description\": \"This badge recognizes the development of the capacity to collaborate within a group environment.\",\n                \"name\": \"Teamwork\"\n            }\n        }\n    }\n}",
 							"options": {
 								"raw": {
 									"language": "json"
@@ -84,11 +74,8 @@
 						{
 							"listen": "prerequest",
 							"script": {
-								"exec": [
-									""
-								],
-								"type": "text/javascript",
-								"packages": {}
+								"exec": [],
+								"type": "text/javascript"
 							}
 						}
 					],
@@ -98,114 +85,6 @@
 						"body": {
 							"mode": "raw",
 							"raw": "{\n    \"offerId\":\"{{OFFER_ID}}\",\n    \"credentialConfigurationId\": \"w3c_vc_credential\",\n    \"credential\": {\n        \"credentialSubject\": {\n            \"first_name\": \"Ferris\",\n            \"last_name\": \"Crabman\",\n            \"dob\": \"1982-01-01\"\n        }\n    }\n}",
-							"options": {
-								"raw": {
-									"language": "json"
-								}
-							}
-						},
-						"url": {
-							"raw": "{{HOST}}/v0/credentials",
-							"host": [
-								"{{HOST}}"
-							],
-							"path": [
-								"v0",
-								"credentials"
-							]
-						}
-					},
-					"response": []
-				},
-				{
-					"name": "all_credentials",
-					"event": [
-						{
-							"listen": "test",
-							"script": {
-								"exec": [
-									"const location = pm.response.headers.get(\"LOCATION\");",
-									"",
-									"if(location){",
-									"    pm.collectionVariables.set(\"CREDENTIAL_LOCATION\",location)",
-									"}",
-									""
-								],
-								"type": "text/javascript",
-								"packages": {}
-							}
-						},
-						{
-							"listen": "prerequest",
-							"script": {
-								"exec": [
-									""
-								],
-								"type": "text/javascript",
-								"packages": {}
-							}
-						}
-					],
-					"request": {
-						"method": "POST",
-						"header": [],
-						"body": {
-							"mode": "raw",
-							"raw": "{\n    \"offerId\":\"{{OFFER_ID}}\",\n    \"credentialConfigurationId\": \"w3c_vc_credential\",\n    \"credential\": {\n        \"credentialSubject\": {\n            \"first_name\": \"Ferris\",\n            \"last_name\": \"Crabman\",\n            \"dob\": \"1982-01-01\"\n        }\n    }\n}",
-							"options": {
-								"raw": {
-									"language": "json"
-								}
-							}
-						},
-						"url": {
-							"raw": "{{HOST}}/v0/credentials",
-							"host": [
-								"{{HOST}}"
-							],
-							"path": [
-								"v0",
-								"credentials"
-							]
-						}
-					},
-					"response": []
-				},
-				{
-					"name": "temp_thuiswinkel_credential",
-					"event": [
-						{
-							"listen": "test",
-							"script": {
-								"exec": [
-									"const location = pm.response.headers.get(\"LOCATION\");",
-									"",
-									"if(location){",
-									"    pm.collectionVariables.set(\"CREDENTIAL_LOCATION\",location)",
-									"}",
-									""
-								],
-								"type": "text/javascript",
-								"packages": {}
-							}
-						},
-						{
-							"listen": "prerequest",
-							"script": {
-								"exec": [
-									""
-								],
-								"type": "text/javascript",
-								"packages": {}
-							}
-						}
-					],
-					"request": {
-						"method": "POST",
-						"header": [],
-						"body": {
-							"mode": "raw",
-							"raw": "{\n    \"offerId\":\"{{OFFER_ID}}\",\n    \"credentialConfigurationId\": \"w3c_vc_credential\",\n    \"credential\": {\n        \"credentialSubject\": {\n            \"id\": \"https://ecommerce.impierce.com/\",\n            \"image\": \"https://www.thuiswinkel.org/Images/logo-thuiswinkel_waarborg.svg\",\n            \"name\": \"Impierce Bar\",\n            \"certificaat\": {\n                \"type\": \"ThuiswinkelWaarborg\",\n                \"certificeringsDatum\": \"2024-06-26\",\n                \"geldigheidsPeriode\": \"1 jaar\",\n                \"garanties\": [\n                    \"Het bedrijf is echt en bereikbaar.\",\n                    \"Voldoet aan de Thuiswinkel Algemene Voorwaarden.\",\n                    \"14 dagen bedenktijd.\",\n                    \"Veilige betaalmethoden.\",\n                    \"Duidelijke product/servicebeschrijvingen.\",\n                    \"Transparant bestelproces.\",\n                    \"Duidelijke prijzen.\",\n                    \"Veilige betaalomgeving.\",\n                    \"Veilige omgang met persoonlijke gegevens.\",\n                    \"Effectieve klachtenafhandeling en onafhankelijke geschillenbemiddeling.\"\n                ]\n            }\n        }\n    }\n}",
 							"options": {
 								"raw": {
 									"language": "json"
@@ -241,65 +120,6 @@
 				},
 				{
 					"name": "offers",
-					"event": [
-						{
-							"listen": "test",
-							"script": {
-								"exec": [
-									"const credential_offer = responseBody;",
-									"",
-									"const decodedString = decodeURIComponent(credential_offer);",
-									"",
-									"// Split the string on the first '=' character and take the second item",
-									"const [, secondItem] = decodedString.split('=', 2);",
-									"",
-									"var jsonObject = JSON.parse(secondItem);",
-									"const pre_authorized_code = jsonObject.grants['urn:ietf:params:oauth:grant-type:pre-authorized_code']['pre-authorized_code'];",
-									"",
-									"if(pre_authorized_code){",
-									"    pm.collectionVariables.set(\"PRE_AUTHORIZED_CODE\",pre_authorized_code)",
-									"}",
-									""
-								],
-								"type": "text/javascript",
-								"packages": {}
-							}
-						},
-						{
-							"listen": "prerequest",
-							"script": {
-								"exec": [],
-								"type": "text/javascript"
-							}
-						}
-					],
-					"request": {
-						"method": "POST",
-						"header": [],
-						"body": {
-							"mode": "raw",
-							"raw": "{\n    \"offerId\": \"{{OFFER_ID}}\"\n}",
-							"options": {
-								"raw": {
-									"language": "json"
-								}
-							}
-						},
-						"url": {
-							"raw": "{{HOST}}/v0/offers",
-							"host": [
-								"{{HOST}}"
-							],
-							"path": [
-								"v0",
-								"offers"
-							]
-						}
-					},
-					"response": []
-				},
-				{
-					"name": "all_offers",
 					"event": [
 						{
 							"listen": "test",
@@ -829,11 +649,8 @@
 						{
 							"listen": "prerequest",
 							"script": {
-								"exec": [
-									""
-								],
-								"type": "text/javascript",
-								"packages": {}
+								"exec": [],
+								"type": "text/javascript"
 							}
 						}
 					],
@@ -849,6 +666,25 @@
 								"v0",
 								"holder",
 								"offers"
+							]
+						}
+					},
+					"response": []
+				},
+				{
+					"name": "credentials",
+					"request": {
+						"method": "GET",
+						"header": [],
+						"url": {
+							"raw": "{{HOST}}/v0/holder/credentials",
+							"host": [
+								"{{HOST}}"
+							],
+							"path": [
+								"v0",
+								"holder",
+								"credentials"
 							]
 						}
 					},
@@ -891,105 +727,6 @@
 								"offers",
 								"{{RECEIVED_OFFER_ID}}",
 								"reject"
-							]
-						}
-					},
-					"response": []
-				},
-				{
-					"name": "credentials",
-					"request": {
-						"method": "GET",
-						"header": [],
-						"url": {
-							"raw": "{{HOST}}/v0/holder/credentials",
-							"host": [
-								"{{HOST}}"
-							],
-							"path": [
-								"v0",
-								"holder",
-								"credentials"
-							]
-						}
-					},
-					"response": []
-				},
-				{
-					"name": "presentations",
-					"request": {
-						"method": "GET",
-						"header": [],
-						"url": {
-							"raw": "{{HOST}}/v0/holder/presentations",
-							"host": [
-								"{{HOST}}"
-							],
-							"path": [
-								"v0",
-								"holder",
-								"presentations"
-							]
-						}
-					},
-					"response": []
-				},
-				{
-					"name": "presentations",
-					"request": {
-						"method": "POST",
-						"header": [],
-						"body": {
-							"mode": "raw",
-							"raw": "{\n    \"credentialIds\": [\"credential_id\"]\n}",
-							"options": {
-								"raw": {
-									"language": "json"
-								}
-							}
-						},
-						"url": {
-							"raw": "{{HOST}}/v0/holder/presentations",
-							"host": [
-								"{{HOST}}"
-							],
-							"path": [
-								"v0",
-								"holder",
-								"presentations"
-							]
-						}
-					},
-					"response": []
-				}
-			]
-		},
-		{
-			"name": "Identity",
-			"item": [
-				{
-					"name": "services/linked-vp",
-					"request": {
-						"method": "POST",
-						"header": [],
-						"body": {
-							"mode": "raw",
-							"raw": "{\n    \"presentationId\": \"presentation_id\"\n}",
-							"options": {
-								"raw": {
-									"language": "json"
-								}
-							}
-						},
-						"url": {
-							"raw": "{{HOST}}/v0/services/linked-vp",
-							"host": [
-								"{{HOST}}"
-							],
-							"path": [
-								"v0",
-								"services",
-								"linked-vp"
 							]
 						}
 					},

--- a/agent_api_rest/postman/ssi-agent.postman_collection.json
+++ b/agent_api_rest/postman/ssi-agent.postman_collection.json
@@ -119,6 +119,58 @@
 					"response": []
 				},
 				{
+					"name": "all_credentials",
+					"event": [
+						{
+							"listen": "test",
+							"script": {
+								"exec": [
+									""
+								],
+								"type": "text/javascript",
+								"packages": {}
+							}
+						},
+						{
+							"listen": "prerequest",
+							"script": {
+								"exec": [
+									""
+								],
+								"type": "text/javascript",
+								"packages": {}
+							}
+						}
+					],
+					"protocolProfileBehavior": {
+						"disableBodyPruning": true
+					},
+					"request": {
+						"method": "GET",
+						"header": [],
+						"body": {
+							"mode": "raw",
+							"raw": "{\n    \"offerId\":\"{{OFFER_ID}}\",\n    \"credentialConfigurationId\": \"w3c_vc_credential\",\n    \"credential\": {\n        \"credentialSubject\": {\n            \"first_name\": \"Ferris\",\n            \"last_name\": \"Crabman\",\n            \"dob\": \"1982-01-01\"\n        }\n    }\n}",
+							"options": {
+								"raw": {
+									"language": "json"
+								}
+							}
+						},
+						"url": {
+							"raw": "{{HOST}}/v0/credentials",
+							"host": [
+								"{{HOST}}"
+							],
+							"path": [
+								"v0",
+								"credentials"
+							]
+						}
+					},
+					"response": []
+				},
+				{
 					"name": "offers",
 					"event": [
 						{
@@ -154,6 +206,58 @@
 					],
 					"request": {
 						"method": "POST",
+						"header": [],
+						"body": {
+							"mode": "raw",
+							"raw": "{\n    \"offerId\": \"{{OFFER_ID}}\"\n}",
+							"options": {
+								"raw": {
+									"language": "json"
+								}
+							}
+						},
+						"url": {
+							"raw": "{{HOST}}/v0/offers",
+							"host": [
+								"{{HOST}}"
+							],
+							"path": [
+								"v0",
+								"offers"
+							]
+						}
+					},
+					"response": []
+				},
+				{
+					"name": "all_offers",
+					"event": [
+						{
+							"listen": "test",
+							"script": {
+								"exec": [
+									""
+								],
+								"type": "text/javascript",
+								"packages": {}
+							}
+						},
+						{
+							"listen": "prerequest",
+							"script": {
+								"exec": [
+									""
+								],
+								"type": "text/javascript",
+								"packages": {}
+							}
+						}
+					],
+					"protocolProfileBehavior": {
+						"disableBodyPruning": true
+					},
+					"request": {
+						"method": "GET",
 						"header": [],
 						"body": {
 							"mode": "raw",

--- a/agent_api_rest/src/holder/holder/credentials/mod.rs
+++ b/agent_api_rest/src/holder/holder/credentials/mod.rs
@@ -10,7 +10,7 @@ use serde_json::json;
 
 #[axum_macros::debug_handler]
 pub(crate) async fn credentials(State(state): State<HolderState>) -> Response {
-    match query_handler("all_credentials", &state.query.all_holder_credentials).await {
+    match query_handler("all_holder_credentials", &state.query.all_holder_credentials).await {
         Ok(Some(all_credentials_view)) => (StatusCode::OK, Json(all_credentials_view)).into_response(),
         Ok(None) => (StatusCode::OK, Json(json!({}))).into_response(),
         _ => StatusCode::INTERNAL_SERVER_ERROR.into_response(),

--- a/agent_api_rest/src/holder/holder/credentials/mod.rs
+++ b/agent_api_rest/src/holder/holder/credentials/mod.rs
@@ -10,7 +10,7 @@ use serde_json::json;
 
 #[axum_macros::debug_handler]
 pub(crate) async fn credentials(State(state): State<HolderState>) -> Response {
-    match query_handler("all_credentials", &state.query.all_credentials).await {
+    match query_handler("all_credentials", &state.query.all_holder_credentials).await {
         Ok(Some(all_credentials_view)) => (StatusCode::OK, Json(all_credentials_view)).into_response(),
         Ok(None) => (StatusCode::OK, Json(json!({}))).into_response(),
         _ => StatusCode::INTERNAL_SERVER_ERROR.into_response(),

--- a/agent_api_rest/src/holder/holder/offers/accept.rs
+++ b/agent_api_rest/src/holder/holder/offers/accept.rs
@@ -1,6 +1,6 @@
 use agent_holder::{
     credential::command::CredentialCommand,
-    offer::{command::OfferCommand, queries::OfferView},
+    offer::{command::OfferCommand, queries::ReceivedOfferView},
     state::HolderState,
 };
 use agent_shared::handlers::{command_handler, query_handler};
@@ -18,8 +18,8 @@ pub(crate) async fn accept(State(state): State<HolderState>, Path(offer_id): Pat
     // Furthermore, the Application Layer (not implemented yet) should be kept very thin as well. See: https://github.com/impierce/ssi-agent/issues/114
 
     // Accept the Credential Offer if it exists
-    match query_handler(&offer_id, &state.query.offer).await {
-        Ok(Some(OfferView { .. })) => {
+    match query_handler(&offer_id, &state.query.received_offer).await {
+        Ok(Some(ReceivedOfferView { .. })) => {
             let command = OfferCommand::AcceptCredentialOffer {
                 offer_id: offer_id.clone(),
             };
@@ -45,8 +45,8 @@ pub(crate) async fn accept(State(state): State<HolderState>, Path(offer_id): Pat
         return StatusCode::INTERNAL_SERVER_ERROR.into_response();
     }
 
-    let credentials = match query_handler(&offer_id, &state.query.offer).await {
-        Ok(Some(OfferView { credentials, .. })) => credentials,
+    let credentials = match query_handler(&offer_id, &state.query.received_offer).await {
+        Ok(Some(ReceivedOfferView { credentials, .. })) => credentials,
         _ => return StatusCode::INTERNAL_SERVER_ERROR.into_response(),
     };
 

--- a/agent_api_rest/src/holder/holder/offers/mod.rs
+++ b/agent_api_rest/src/holder/holder/offers/mod.rs
@@ -13,7 +13,7 @@ use serde_json::json;
 
 #[axum_macros::debug_handler]
 pub(crate) async fn offers(State(state): State<HolderState>) -> Response {
-    match query_handler("all_offers", &state.query.all_offers).await {
+    match query_handler("all_offers", &state.query.all_received_offers).await {
         Ok(Some(all_offers_view)) => (StatusCode::OK, Json(all_offers_view)).into_response(),
         Ok(None) => (StatusCode::OK, Json(json!({}))).into_response(),
         _ => StatusCode::INTERNAL_SERVER_ERROR.into_response(),

--- a/agent_api_rest/src/holder/holder/offers/mod.rs
+++ b/agent_api_rest/src/holder/holder/offers/mod.rs
@@ -13,7 +13,7 @@ use serde_json::json;
 
 #[axum_macros::debug_handler]
 pub(crate) async fn offers(State(state): State<HolderState>) -> Response {
-    match query_handler("all_offers", &state.query.all_received_offers).await {
+    match query_handler("all_received_offers", &state.query.all_received_offers).await {
         Ok(Some(all_offers_view)) => (StatusCode::OK, Json(all_offers_view)).into_response(),
         Ok(None) => (StatusCode::OK, Json(json!({}))).into_response(),
         _ => StatusCode::INTERNAL_SERVER_ERROR.into_response(),

--- a/agent_api_rest/src/issuance/credentials.rs
+++ b/agent_api_rest/src/issuance/credentials.rs
@@ -17,6 +17,8 @@ use serde::{Deserialize, Serialize};
 use serde_json::Value;
 use tracing::info;
 
+use serde_json::json;
+
 #[axum_macros::debug_handler]
 pub(crate) async fn get_credentials(State(state): State<IssuanceState>, Path(credential_id): Path<String>) -> Response {
     // Get the credential if it exists.
@@ -159,6 +161,16 @@ pub(crate) async fn credentials(
         _ => StatusCode::INTERNAL_SERVER_ERROR.into_response(),
     }
 }
+
+#[axum_macros::debug_handler]
+pub(crate) async fn all_credentials(State(state): State<IssuanceState>) -> Response {
+    match query_handler("all_credentials", &state.query.all_credentials).await {
+        Ok(Some(all_credentials_view)) => (StatusCode::OK, Json(all_credentials_view)).into_response(),
+        Ok(None) => (StatusCode::OK, Json(json!({}))).into_response(),
+        _ => StatusCode::INTERNAL_SERVER_ERROR.into_response(),
+    }
+}
+
 
 #[cfg(test)]
 pub mod tests {

--- a/agent_api_rest/src/issuance/credentials.rs
+++ b/agent_api_rest/src/issuance/credentials.rs
@@ -171,7 +171,6 @@ pub(crate) async fn all_credentials(State(state): State<IssuanceState>) -> Respo
     }
 }
 
-
 #[cfg(test)]
 pub mod tests {
     use super::*;

--- a/agent_api_rest/src/issuance/mod.rs
+++ b/agent_api_rest/src/issuance/mod.rs
@@ -5,6 +5,8 @@ pub mod offers;
 use agent_issuance::state::IssuanceState;
 use axum::routing::get;
 use axum::{routing::post, Router};
+use credentials::all_credentials;
+use offers::all_offers;
 
 use crate::issuance::{
     credential_issuer::{
@@ -21,9 +23,9 @@ pub fn router(issuance_state: IssuanceState) -> Router {
         .nest(
             API_VERSION,
             Router::new()
-                .route("/credentials", post(credentials))
+                .route("/credentials", post(credentials).get(all_credentials))
                 .route("/credentials/:credential_id", get(get_credentials))
-                .route("/offers", post(offers))
+                .route("/offers", post(offers).get(all_offers))
                 .route("/offers/send", post(send)),
         )
         .route(

--- a/agent_api_rest/src/issuance/offers/mod.rs
+++ b/agent_api_rest/src/issuance/offers/mod.rs
@@ -13,9 +13,9 @@ use axum::{
 };
 use hyper::header;
 use serde::{Deserialize, Serialize};
+use serde_json::json;
 use serde_json::Value;
 use tracing::info;
-use serde_json::json;
 
 #[derive(Deserialize, Serialize)]
 #[serde(rename_all = "camelCase")]
@@ -81,7 +81,6 @@ pub(crate) async fn offers(State(state): State<IssuanceState>, Json(payload): Js
         _ => StatusCode::INTERNAL_SERVER_ERROR.into_response(),
     }
 }
-
 
 #[axum_macros::debug_handler]
 pub(crate) async fn all_offers(State(state): State<IssuanceState>) -> Response {

--- a/agent_api_rest/src/issuance/offers/mod.rs
+++ b/agent_api_rest/src/issuance/offers/mod.rs
@@ -15,6 +15,7 @@ use hyper::header;
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
 use tracing::info;
+use serde_json::json;
 
 #[derive(Deserialize, Serialize)]
 #[serde(rename_all = "camelCase")]
@@ -77,6 +78,16 @@ pub(crate) async fn offers(State(state): State<IssuanceState>, Json(payload): Js
             form_url_encoded_credential_offer,
         )
             .into_response(),
+        _ => StatusCode::INTERNAL_SERVER_ERROR.into_response(),
+    }
+}
+
+
+#[axum_macros::debug_handler]
+pub(crate) async fn all_offers(State(state): State<IssuanceState>) -> Response {
+    match query_handler("all_offers", &state.query.all_offers).await {
+        Ok(Some(all_offers_view)) => (StatusCode::OK, Json(all_offers_view)).into_response(),
+        Ok(None) => (StatusCode::OK, Json(json!({}))).into_response(),
         _ => StatusCode::INTERNAL_SERVER_ERROR.into_response(),
     }
 }

--- a/agent_application/docker/.env.example
+++ b/agent_application/docker/.env.example
@@ -1,1 +1,1 @@
-UNICORE__URL=http://192.168.1.100:3033
+UNICORE__URL="http://localhost:3033"

--- a/agent_application/docker/db/init.sql
+++ b/agent_application/docker/db/init.sql
@@ -18,6 +18,14 @@ CREATE TABLE offer
     PRIMARY KEY (view_id)
 );
 
+CREATE TABLE all_offers
+(
+    view_id           text                        NOT NULL,
+    version           bigint CHECK (version >= 0) NOT NULL,
+    payload           json                        NOT NULL,
+    PRIMARY KEY (view_id)
+);
+
 CREATE TABLE pre_authorized_code
 (
     view_id           text                        NOT NULL,
@@ -42,6 +50,14 @@ CREATE TABLE credential
     PRIMARY KEY (view_id)
 );
 
+CREATE TABLE all_credentials
+(
+    view_id           text                        NOT NULL,
+    version           bigint CHECK (version >= 0) NOT NULL,
+    payload           json                        NOT NULL,
+    PRIMARY KEY (view_id)
+);
+
 CREATE TABLE server_config
 (
     view_id           text                        NOT NULL,
@@ -58,7 +74,7 @@ CREATE TABLE received_offer
     PRIMARY KEY (view_id)
 );
 
-CREATE TABLE all_offers
+CREATE TABLE all_received_offers
 (
     view_id           text                        NOT NULL,
     version           bigint CHECK (version >= 0) NOT NULL,
@@ -75,7 +91,7 @@ CREATE TABLE holder_credential
 );
 
 
-CREATE TABLE all_credentials
+CREATE TABLE all_holder_credentials
 (
     view_id           text                        NOT NULL,
     version           bigint CHECK (version >= 0) NOT NULL,

--- a/agent_holder/src/credential/queries/all_credentials.rs
+++ b/agent_holder/src/credential/queries/all_credentials.rs
@@ -1,16 +1,16 @@
-use super::CredentialView;
+use super::HolderCredentialView;
 use crate::credential::queries::Credential;
 use cqrs_es::{EventEnvelope, View};
 use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
 
 #[derive(Debug, Default, Serialize, Deserialize, Clone)]
-pub struct AllCredentialsView {
+pub struct AllHolderCredentialsView {
     #[serde(flatten)]
-    pub credentials: HashMap<String, CredentialView>,
+    pub credentials: HashMap<String, HolderCredentialView>,
 }
 
-impl View<Credential> for AllCredentialsView {
+impl View<Credential> for AllHolderCredentialsView {
     fn update(&mut self, event: &EventEnvelope<Credential>) {
         self.credentials
             // Get the entry for the aggregate_id

--- a/agent_holder/src/credential/queries/mod.rs
+++ b/agent_holder/src/credential/queries/mod.rs
@@ -6,13 +6,13 @@ use cqrs_es::{EventEnvelope, View};
 use serde::{Deserialize, Serialize};
 
 #[derive(Debug, Default, Serialize, Deserialize, Clone)]
-pub struct CredentialView {
+pub struct HolderCredentialView {
     pub credential_id: Option<String>,
     pub offer_id: Option<String>,
     pub credential: Option<serde_json::Value>,
 }
 
-impl View<Credential> for CredentialView {
+impl View<Credential> for HolderCredentialView {
     fn update(&mut self, event: &EventEnvelope<Credential>) {
         use CredentialEvent::*;
 

--- a/agent_holder/src/offer/queries/all_offers.rs
+++ b/agent_holder/src/offer/queries/all_offers.rs
@@ -1,16 +1,16 @@
-use super::OfferView;
+use super::ReceivedOfferView;
 use crate::offer::queries::Offer;
 use cqrs_es::{EventEnvelope, View};
 use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
 
 #[derive(Debug, Default, Serialize, Deserialize, Clone)]
-pub struct AllOffersView {
+pub struct AllReceivedOffersView {
     #[serde(flatten)]
-    pub offers: HashMap<String, OfferView>,
+    pub offers: HashMap<String, ReceivedOfferView>,
 }
 
-impl View<Offer> for AllOffersView {
+impl View<Offer> for AllReceivedOffersView {
     fn update(&mut self, event: &EventEnvelope<Offer>) {
         self.offers
             // Get the entry for the aggregate_id

--- a/agent_holder/src/offer/queries/mod.rs
+++ b/agent_holder/src/offer/queries/mod.rs
@@ -11,7 +11,7 @@ use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
 
 #[derive(Debug, Default, Serialize, Deserialize, Clone)]
-pub struct OfferView {
+pub struct ReceivedOfferView {
     pub credential_offer: Option<CredentialOfferParameters>,
     pub status: Status,
     pub credential_configurations: Option<HashMap<String, CredentialConfigurationsSupportedObject>>,
@@ -19,7 +19,7 @@ pub struct OfferView {
     pub credentials: Vec<serde_json::Value>,
 }
 
-impl View<Offer> for OfferView {
+impl View<Offer> for ReceivedOfferView {
     fn update(&mut self, event: &EventEnvelope<Offer>) {
         use crate::offer::event::OfferEvent::*;
 

--- a/agent_holder/src/state.rs
+++ b/agent_holder/src/state.rs
@@ -3,11 +3,11 @@ use cqrs_es::persist::ViewRepository;
 use std::sync::Arc;
 
 use crate::credential::aggregate::Credential;
-use crate::credential::queries::all_credentials::AllCredentialsView;
-use crate::credential::queries::CredentialView;
+use crate::credential::queries::all_credentials::AllHolderCredentialsView;
+use crate::credential::queries::HolderCredentialView;
 use crate::offer::aggregate::Offer;
-use crate::offer::queries::all_offers::AllOffersView;
-use crate::offer::queries::OfferView;
+use crate::offer::queries::all_offers::AllReceivedOffersView;
+use crate::offer::queries::ReceivedOfferView;
 
 #[derive(Clone)]
 pub struct HolderState {
@@ -26,32 +26,32 @@ pub struct CommandHandlers {
 /// that any type of repository that implements the `ViewRepository` trait can be used, but the corresponding `View` and
 /// `Aggregate` types must be the same.
 type Queries = ViewRepositories<
-    dyn ViewRepository<CredentialView, Credential>,
-    dyn ViewRepository<AllCredentialsView, Credential>,
-    dyn ViewRepository<OfferView, Offer>,
-    dyn ViewRepository<AllOffersView, Offer>,
+    dyn ViewRepository<HolderCredentialView, Credential>,
+    dyn ViewRepository<AllHolderCredentialsView, Credential>,
+    dyn ViewRepository<ReceivedOfferView, Offer>,
+    dyn ViewRepository<AllReceivedOffersView, Offer>,
 >;
 
 pub struct ViewRepositories<C1, C2, O1, O2>
 where
-    C1: ViewRepository<CredentialView, Credential> + ?Sized,
-    C2: ViewRepository<AllCredentialsView, Credential> + ?Sized,
-    O1: ViewRepository<OfferView, Offer> + ?Sized,
-    O2: ViewRepository<AllOffersView, Offer> + ?Sized,
+    C1: ViewRepository<HolderCredentialView, Credential> + ?Sized,
+    C2: ViewRepository<AllHolderCredentialsView, Credential> + ?Sized,
+    O1: ViewRepository<ReceivedOfferView, Offer> + ?Sized,
+    O2: ViewRepository<AllReceivedOffersView, Offer> + ?Sized,
 {
-    pub credential: Arc<C1>,
-    pub all_credentials: Arc<C2>,
-    pub offer: Arc<O1>,
-    pub all_offers: Arc<O2>,
+    pub holder_credential: Arc<C1>,
+    pub all_holder_credentials: Arc<C2>,
+    pub received_offer: Arc<O1>,
+    pub all_received_offers: Arc<O2>,
 }
 
 impl Clone for Queries {
     fn clone(&self) -> Self {
         ViewRepositories {
-            credential: self.credential.clone(),
-            all_credentials: self.all_credentials.clone(),
-            offer: self.offer.clone(),
-            all_offers: self.all_offers.clone(),
+            holder_credential: self.holder_credential.clone(),
+            all_holder_credentials: self.all_holder_credentials.clone(),
+            received_offer: self.received_offer.clone(),
+            all_received_offers: self.all_received_offers.clone(),
         }
     }
 }

--- a/agent_issuance/src/credential/queries/all_credentials.rs
+++ b/agent_issuance/src/credential/queries/all_credentials.rs
@@ -1,0 +1,23 @@
+use super::CredentialView;
+use crate::credential::queries::Credential;
+use cqrs_es::{EventEnvelope, View};
+use serde::{Deserialize, Serialize};
+use std::collections::HashMap;
+
+#[derive(Debug, Default, Serialize, Deserialize, Clone)]
+pub struct AllCredentialsView {
+    #[serde(flatten)]
+    pub credentials: HashMap<String, CredentialView>,
+}
+
+impl View<Credential> for AllCredentialsView {
+    fn update(&mut self, event: &EventEnvelope<Credential>) {
+        self.credentials
+            // Get the entry for the aggregate_id
+            .entry(event.aggregate_id.clone())
+            // or insert a new one if it doesn't exist
+            .or_default()
+            // update the view with the event
+            .update(event);
+    }
+}

--- a/agent_issuance/src/credential/queries/mod.rs
+++ b/agent_issuance/src/credential/queries/mod.rs
@@ -1,3 +1,5 @@
+pub mod all_credentials;
+
 use super::{entity::Data, event::CredentialEvent};
 use crate::credential::aggregate::Credential;
 use cqrs_es::{EventEnvelope, View};

--- a/agent_issuance/src/offer/queries/all_offers.rs
+++ b/agent_issuance/src/offer/queries/all_offers.rs
@@ -1,0 +1,23 @@
+use super::OfferView;
+use crate::offer::queries::Offer;
+use cqrs_es::{EventEnvelope, View};
+use serde::{Deserialize, Serialize};
+use std::collections::HashMap;
+
+#[derive(Debug, Default, Serialize, Deserialize, Clone)]
+pub struct AllOffersView {
+    #[serde(flatten)]
+    pub offers: HashMap<String, OfferView>,
+}
+
+impl View<Offer> for AllOffersView {
+    fn update(&mut self, event: &EventEnvelope<Offer>) {
+        self.offers
+            // Get the entry for the aggregate_id
+            .entry(event.aggregate_id.clone())
+            // or insert a new one if it doesn't exist
+            .or_default()
+            // update the view with the event
+            .update(event);
+    }
+}

--- a/agent_issuance/src/offer/queries/mod.rs
+++ b/agent_issuance/src/offer/queries/mod.rs
@@ -1,6 +1,6 @@
 pub mod access_token;
-pub mod pre_authorized_code;
 pub mod all_offers;
+pub mod pre_authorized_code;
 
 use super::event::OfferEvent;
 use crate::offer::aggregate::Offer;

--- a/agent_issuance/src/offer/queries/mod.rs
+++ b/agent_issuance/src/offer/queries/mod.rs
@@ -1,5 +1,6 @@
 pub mod access_token;
 pub mod pre_authorized_code;
+pub mod all_offers;
 
 use super::event::OfferEvent;
 use crate::offer::aggregate::Offer;

--- a/agent_issuance/src/state.rs
+++ b/agent_issuance/src/state.rs
@@ -35,43 +35,43 @@ pub struct CommandHandlers {
 /// `Aggregate` types must be the same.
 type Queries = ViewRepositories<
     dyn ViewRepository<ServerConfigView, ServerConfig>,
-    dyn ViewRepository<PreAuthorizedCodeView, Offer>,
-    dyn ViewRepository<AccessTokenView, Offer>,
     dyn ViewRepository<CredentialView, Credential>,
     dyn ViewRepository<AllCredentialsView, Credential>,
     dyn ViewRepository<OfferView, Offer>,
     dyn ViewRepository<AllOffersView, Offer>,
+    dyn ViewRepository<PreAuthorizedCodeView, Offer>,
+    dyn ViewRepository<AccessTokenView, Offer>,
 >;
 
-pub struct ViewRepositories<SC, PC, AT, C, C2, O, O2>
+pub struct ViewRepositories<SC, C, C1, O, O1, O2, O3>
 where
     SC: ViewRepository<ServerConfigView, ServerConfig> + ?Sized,
-    PC: ViewRepository<PreAuthorizedCodeView, Offer> + ?Sized,
-    AT: ViewRepository<AccessTokenView, Offer> + ?Sized,
     C: ViewRepository<CredentialView, Credential> + ?Sized,
-    C2: ViewRepository<AllCredentialsView, Credential> + ?Sized,
+    C1: ViewRepository<AllCredentialsView, Credential> + ?Sized,
     O: ViewRepository<OfferView, Offer> + ?Sized,
-    O2: ViewRepository<AllOffersView, Offer> + ?Sized,
+    O1: ViewRepository<AllOffersView, Offer> + ?Sized,
+    O2: ViewRepository<PreAuthorizedCodeView, Offer> + ?Sized,
+    O3: ViewRepository<AccessTokenView, Offer> + ?Sized,
 {
     pub server_config: Arc<SC>,
-    pub pre_authorized_code: Arc<PC>,
-    pub access_token: Arc<AT>,
     pub credential: Arc<C>,
-    pub all_credentials: Arc<C2>,
+    pub all_credentials: Arc<C1>,
     pub offer: Arc<O>,
-    pub all_offers: Arc<O2>,
+    pub all_offers: Arc<O1>,
+    pub pre_authorized_code: Arc<O2>,
+    pub access_token: Arc<O3>,
 }
 
 impl Clone for Queries {
     fn clone(&self) -> Self {
         ViewRepositories {
             server_config: self.server_config.clone(),
-            pre_authorized_code: self.pre_authorized_code.clone(),
-            access_token: self.access_token.clone(),
             credential: self.credential.clone(),
             all_credentials: self.all_credentials.clone(),
             offer: self.offer.clone(),
             all_offers: self.all_offers.clone(),
+            pre_authorized_code: self.pre_authorized_code.clone(),
+            access_token: self.access_token.clone(),
         }
     }
 }

--- a/agent_issuance/src/state.rs
+++ b/agent_issuance/src/state.rs
@@ -6,7 +6,9 @@ use tracing::{info, warn};
 
 use crate::credential::aggregate::Credential;
 use crate::credential::queries::CredentialView;
+use crate::credential::queries::all_credentials::AllCredentialsView;
 use crate::offer::aggregate::Offer;
+use crate::offer::queries::all_offers::AllOffersView;
 use crate::offer::queries::access_token::AccessTokenView;
 use crate::offer::queries::pre_authorized_code::PreAuthorizedCodeView;
 use crate::offer::queries::OfferView;
@@ -33,35 +35,43 @@ pub struct CommandHandlers {
 /// `Aggregate` types must be the same.
 type Queries = ViewRepositories<
     dyn ViewRepository<ServerConfigView, ServerConfig>,
-    dyn ViewRepository<CredentialView, Credential>,
-    dyn ViewRepository<OfferView, Offer>,
     dyn ViewRepository<PreAuthorizedCodeView, Offer>,
     dyn ViewRepository<AccessTokenView, Offer>,
+    dyn ViewRepository<CredentialView, Credential>,
+    dyn ViewRepository<AllCredentialsView, Credential>,
+    dyn ViewRepository<OfferView, Offer>,
+    dyn ViewRepository<AllOffersView, Offer>,
 >;
 
-pub struct ViewRepositories<SC, C, O, O1, O2>
+pub struct ViewRepositories<SC, PC, AT, C, C2, O, O2>
 where
     SC: ViewRepository<ServerConfigView, ServerConfig> + ?Sized,
+    PC: ViewRepository<PreAuthorizedCodeView, Offer> + ?Sized,
+    AT: ViewRepository<AccessTokenView, Offer> + ?Sized,
     C: ViewRepository<CredentialView, Credential> + ?Sized,
+    C2: ViewRepository<AllCredentialsView, Credential> + ?Sized,
     O: ViewRepository<OfferView, Offer> + ?Sized,
-    O1: ViewRepository<PreAuthorizedCodeView, Offer> + ?Sized,
-    O2: ViewRepository<AccessTokenView, Offer> + ?Sized,
+    O2: ViewRepository<AllOffersView, Offer> + ?Sized,
 {
     pub server_config: Arc<SC>,
+    pub pre_authorized_code: Arc<PC>,
+    pub access_token: Arc<AT>,
     pub credential: Arc<C>,
+    pub all_credentials: Arc<C2>,
     pub offer: Arc<O>,
-    pub pre_authorized_code: Arc<O1>,
-    pub access_token: Arc<O2>,
+    pub all_offers: Arc<O2>,
 }
 
 impl Clone for Queries {
     fn clone(&self) -> Self {
         ViewRepositories {
             server_config: self.server_config.clone(),
-            credential: self.credential.clone(),
-            offer: self.offer.clone(),
             pre_authorized_code: self.pre_authorized_code.clone(),
             access_token: self.access_token.clone(),
+            credential: self.credential.clone(),
+            all_credentials: self.all_credentials.clone(),
+            offer: self.offer.clone(),
+            all_offers: self.all_offers.clone()
         }
     }
 }

--- a/agent_issuance/src/state.rs
+++ b/agent_issuance/src/state.rs
@@ -5,11 +5,11 @@ use std::sync::Arc;
 use tracing::{info, warn};
 
 use crate::credential::aggregate::Credential;
-use crate::credential::queries::CredentialView;
 use crate::credential::queries::all_credentials::AllCredentialsView;
+use crate::credential::queries::CredentialView;
 use crate::offer::aggregate::Offer;
-use crate::offer::queries::all_offers::AllOffersView;
 use crate::offer::queries::access_token::AccessTokenView;
+use crate::offer::queries::all_offers::AllOffersView;
 use crate::offer::queries::pre_authorized_code::PreAuthorizedCodeView;
 use crate::offer::queries::OfferView;
 use crate::server_config::aggregate::ServerConfig;
@@ -71,7 +71,7 @@ impl Clone for Queries {
             credential: self.credential.clone(),
             all_credentials: self.all_credentials.clone(),
             offer: self.offer.clone(),
-            all_offers: self.all_offers.clone()
+            all_offers: self.all_offers.clone(),
         }
     }
 }

--- a/agent_store/src/in_memory.rs
+++ b/agent_store/src/in_memory.rs
@@ -215,10 +215,10 @@ pub async fn holder_state(
             ),
         },
         query: agent_holder::state::ViewRepositories {
-            credential: holder_credential,
-            all_credentials: all_holder_credentials,
-            offer: received_offer,
-            all_offers: all_received_offers,
+            holder_credential,
+            all_holder_credentials,
+            received_offer,
+            all_received_offers,
         },
     }
 }

--- a/agent_store/src/postgres.rs
+++ b/agent_store/src/postgres.rs
@@ -76,10 +76,12 @@ pub async fn issuance_state(
 
     // Initialize the postgres repositories.
     let server_config = Arc::new(PostgresViewRepository::new("server_config", pool.clone()));
-    let credential = Arc::new(PostgresViewRepository::new("credential", pool.clone()));
-    let offer = Arc::new(PostgresViewRepository::new("offer", pool.clone()));
     let pre_authorized_code = Arc::new(PostgresViewRepository::new("pre_authorized_code", pool.clone()));
     let access_token = Arc::new(PostgresViewRepository::new("access_token", pool.clone()));
+    let credential = Arc::new(PostgresViewRepository::new("credential", pool.clone()));
+    let offer = Arc::new(PostgresViewRepository::new("offer", pool.clone()));
+    let all_credentials = Arc::new(PostgresViewRepository::new("all_credentials", pool.clone()));
+    let all_offers = Arc::new(PostgresViewRepository::new("all_offers", pool.clone()));
 
     // Create custom-queries for the offer aggregate.
     let pre_authorized_code_query = PreAuthorizedCodeQuery::new(pre_authorized_code.clone());
@@ -88,6 +90,10 @@ pub async fn issuance_state(
     // Partition the event_publishers into the different aggregates.
     let (server_config_event_publishers, credential_event_publishers, offer_event_publishers, _, _, _, _) =
         partition_event_publishers(event_publishers);
+
+    // Create custom-queries for the offer aggregate.
+    let all_credentials_query = ListAllQuery::new(all_credentials.clone(), "all_credentials");
+    let all_offers_query = ListAllQuery::new(all_offers.clone(), "all_offers");
 
     IssuanceState {
         command: CommandHandlers {
@@ -121,7 +127,9 @@ pub async fn issuance_state(
         query: ViewRepositories {
             server_config,
             credential,
+            all_credentials,
             offer,
+            all_offers,
             pre_authorized_code,
             access_token,
         },
@@ -138,16 +146,16 @@ pub async fn holder_state(
     let pool = default_postgress_pool(&connection_string).await;
 
     // Initialize the postgres repositories.
-    let credential: Arc<PostgresViewRepository<_, _>> =
+    let holder_credential: Arc<PostgresViewRepository<_, _>> =
         Arc::new(PostgresViewRepository::new("holder_credential", pool.clone()));
-    let all_credentials: Arc<PostgresViewRepository<_, _>> =
+    let all_holder_credentials: Arc<PostgresViewRepository<_, _>> =
         Arc::new(PostgresViewRepository::new("all_credentials", pool.clone()));
-    let offer = Arc::new(PostgresViewRepository::new("received_offer", pool.clone()));
-    let all_offers = Arc::new(PostgresViewRepository::new("all_offers", pool.clone()));
+    let received_offer = Arc::new(PostgresViewRepository::new("received_offer", pool.clone()));
+    let all_received_offers = Arc::new(PostgresViewRepository::new("all_offers", pool.clone()));
 
     // Create custom-queries for the offer aggregate.
-    let all_credentials_query = ListAllQuery::new(all_credentials.clone(), "all_credentials");
-    let all_offers_query = ListAllQuery::new(all_offers.clone(), "all_offers");
+    let all_holder_credentials_query = ListAllQuery::new(all_holder_credentials.clone(), "all_credentials");
+    let all_received_offers_query = ListAllQuery::new(all_received_offers.clone(), "all_offers");
 
     // Partition the event_publishers into the different aggregates.
     let (_, _, _, credential_event_publishers, offer_event_publishers, _, _) =
@@ -159,8 +167,8 @@ pub async fn holder_state(
                 credential_event_publishers.into_iter().fold(
                     AggregateHandler::new(pool.clone(), holder_services.clone())
                         .append_query(SimpleLoggingQuery {})
-                        .append_query(generic_query(credential.clone()))
-                        .append_query(all_credentials_query),
+                        .append_query(generic_query(holder_credential.clone()))
+                        .append_query(all_holder_credentials_query),
                     |aggregate_handler, event_publisher| aggregate_handler.append_event_publisher(event_publisher),
                 ),
             ),
@@ -168,17 +176,17 @@ pub async fn holder_state(
                 offer_event_publishers.into_iter().fold(
                     AggregateHandler::new(pool, holder_services.clone())
                         .append_query(SimpleLoggingQuery {})
-                        .append_query(generic_query(offer.clone()))
-                        .append_query(all_offers_query),
+                        .append_query(generic_query(received_offer.clone()))
+                        .append_query(all_received_offers_query),
                     |aggregate_handler, event_publisher| aggregate_handler.append_event_publisher(event_publisher),
                 ),
             ),
         },
         query: agent_holder::state::ViewRepositories {
-            credential,
-            all_credentials,
-            offer,
-            all_offers,
+            credential: holder_credential,
+            all_credentials: all_holder_credentials,
+            offer: received_offer,
+            all_offers: all_received_offers,
         },
     }
 }

--- a/agent_store/src/postgres.rs
+++ b/agent_store/src/postgres.rs
@@ -151,13 +151,13 @@ pub async fn holder_state(
     let holder_credential: Arc<PostgresViewRepository<_, _>> =
         Arc::new(PostgresViewRepository::new("holder_credential", pool.clone()));
     let all_holder_credentials: Arc<PostgresViewRepository<_, _>> =
-        Arc::new(PostgresViewRepository::new("all_credentials", pool.clone()));
+        Arc::new(PostgresViewRepository::new("all_holder_credentials", pool.clone()));
     let received_offer = Arc::new(PostgresViewRepository::new("received_offer", pool.clone()));
-    let all_received_offers = Arc::new(PostgresViewRepository::new("all_offers", pool.clone()));
+    let all_received_offers = Arc::new(PostgresViewRepository::new("all_received_offers", pool.clone()));
 
     // Create custom-queries for the offer aggregate.
-    let all_holder_credentials_query = ListAllQuery::new(all_holder_credentials.clone(), "all_credentials");
-    let all_received_offers_query = ListAllQuery::new(all_received_offers.clone(), "all_offers");
+    let all_holder_credentials_query = ListAllQuery::new(all_holder_credentials.clone(), "all_holder_credentials");
+    let all_received_offers_query = ListAllQuery::new(all_received_offers.clone(), "all_received_offers");
 
     // Partition the event_publishers into the different aggregates.
     let (_, _, _, credential_event_publishers, offer_event_publishers, _, _) =


### PR DESCRIPTION
# Description of change
This feature enables the querying of all offers/credentials currently in the IssuanceState.

## Links to any relevant issues
- #118 

## How the change has been tested
Manually tested all the changes by running the UniCore instance and checking it with Postman.
I've added the relevant requests to the Postman Collection in the codebase.

## Definition of Done checklist
Add an `x` to the boxes that are relevant to your changes.

- [x] I have followed the contribution guidelines for this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have successfully tested this change in a docker environment 
