### PR TITLE
style: box `CredentialConfigurationsSupportedObject`

### DIFF
--- a/agent_api_rest/src/issuance/credentials.rs
+++ b/agent_api_rest/src/issuance/credentials.rs
@@ -65,29 +65,31 @@ pub(crate) async fn credentials(
 
     let credential_id = uuid::Uuid::new_v4().to_string();
 
-    let credential_configuration = match query_handler(SERVER_CONFIG_ID, &state.query.server_config).await {
-        Ok(Some(ServerConfigView {
-            credential_issuer_metadata:
-                Some(CredentialIssuerMetadata {
-                    credential_configurations_supported,
-                    ..
-                }),
-            ..
-        })) => {
-            if let Some(credential_configuration) =
-                credential_configurations_supported.get(&credential_configuration_id)
-            {
-                credential_configuration.clone()
-            } else {
-                return (
-                    StatusCode::NOT_FOUND,
-                    format!("No Credential Configuration found with id: `{credential_configuration_id}`"),
-                )
-                    .into_response();
+    let credential_configuration = Box::new(
+        match query_handler(SERVER_CONFIG_ID, &state.query.server_config).await {
+            Ok(Some(ServerConfigView {
+                credential_issuer_metadata:
+                    Some(CredentialIssuerMetadata {
+                        credential_configurations_supported,
+                        ..
+                    }),
+                ..
+            })) => {
+                if let Some(credential_configuration) =
+                    credential_configurations_supported.get(&credential_configuration_id)
+                {
+                    credential_configuration.clone()
+                } else {
+                    return (
+                        StatusCode::NOT_FOUND,
+                        format!("No Credential Configuration found with id: `{credential_configuration_id}`"),
+                    )
+                        .into_response();
+                }
             }
-        }
-        _ => return StatusCode::INTERNAL_SERVER_ERROR.into_response(),
-    };
+            _ => return StatusCode::INTERNAL_SERVER_ERROR.into_response(),
+        },
+    );
 
     let command = if is_signed {
         CredentialCommand::CreateSignedCredential {

--- a/agent_issuance/src/credential/aggregate.rs
+++ b/agent_issuance/src/credential/aggregate.rs
@@ -241,7 +241,7 @@ impl Aggregate for Credential {
                 credential_configuration,
             } => {
                 self.data.replace(data);
-                self.credential_configuration = credential_configuration;
+                self.credential_configuration = *credential_configuration;
             }
             SignedCredentialCreated { signed_credential } => {
                 self.signed.replace(signed_credential);
@@ -295,13 +295,13 @@ pub mod credential_tests {
                 data: Data {
                     raw: credential_subject,
                 },
-                credential_configuration: credential_configuration.clone(),
+                credential_configuration: Box::new(credential_configuration.clone()),
             })
             .then_expect_events(vec![CredentialEvent::UnsignedCredentialCreated {
                 data: Data {
                     raw: unsigned_credential,
                 },
-                credential_configuration,
+                credential_configuration: Box::new(credential_configuration),
             }])
     }
 
@@ -327,7 +327,7 @@ pub mod credential_tests {
                 data: Data {
                     raw: unsigned_credential,
                 },
-                credential_configuration,
+                credential_configuration: Box::new(credential_configuration),
             }])
             .when(CredentialCommand::SignCredential {
                 subject_id: SUBJECT_KEY_DID.identifier("did:key", Algorithm::EdDSA).await.unwrap(),

--- a/agent_issuance/src/credential/command.rs
+++ b/agent_issuance/src/credential/command.rs
@@ -8,7 +8,7 @@ use super::entity::Data;
 pub enum CredentialCommand {
     CreateUnsignedCredential {
         data: Data,
-        credential_configuration: CredentialConfigurationsSupportedObject,
+        credential_configuration: Box<CredentialConfigurationsSupportedObject>,
     },
     CreateSignedCredential {
         signed_credential: serde_json::Value,

--- a/agent_issuance/src/credential/event.rs
+++ b/agent_issuance/src/credential/event.rs
@@ -9,7 +9,7 @@ pub enum CredentialEvent {
     // TODO: rename to `DataCredentialCreated`?
     UnsignedCredentialCreated {
         data: Data,
-        credential_configuration: CredentialConfigurationsSupportedObject,
+        credential_configuration: Box<CredentialConfigurationsSupportedObject>,
     },
     SignedCredentialCreated {
         signed_credential: serde_json::Value,

--- a/agent_issuance/src/credential/queries/mod.rs
+++ b/agent_issuance/src/credential/queries/mod.rs
@@ -21,7 +21,7 @@ impl View<Credential> for CredentialView {
                 credential_configuration,
             } => {
                 self.data.replace(data.clone());
-                self.credential_configuration = credential_configuration.clone();
+                self.credential_configuration = *credential_configuration.clone();
             }
             CredentialEvent::SignedCredentialCreated { signed_credential } => {
                 self.signed.replace(signed_credential.clone());


### PR DESCRIPTION
# Description of change
As title.

This change fixes the following clippy suggestions:
```bash
error: large size difference between variants
  --> agent_issuance/src/credential/command.rs:8:1
   |
8  | /   pub enum CredentialCommand {
9  | | /     CreateUnsignedCredential {
10 | | |         data: Data,
11 | | |         credential_configuration: CredentialConfigurationsSupportedObject,
12 | | |     },
   | | |_____- the largest variant contains at least 368 bytes
13 | | /     CreateSignedCredential {
14 | | |         signed_credential: serde_json::Value,
15 | | |     },
   | | |_____- the second-largest variant contains at least 72 bytes
...  |
20 | |       },
21 | |   }
   | |___^ the entire enum is at least 368 bytes
   |
   = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#large_enum_variant
   = note: `-D clippy::large-enum-variant` implied by `-D warnings`
   = help: to override `-D warnings` add `#[allow(clippy::large_enum_variant)]`
help: consider boxing the large fields to reduce the total size of the enum
   |
11 |         credential_configuration: Box<CredentialConfigurationsSupportedObject>,
   |                                   ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

error: large size difference between variants
  --> agent_issuance/src/credential/event.rs:8:1
   |
8  | /   pub enum CredentialEvent {
9  | |       // TODO: rename to `DataCredentialCreated`?
10 | | /     UnsignedCredentialCreated {
11 | | |         data: Data,
12 | | |         credential_configuration: CredentialConfigurationsSupportedObject,
13 | | |     },
   | | |_____- the largest variant contains at least 368 bytes
14 | | /     SignedCredentialCreated {
15 | | |         signed_credential: serde_json::Value,
16 | | |     },
   | | |_____- the second-largest variant contains at least 72 bytes
...  |
19 | |       },
20 | |   }
   | |___^ the entire enum is at least 368 bytes
   |
   = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#large_enum_variant
help: consider boxing the large fields to reduce the total size of the enum
   |
12 |         credential_configuration: Box<CredentialConfigurationsSupportedObject>,
   |                                   ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
```

## Links to any relevant issues
n/a

## How the change has been tested
`cargo clippy --all-targets --all-features -- -D warnings`

## Definition of Done checklist
Add an `x` to the boxes that are relevant to your changes.

- [x] I have followed the contribution guidelines for this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] I have successfully tested this change in a docker environment 
