### PR TITLE
feat: upload holder credentials via HTTP API

### DIFF
--- a/agent_api_rest/postman/ssi-agent.postman_collection.json
+++ b/agent_api_rest/postman/ssi-agent.postman_collection.json
@@ -959,6 +959,45 @@
 					"response": []
 				},
 				{
+					"name": "Add signed Holder Credential",
+					"event": [
+						{
+							"listen": "test",
+							"script": {
+								"exec": [
+									""
+								],
+								"type": "text/javascript"
+							}
+						}
+					],
+					"request": {
+						"method": "POST",
+						"header": [],
+						"body": {
+							"mode": "raw",
+							"raw": "{\n    \"credential\": \"eyJ0eXAiOiJKV1QiLCJhbGciOiJFZERTQSIsImtpZCI6ImRpZDprZXk6ejZNa2dFODROQ01wTWVBeDlqSzljZjVXNEc4Z2NaOXh1d0p2RzFlN3dOazhLQ2d0I3o2TWtnRTg0TkNNcE1lQXg5aks5Y2Y1VzRHOGdjWjl4dXdKdkcxZTd3Tms4S0NndCJ9.eyJpc3MiOiJkaWQ6a2V5Ono2TWtnRTg0TkNNcE1lQXg5aks5Y2Y1VzRHOGdjWjl4dXdKdkcxZTd3Tms4S0NndCIsInN1YiI6ImRpZDprZXk6ejZNa2lpZXlvTE1TVnNKQVp2N0pqZTV3V1NrREV5bVVna3lGOGtiY3JqWnBYM3FkIiwiZXhwIjo5OTk5OTk5OTk5LCJpYXQiOjAsInZjIjp7IkBjb250ZXh0IjoiaHR0cHM6Ly93d3cudzMub3JnLzIwMTgvY3JlZGVudGlhbHMvdjEiLCJ0eXBlIjpbIlZlcmlmaWFibGVDcmVkZW50aWFsIl0sImNyZWRlbnRpYWxTdWJqZWN0Ijp7ImlkIjoiZGlkOmtleTp6Nk1raWlleW9MTVNWc0pBWnY3SmplNXdXU2tERXltVWdreUY4a2JjcmpacFgzcWQiLCJmaXJzdF9uYW1lIjoiRmVycmlzIiwibGFzdF9uYW1lIjoiUnVzdGFjZWFuIn0sImlzc3VlciI6ImRpZDprZXk6ejZNa2dFODROQ01wTWVBeDlqSzljZjVXNEc4Z2NaOXh1d0p2RzFlN3dOazhLQ2d0IiwiaXNzdWFuY2VEYXRlIjoiMjAxMC0wMS0wMVQwMDowMDowMFoifX0.d4QN73vDtZu79RP6GldHObu6rGsjidkLYp0XMRQNbNPY75LJoSv2iXk2Rz5M-VMBZGSU3YPZHytlrKBjxr1IBQ\"\n}",
+							"options": {
+								"raw": {
+									"language": "json"
+								}
+							}
+						},
+						"url": {
+							"raw": "{{HOST}}/v0/holder/credentials",
+							"host": [
+								"{{HOST}}"
+							],
+							"path": [
+								"v0",
+								"holder",
+								"credentials"
+							]
+						}
+					},
+					"response": []
+				},
+				{
 					"name": "Holder Credential by ID",
 					"request": {
 						"method": "GET",

--- a/agent_api_rest/src/holder/holder/credentials/mod.rs
+++ b/agent_api_rest/src/holder/holder/credentials/mod.rs
@@ -1,12 +1,19 @@
-use agent_holder::state::HolderState;
-use agent_shared::handlers::query_handler;
+use agent_holder::{credential::command::CredentialCommand, state::HolderState};
+use agent_shared::{
+    generate_random_string,
+    handlers::{command_handler, query_handler},
+};
 use axum::{
     extract::{Path, State},
     response::{IntoResponse, Response},
     Json,
 };
 use hyper::StatusCode;
-use serde_json::json;
+use identity_credential::credential::Jwt;
+use serde::{Deserialize, Serialize};
+use serde_json::{json, Value};
+use tracing::info;
+use uuid::Uuid;
 
 #[axum_macros::debug_handler]
 pub(crate) async fn credentials(State(state): State<HolderState>) -> Response {
@@ -17,6 +24,42 @@ pub(crate) async fn credentials(State(state): State<HolderState>) -> Response {
             (StatusCode::OK, Json(all_credentials)).into_response()
         }
         Ok(None) => (StatusCode::OK, Json(json!([]))).into_response(),
+        _ => StatusCode::INTERNAL_SERVER_ERROR.into_response(),
+    }
+}
+
+#[derive(Deserialize, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct HolderCredentialsEndpointRequest {
+    pub credential: Jwt,
+}
+
+#[axum_macros::debug_handler]
+pub(crate) async fn post_credentials(State(state): State<HolderState>, Json(payload): Json<Value>) -> Response {
+    info!("Request Body: {}", payload);
+
+    let Ok(HolderCredentialsEndpointRequest { credential }) = serde_json::from_value(payload) else {
+        return (StatusCode::BAD_REQUEST, "invalid payload").into_response();
+    };
+
+    let holder_credential_id = uuid::Uuid::new_v4().to_string();
+
+    let command = CredentialCommand::AddCredential {
+        holder_credential_id: holder_credential_id.clone(),
+        received_offer_id: None,
+        credential,
+    };
+
+    // Add the credential.
+    if command_handler(&holder_credential_id, &state.command.credential, command)
+        .await
+        .is_err()
+    {
+        return StatusCode::INTERNAL_SERVER_ERROR.into_response();
+    }
+
+    match query_handler(&holder_credential_id, &state.query.holder_credential).await {
+        Ok(Some(holder_credential_view)) => (StatusCode::OK, Json(holder_credential_view)).into_response(),
         _ => StatusCode::INTERNAL_SERVER_ERROR.into_response(),
     }
 }

--- a/agent_api_rest/src/holder/holder/credentials/mod.rs
+++ b/agent_api_rest/src/holder/holder/credentials/mod.rs
@@ -1,8 +1,5 @@
 use agent_holder::{credential::command::CredentialCommand, state::HolderState};
-use agent_shared::{
-    generate_random_string,
-    handlers::{command_handler, query_handler},
-};
+use agent_shared::handlers::{command_handler, query_handler};
 use axum::{
     extract::{Path, State},
     response::{IntoResponse, Response},
@@ -13,7 +10,6 @@ use identity_credential::credential::Jwt;
 use serde::{Deserialize, Serialize};
 use serde_json::{json, Value};
 use tracing::info;
-use uuid::Uuid;
 
 #[axum_macros::debug_handler]
 pub(crate) async fn credentials(State(state): State<HolderState>) -> Response {

--- a/agent_api_rest/src/holder/holder/offers/accept.rs
+++ b/agent_api_rest/src/holder/holder/offers/accept.rs
@@ -64,7 +64,7 @@ pub(crate) async fn accept(State(state): State<HolderState>, Path(received_offer
     {
         let command = CredentialCommand::AddCredential {
             holder_credential_id: holder_credential_id.clone(),
-            received_offer_id: received_offer_id.clone(),
+            received_offer_id: Some(received_offer_id.clone()),
             credential,
         };
 

--- a/agent_api_rest/src/holder/holder/presentations/mod.rs
+++ b/agent_api_rest/src/holder/holder/presentations/mod.rs
@@ -10,7 +10,6 @@ use axum::{
     Json,
 };
 use hyper::StatusCode;
-use identity_credential::credential::Jwt;
 use serde::{Deserialize, Serialize};
 use serde_json::{json, Value};
 use tracing::info;
@@ -40,23 +39,18 @@ pub(crate) async fn presentation(State(state): State<HolderState>, Path(presenta
 #[derive(Deserialize, Serialize)]
 #[serde(rename_all = "camelCase")]
 pub struct PresentationsEndpointRequest {
-    #[serde(default)]
     pub credential_ids: Vec<String>,
-    #[serde(default)]
-    pub credentials: Vec<Jwt>,
 }
 
 #[axum_macros::debug_handler]
 pub(crate) async fn post_presentations(State(state): State<HolderState>, Json(payload): Json<Value>) -> Response {
     info!("Request Body: {}", payload);
 
-    let Ok(PresentationsEndpointRequest {
-        credential_ids,
-        mut credentials,
-    }) = serde_json::from_value(payload)
-    else {
+    let Ok(PresentationsEndpointRequest { credential_ids }) = serde_json::from_value(payload) else {
         return (StatusCode::BAD_REQUEST, "invalid payload").into_response();
     };
+
+    let mut credentials = vec![];
 
     // Get all the credentials.
     for credential_id in credential_ids {

--- a/agent_api_rest/src/holder/holder/presentations/mod.rs
+++ b/agent_api_rest/src/holder/holder/presentations/mod.rs
@@ -10,6 +10,7 @@ use axum::{
     Json,
 };
 use hyper::StatusCode;
+use identity_credential::credential::Jwt;
 use serde::{Deserialize, Serialize};
 use serde_json::{json, Value};
 use tracing::info;
@@ -39,18 +40,23 @@ pub(crate) async fn presentation(State(state): State<HolderState>, Path(presenta
 #[derive(Deserialize, Serialize)]
 #[serde(rename_all = "camelCase")]
 pub struct PresentationsEndpointRequest {
+    #[serde(default)]
     pub credential_ids: Vec<String>,
+    #[serde(default)]
+    pub credentials: Vec<Jwt>,
 }
 
 #[axum_macros::debug_handler]
 pub(crate) async fn post_presentations(State(state): State<HolderState>, Json(payload): Json<Value>) -> Response {
     info!("Request Body: {}", payload);
 
-    let Ok(PresentationsEndpointRequest { credential_ids }) = serde_json::from_value(payload) else {
+    let Ok(PresentationsEndpointRequest {
+        credential_ids,
+        mut credentials,
+    }) = serde_json::from_value(payload)
+    else {
         return (StatusCode::BAD_REQUEST, "invalid payload").into_response();
     };
-
-    let mut credentials = vec![];
 
     // Get all the credentials.
     for credential_id in credential_ids {

--- a/agent_api_rest/src/holder/mod.rs
+++ b/agent_api_rest/src/holder/mod.rs
@@ -12,7 +12,7 @@ use agent_holder::state::HolderState;
 use axum::routing::get;
 use axum::{routing::post, Router};
 use holder::{
-    credentials::credential,
+    credentials::{credential, post_credentials},
     presentations::{get_presentations, post_presentations, presentation, presentation_signed::presentation_signed},
 };
 
@@ -21,7 +21,7 @@ pub fn router(holder_state: HolderState) -> Router {
         .nest(
             API_VERSION,
             Router::new()
-                .route("/holder/credentials", get(credentials))
+                .route("/holder/credentials", get(credentials).post(post_credentials))
                 .route("/holder/credentials/:credential_id", get(credential))
                 .route("/holder/presentations", get(get_presentations).post(post_presentations))
                 .route("/holder/presentations/:presentation_id", get(presentation))

--- a/agent_holder/src/credential/aggregate.rs
+++ b/agent_holder/src/credential/aggregate.rs
@@ -80,7 +80,7 @@ impl Aggregate for Credential {
                 data,
             } => {
                 self.holder_credential_id = holder_credential_id;
-                self.received_offer_id = Some(received_offer_id);
+                self.received_offer_id = received_offer_id;
                 self.signed = Some(credential);
                 self.data = Some(data);
             }
@@ -123,12 +123,12 @@ pub mod credential_tests {
             .given_no_previous_events()
             .when(CredentialCommand::AddCredential {
                 holder_credential_id: holder_credential_id.clone(),
-                received_offer_id: received_offer_id.clone(),
+                received_offer_id: Some(received_offer_id.clone()),
                 credential: Jwt::from(OPENBADGE_VERIFIABLE_CREDENTIAL_JWT.to_string()),
             })
             .then_expect_events(vec![CredentialEvent::CredentialAdded {
                 holder_credential_id,
-                received_offer_id,
+                received_offer_id: Some(received_offer_id),
                 credential: Jwt::from(OPENBADGE_VERIFIABLE_CREDENTIAL_JWT.to_string()),
                 data: Data {
                     raw: get_unverified_jwt_claims(&serde_json::json!(OPENBADGE_VERIFIABLE_CREDENTIAL_JWT)).unwrap()

--- a/agent_holder/src/credential/command.rs
+++ b/agent_holder/src/credential/command.rs
@@ -6,7 +6,7 @@ use serde::Deserialize;
 pub enum CredentialCommand {
     AddCredential {
         holder_credential_id: String,
-        received_offer_id: String,
+        received_offer_id: Option<String>,
         credential: Jwt,
     },
 }

--- a/agent_holder/src/credential/event.rs
+++ b/agent_holder/src/credential/event.rs
@@ -8,7 +8,7 @@ use super::aggregate::Data;
 pub enum CredentialEvent {
     CredentialAdded {
         holder_credential_id: String,
-        received_offer_id: String,
+        received_offer_id: Option<String>,
         credential: Jwt,
         data: Data,
     },

--- a/agent_holder/src/credential/queries/mod.rs
+++ b/agent_holder/src/credential/queries/mod.rs
@@ -18,7 +18,7 @@ impl View<Credential> for Credential {
                 data,
             } => {
                 self.holder_credential_id.clone_from(holder_credential_id);
-                self.received_offer_id.replace(offer_id.clone());
+                self.received_offer_id.clone_from(offer_id);
                 self.signed.replace(credential.clone());
                 self.data.replace(data.clone());
             }


### PR DESCRIPTION
# Description of change

This update allows users to send their credentials directly through the designated `POST /v0/holder/credentials` in JWT format.

This update allows users to upload their own credentials directly to UniCore securely. With this change, users can add and manage credentials that weren’t originally issued by UniCore, making it easier to integrate and use a variety of credentials within the platform.

Example:
```http
POST /v0/holder/credentials HTTP/1.1
Host: "https://my-server.com"
Content-Type: application/json
Content-Length: 947

{
    "credential": "eyJ0eXAiOiJKV1QiLCJhbGciOiJFZERTQSIsImtpZCI6ImRpZDprZXk6ejZNa2dFODROQ01wTWVBeDlqSzljZjVXNEc4Z2NaOXh1d0p2RzFlN3dOazhLQ2d0I3o2TWtnRTg0TkNNcE1lQXg5aks5Y2Y1VzRHOGdjWjl4dXdKdkcxZTd3Tms4S0NndCJ9.eyJpc3MiOiJkaWQ6a2V5Ono2TWtnRTg0TkNNcE1lQXg5aks5Y2Y1VzRHOGdjWjl4dXdKdkcxZTd3Tms4S0NndCIsInN1YiI6ImRpZDprZXk6ejZNa2lpZXlvTE1TVnNKQVp2N0pqZTV3V1NrREV5bVVna3lGOGtiY3JqWnBYM3FkIiwiZXhwIjo5OTk5OTk5OTk5LCJpYXQiOjAsInZjIjp7IkBjb250ZXh0IjoiaHR0cHM6Ly93d3cudzMub3JnLzIwMTgvY3JlZGVudGlhbHMvdjEiLCJ0eXBlIjpbIlZlcmlmaWFibGVDcmVkZW50aWFsIl0sImNyZWRlbnRpYWxTdWJqZWN0Ijp7ImlkIjoiZGlkOmtleTp6Nk1raWlleW9MTVNWc0pBWnY3SmplNXdXU2tERXltVWdreUY4a2JjcmpacFgzcWQiLCJmaXJzdF9uYW1lIjoiRmVycmlzIiwibGFzdF9uYW1lIjoiUnVzdGFjZWFuIn0sImlzc3VlciI6ImRpZDprZXk6ejZNa2dFODROQ01wTWVBeDlqSzljZjVXNEc4Z2NaOXh1d0p2RzFlN3dOazhLQ2d0IiwiaXNzdWFuY2VEYXRlIjoiMjAxMC0wMS0wMVQwMDowMDowMFoifX0.d4QN73vDtZu79RP6GldHObu6rGsjidkLYp0XMRQNbNPY75LJoSv2iXk2Rz5M-VMBZGSU3YPZHytlrKBjxr1IBQ"
}
```

In a future improvement we should make sure that UniCore will/can validate the credential's schema and validity (related to #151)

## Links to any relevant issues
n/a

## How the change has been tested
Tested through updated Postman Collection (see `Add signed Holder Credential` request).

## Definition of Done checklist
Add an `x` to the boxes that are relevant to your changes.

- [x] I have followed the contribution guidelines for this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] I have successfully tested this change in a docker environment 
