### PR TITLE
feat: remove ˋdid:iota:rmsˋ DID method (discontinued)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -5,8 +5,3 @@ UNICORE__URL="http://localhost:3033"
 
 UNICORE__SECRET_MANAGER__STRONGHOLD_PATH="agent_secret_manager/tests/res/temp.stronghold"
 UNICORE__SECRET_MANAGER__STRONGHOLD_PASSWORD="secure_password"
-# Uncomment to enable DID IOTA for testing purposes
-# UNICORE__SECRET_MANAGER__STRONGHOLD_PATH="agent_secret_manager/tests/res/test.stronghold"
-# UNICORE__SECRET_MANAGER__ISSUER_EDDSA_KEY_ID="9O66nzWqYYy1LmmiOudOlh2SMIaUWoTS"
-# UNICORE__SECRET_MANAGER__ISSUER_DID="did:iota:rms:0x42ad588322e58b3c07aa39e4948d021ee17ecb5747915e9e1f35f028d7ecaf90"
-# UNICORE__SECRET_MANAGER__ISSUER_FRAGMENT="bQKQRzaop7CgEvqVq8UlgLGsdF-R-hnLFkKFZqW2VN0"

--- a/agent_api_rest/src/issuance/credential_issuer/well_known/openid_credential_issuer.rs
+++ b/agent_api_rest/src/issuance/credential_issuer/well_known/openid_credential_issuer.rs
@@ -88,11 +88,7 @@ mod tests {
                                 .into(),
                         }),
                         scope: None,
-                        cryptographic_binding_methods_supported: vec![
-                            "did:iota:rms".to_string(),
-                            "did:jwk".to_string(),
-                            "did:key".to_string()
-                        ],
+                        cryptographic_binding_methods_supported: vec!["did:jwk".to_string(), "did:key".to_string()],
                         credential_signing_alg_values_supported: vec!["EdDSA".to_string()],
                         proof_types_supported: HashMap::from_iter([(
                             ProofType::Jwt,

--- a/agent_application/docker/compose.yaml
+++ b/agent_application/docker/compose.yaml
@@ -41,10 +41,6 @@ services:
       UNICORE__SECRET_MANAGER__STRONGHOLD_PATH: "/app/res/stronghold"
       UNICORE__SECRET_MANAGER__STRONGHOLD_PASSWORD: "secure_password"
 
-      # Uncomment the following lines to use the DID method `did:iota:rms`
-      # UNICORE__SECRET_MANAGER__ISSUER_KEY_ID: "9O66nzWqYYy1LmmiOudOlh2SMIaUWoTS"
-      # UNICORE__SECRET_MANAGER__ISSUER_DID: "did:iota:rms:0x42ad588322e58b3c07aa39e4948d021ee17ecb5747915e9e1f35f028d7ecaf90"
-      # UNICORE__SECRET_MANAGER__ISSUER_FRAGMENT: "bQKQRzaop7CgEvqVq8UlgLGsdF-R-hnLFkKFZqW2VN0"
     volumes:
       - ../../agent_application/config.yaml:/app/agent_application/config.yaml
       # - ../../agent_secret_manager/tests/res/test.stronghold:/app/res/stronghold

--- a/agent_application/example.config.yaml
+++ b/agent_application/example.config.yaml
@@ -14,8 +14,6 @@ did_methods:
     preferred: true
   did_key:
     enabled: true
-  did_iota_rms:
-    enabled: false
   did_web:
     enabled: false
 
@@ -83,5 +81,3 @@ secret_manager:
   # stronghold_password_file: ""
   # issuer_eddsa_key_id: "ed25519-0"
   issuer_es256_key_id: "es256-0"
-  # issuer_did: "did:iota:rms:0x0000000000000000000000000000000000000000000000000000000000000000"
-  # issuer_fragment: "key-0"

--- a/agent_issuance/src/credential/aggregate.rs
+++ b/agent_issuance/src/credential/aggregate.rs
@@ -553,11 +553,7 @@ pub mod test_utils {
                     )
                         .into(),
                 }),
-                cryptographic_binding_methods_supported: vec![
-                    "did:key".to_string(),
-                    "did:iota:rms".to_string(),
-                    "did:jwk".to_string(),
-                ],
+                cryptographic_binding_methods_supported: vec!["did:key".to_string(), "did:jwk".to_string(),],
                 credential_signing_alg_values_supported: vec!["EdDSA".to_string()],
                 proof_types_supported: HashMap::from_iter(vec![(
                     ProofType::Jwt,
@@ -585,11 +581,7 @@ pub mod test_utils {
                     )
                         .into(),
                 }),
-                cryptographic_binding_methods_supported: vec![
-                    "did:iota:rms".to_string(),
-                    "did:jwk".to_string(),
-                    "did:key".to_string(),
-                ],
+                cryptographic_binding_methods_supported: vec!["did:jwk".to_string(), "did:key".to_string(),],
                 credential_signing_alg_values_supported: vec!["EdDSA".to_string()],
                 proof_types_supported: HashMap::from_iter(vec![(
                     ProofType::Jwt,

--- a/agent_secret_manager/src/lib.rs
+++ b/agent_secret_manager/src/lib.rs
@@ -1,4 +1,4 @@
-use agent_shared::config::{config, get_all_enabled_did_methods, SecretManagerConfig};
+use agent_shared::config::{config, SecretManagerConfig};
 use did_manager::{InMemoryCache, SecretManager};
 use log::info;
 
@@ -12,8 +12,6 @@ pub async fn secret_manager() -> SecretManager {
         stronghold_password: password,
         issuer_eddsa_key_id,
         issuer_es256_key_id,
-        issuer_did,
-        issuer_fragment,
     } = config().secret_manager.clone();
 
     info!("{:?}", config().secret_manager);
@@ -28,19 +26,6 @@ pub async fn secret_manager() -> SecretManager {
 
     if let Some(issuer_es256_key_id) = issuer_es256_key_id {
         builder = builder.with_es256_key(&issuer_es256_key_id);
-    }
-
-    // If `did:iota:rms` is enabled, further values are required.
-    if get_all_enabled_did_methods().contains(&agent_shared::config::SupportedDidMethod::IotaRms) {
-        builder =
-            builder
-                .with_did(
-                    &issuer_did
-                        .expect("`You have enabled did:iota:rms, which requires a known DID. Please provide the value through the config or environment variable.`"),
-                )
-                .with_fragment(&issuer_fragment.expect(
-                    "`You have enabled did:iota:rms, which requires the fragment identifier of the key to be used. Please provide the value through the config or environment variable.`",
-                ));
     }
 
     if let Some(did_document_cache) = config().did_document_cache.clone() {

--- a/agent_secret_manager/src/subject.rs
+++ b/agent_secret_manager/src/subject.rs
@@ -159,8 +159,6 @@ mod tests {
             stronghold_password: "sup3rSecr3t".to_string(),
             issuer_eddsa_key_id: Some("ed25519-0".to_string()),
             issuer_es256_key_id: Some("es256-0".to_string()),
-            issuer_did: Some("did:foo:bar".to_string()),
-            issuer_fragment: Some("0".to_string()),
         };
     }
 

--- a/agent_shared/src/config.rs
+++ b/agent_shared/src/config.rs
@@ -67,8 +67,6 @@ pub struct SecretManagerConfig {
     pub stronghold_password: String,
     pub issuer_eddsa_key_id: Option<String>,
     pub issuer_es256_key_id: Option<String>,
-    pub issuer_did: Option<String>,
-    pub issuer_fragment: Option<String>,
 }
 
 #[derive(Debug, Deserialize, Clone)]
@@ -240,9 +238,6 @@ pub enum SupportedDidMethod {
     #[serde(alias = "did_iota_smr", rename = "did_iota_smr")]
     #[strum(serialize = "did:iota:smr")]
     IotaSmr,
-    #[serde(alias = "did_iota_rms", rename = "did_iota_rms")]
-    #[strum(serialize = "did:iota:rms")]
-    IotaRms,
 }
 
 impl From<SupportedDidMethod> for SubjectSyntaxType {

--- a/agent_shared/tests/test-config.yaml
+++ b/agent_shared/tests/test-config.yaml
@@ -10,8 +10,6 @@ did_methods:
   did_key:
     enabled: true
     preferred: true
-  did_iota_rms:
-    enabled: true
   did_web:
     enabled: false
 
@@ -62,5 +60,3 @@ secret_manager:
   stronghold_path: "../agent_secret_manager/tests/res/selv.stronghold"
   stronghold_password: "VNvRtH4tKyWwvJDpL6Vuc2aoLiKAecGQ"
   issuer_eddsa_key_id: "UVDxWhG2rB39FkaR7I27mHeUNrGtUgcr"
-  issuer_did: "did:iota:rms:0x42ad588322e58b3c07aa39e4948d021ee17ecb5747915e9e1f35f028d7ecaf90"
-  issuer_fragment: "bQKQRzaop7CgEvqVq8UlgLGsdF-R-hnLFkKFZqW2VN0"

--- a/agent_verification/src/authorization_request/aggregate.rs
+++ b/agent_verification/src/authorization_request/aggregate.rs
@@ -239,8 +239,7 @@ pub mod tests {
     #[rstest]
     #[serial_test::serial]
     async fn test_create_authorization_request(
-        #[values(SupportedDidMethod::Key, SupportedDidMethod::Jwk, SupportedDidMethod::IotaRms)]
-        verifier_did_method: SupportedDidMethod,
+        #[values(SupportedDidMethod::Key, SupportedDidMethod::Jwk)] verifier_did_method: SupportedDidMethod,
     ) {
         set_config().set_preferred_did_method(verifier_did_method.clone());
 
@@ -278,8 +277,7 @@ pub mod tests {
     #[rstest]
     #[serial_test::serial]
     async fn test_sign_authorization_request_object(
-        #[values(SupportedDidMethod::Key, SupportedDidMethod::Jwk, SupportedDidMethod::IotaRms)]
-        verifier_did_method: SupportedDidMethod,
+        #[values(SupportedDidMethod::Key, SupportedDidMethod::Jwk)] verifier_did_method: SupportedDidMethod,
     ) {
         set_config().set_preferred_did_method(verifier_did_method.clone());
 
@@ -320,10 +318,8 @@ pub mod tests {
         // "id_token" represents the `SIOPv2` flow, and "vp_token" represents the `OID4VP` flow.
         #[values("id_token", "vp_token")] response_type: &str,
         // TODO: add `did:web`, check for other tests as well. Probably should be moved to E2E test.
-        #[values(SupportedDidMethod::Key, SupportedDidMethod::Jwk, SupportedDidMethod::IotaRms)]
-        verifier_did_method: SupportedDidMethod,
-        #[values(SupportedDidMethod::Key, SupportedDidMethod::Jwk, SupportedDidMethod::IotaRms)]
-        provider_did_method: SupportedDidMethod,
+        #[values(SupportedDidMethod::Key, SupportedDidMethod::Jwk)] verifier_did_method: SupportedDidMethod,
+        #[values(SupportedDidMethod::Key, SupportedDidMethod::Jwk)] provider_did_method: SupportedDidMethod,
     ) {
         set_config().set_preferred_did_method(verifier_did_method.clone());
 
@@ -531,7 +527,6 @@ pub mod tests {
         match did_method {
             "did:key" => FORM_URL_ENCODED_AUTHORIZATION_REQUEST_DID_KEY.to_string(),
             "did:jwk" => FORM_URL_ENCODED_AUTHORIZATION_REQUEST_DID_JWK.to_string(),
-            "did:iota:rms" => FORM_URL_ENCODED_AUTHORIZATION_REQUEST_DID_IOTA.to_string(),
             _ => unimplemented!("Unknown DID method: {}", did_method),
         }
     }
@@ -540,7 +535,6 @@ pub mod tests {
         match did_method {
             "did:key" => SIGNED_AUTHORIZATION_REQUEST_OBJECT_DID_KEY.to_string(),
             "did:jwk" => SIGNED_AUTHORIZATION_REQUEST_OBJECT_DID_JWK.to_string(),
-            "did:iota:rms" => SIGNED_AUTHORIZATION_REQUEST_OBJECT_DID_IOTA.to_string(),
             _ => unimplemented!("Unknown DID method: {}", did_method),
         }
     }
@@ -587,11 +581,6 @@ pub mod tests {
         openid://?\
             client_id=did%3Ajwk%3AeyJhbGciOiJFZERTQSIsImNydiI6IkVkMjU1MTkiLCJraWQiOiJiUUtRUnphb3A3Q2dFdnFWcThVbGdMR3NkRi1SLWhuTEZrS0ZacVcyVk4wIiwia3R5IjoiT0tQIiwieCI6Ikdsbks5ZVBzODAyWHhBZ2xST1F6b0d1cm05UXB2MElGUEViZE1DSUxOX1UifQ&\
             request_uri=https%3A%2F%2Fmy-domain.example.org%2Frequest%2Fstate";
-    const FORM_URL_ENCODED_AUTHORIZATION_REQUEST_DID_IOTA: &str = "\
-        openid://?\
-            client_id=did%3Aiota%3Arms%3A0x42ad588322e58b3c07aa39e4948d021ee17ecb5747915e9e1f35f028d7ecaf90&\
-            request_uri=https%3A%2F%2Fmy-domain.example.org%2Frequest%2Fstate";
-    const SIGNED_AUTHORIZATION_REQUEST_OBJECT_DID_KEY: &str = "eyJ0eXAiOiJvYXV0aC1hdXRoei1yZXErand0IiwiYWxnIjoiRWREU0EiLCJraWQiOiJkaWQ6a2V5Ono2TWtnRTg0TkNNcE1lQXg5aks5Y2Y1VzRHOGdjWjl4dXdKdkcxZTd3Tms4S0NndCN6Nk1rZ0U4NE5DTXBNZUF4OWpLOWNmNVc0RzhnY1o5eHV3SnZHMWU3d05rOEtDZ3QifQ.eyJjbGllbnRfaWQiOiJkaWQ6a2V5Ono2TWtnRTg0TkNNcE1lQXg5aks5Y2Y1VzRHOGdjWjl4dXdKdkcxZTd3Tms4S0NndCIsInJlZGlyZWN0X3VyaSI6Imh0dHBzOi8vbXktZG9tYWluLmV4YW1wbGUub3JnL3JlZGlyZWN0Iiwic3RhdGUiOiJzdGF0ZSIsInJlc3BvbnNlX3R5cGUiOiJpZF90b2tlbiIsInNjb3BlIjoib3BlbmlkIiwicmVzcG9uc2VfbW9kZSI6ImRpcmVjdF9wb3N0Iiwibm9uY2UiOiJub25jZSIsImNsaWVudF9tZXRhZGF0YSI6eyJjbGllbnRfbmFtZSI6IlVuaUNvcmUiLCJsb2dvX3VyaSI6Imh0dHBzOi8vaW1waWVyY2UuY29tL2ltYWdlcy9mYXZpY29uL2FwcGxlLXRvdWNoLWljb24ucG5nIiwic3ViamVjdF9zeW50YXhfdHlwZXNfc3VwcG9ydGVkIjpbImRpZDpqd2siLCJkaWQ6a2V5IiwiZGlkOmlvdGE6cm1zIl0sImlkX3Rva2VuX3NpZ25lZF9yZXNwb25zZV9hbGciOiJFZERTQSIsImlkX3Rva2VuX3NpZ25pbmdfYWxnX3ZhbHVlc19zdXBwb3J0ZWQiOlsiRWREU0EiXX19.r9N36FoNOJPn7XkH468lLBUf2zzaM3GIg3tVASt1gDktkL5_bbmWsfZEQ0dWu2M1_iSud76r-gBxS-0qw-0fCg";
-    const SIGNED_AUTHORIZATION_REQUEST_OBJECT_DID_JWK: &str = "eyJ0eXAiOiJvYXV0aC1hdXRoei1yZXErand0IiwiYWxnIjoiRWREU0EiLCJraWQiOiJkaWQ6andrOmV5SmhiR2NpT2lKRlpFUlRRU0lzSW1OeWRpSTZJa1ZrTWpVMU1Ua2lMQ0pyYVdRaU9pSmlVVXRSVW5waGIzQTNRMmRGZG5GV2NUaFZiR2RNUjNOa1JpMVNMV2h1VEVaclMwWmFjVmN5Vms0d0lpd2lhM1I1SWpvaVQwdFFJaXdpZUNJNklrZHNia3M1WlZCek9EQXlXSGhCWjJ4U1QxRjZiMGQxY20wNVVYQjJNRWxHVUVWaVpFMURTVXhPWDFVaWZRIzAifQ.eyJjbGllbnRfaWQiOiJkaWQ6andrOmV5SmhiR2NpT2lKRlpFUlRRU0lzSW1OeWRpSTZJa1ZrTWpVMU1Ua2lMQ0pyYVdRaU9pSmlVVXRSVW5waGIzQTNRMmRGZG5GV2NUaFZiR2RNUjNOa1JpMVNMV2h1VEVaclMwWmFjVmN5Vms0d0lpd2lhM1I1SWpvaVQwdFFJaXdpZUNJNklrZHNia3M1WlZCek9EQXlXSGhCWjJ4U1QxRjZiMGQxY20wNVVYQjJNRWxHVUVWaVpFMURTVXhPWDFVaWZRIiwicmVkaXJlY3RfdXJpIjoiaHR0cHM6Ly9teS1kb21haW4uZXhhbXBsZS5vcmcvcmVkaXJlY3QiLCJzdGF0ZSI6InN0YXRlIiwicmVzcG9uc2VfdHlwZSI6ImlkX3Rva2VuIiwic2NvcGUiOiJvcGVuaWQiLCJyZXNwb25zZV9tb2RlIjoiZGlyZWN0X3Bvc3QiLCJub25jZSI6Im5vbmNlIiwiY2xpZW50X21ldGFkYXRhIjp7ImNsaWVudF9uYW1lIjoiVW5pQ29yZSIsImxvZ29fdXJpIjoiaHR0cHM6Ly9pbXBpZXJjZS5jb20vaW1hZ2VzL2Zhdmljb24vYXBwbGUtdG91Y2gtaWNvbi5wbmciLCJzdWJqZWN0X3N5bnRheF90eXBlc19zdXBwb3J0ZWQiOlsiZGlkOmp3ayIsImRpZDprZXkiLCJkaWQ6aW90YTpybXMiXSwiaWRfdG9rZW5fc2lnbmVkX3Jlc3BvbnNlX2FsZyI6IkVkRFNBIiwiaWRfdG9rZW5fc2lnbmluZ19hbGdfdmFsdWVzX3N1cHBvcnRlZCI6WyJFZERTQSJdfX0.AU72_fUX8Q2j_NWfOf9iXLwfZasjpIqVax1U_svyDDizmV_9sttFZpdQ4QjkOxrrUOGmp_KOqZQb0dcg6kpsAA";
-    const SIGNED_AUTHORIZATION_REQUEST_OBJECT_DID_IOTA: &str = "eyJ0eXAiOiJvYXV0aC1hdXRoei1yZXErand0IiwiYWxnIjoiRWREU0EiLCJraWQiOiJkaWQ6aW90YTpybXM6MHg0MmFkNTg4MzIyZTU4YjNjMDdhYTM5ZTQ5NDhkMDIxZWUxN2VjYjU3NDc5MTVlOWUxZjM1ZjAyOGQ3ZWNhZjkwI2JRS1FSemFvcDdDZ0V2cVZxOFVsZ0xHc2RGLVItaG5MRmtLRlpxVzJWTjAifQ.eyJjbGllbnRfaWQiOiJkaWQ6aW90YTpybXM6MHg0MmFkNTg4MzIyZTU4YjNjMDdhYTM5ZTQ5NDhkMDIxZWUxN2VjYjU3NDc5MTVlOWUxZjM1ZjAyOGQ3ZWNhZjkwIiwicmVkaXJlY3RfdXJpIjoiaHR0cHM6Ly9teS1kb21haW4uZXhhbXBsZS5vcmcvcmVkaXJlY3QiLCJzdGF0ZSI6InN0YXRlIiwicmVzcG9uc2VfdHlwZSI6ImlkX3Rva2VuIiwic2NvcGUiOiJvcGVuaWQiLCJyZXNwb25zZV9tb2RlIjoiZGlyZWN0X3Bvc3QiLCJub25jZSI6Im5vbmNlIiwiY2xpZW50X21ldGFkYXRhIjp7ImNsaWVudF9uYW1lIjoiVW5pQ29yZSIsImxvZ29fdXJpIjoiaHR0cHM6Ly9pbXBpZXJjZS5jb20vaW1hZ2VzL2Zhdmljb24vYXBwbGUtdG91Y2gtaWNvbi5wbmciLCJzdWJqZWN0X3N5bnRheF90eXBlc19zdXBwb3J0ZWQiOlsiZGlkOmp3ayIsImRpZDprZXkiLCJkaWQ6aW90YTpybXMiXSwiaWRfdG9rZW5fc2lnbmVkX3Jlc3BvbnNlX2FsZyI6IkVkRFNBIiwiaWRfdG9rZW5fc2lnbmluZ19hbGdfdmFsdWVzX3N1cHBvcnRlZCI6WyJFZERTQSJdfX0.ri-s-jWYuQ8_1UVtgRBq4-1KB76e8XL7RWj1ttsyqjANIClbptABqDZiBPqX-fcmjuhHYygTFG9qZ2Sl3hgpBQ";
+    const SIGNED_AUTHORIZATION_REQUEST_OBJECT_DID_KEY: &str = "eyJ0eXAiOiJvYXV0aC1hdXRoei1yZXErand0IiwiYWxnIjoiRWREU0EiLCJraWQiOiJkaWQ6a2V5Ono2TWtnRTg0TkNNcE1lQXg5aks5Y2Y1VzRHOGdjWjl4dXdKdkcxZTd3Tms4S0NndCN6Nk1rZ0U4NE5DTXBNZUF4OWpLOWNmNVc0RzhnY1o5eHV3SnZHMWU3d05rOEtDZ3QifQ.eyJjbGllbnRfaWQiOiJkaWQ6a2V5Ono2TWtnRTg0TkNNcE1lQXg5aks5Y2Y1VzRHOGdjWjl4dXdKdkcxZTd3Tms4S0NndCIsInJlZGlyZWN0X3VyaSI6Imh0dHBzOi8vbXktZG9tYWluLmV4YW1wbGUub3JnL3JlZGlyZWN0Iiwic3RhdGUiOiJzdGF0ZSIsInJlc3BvbnNlX3R5cGUiOiJpZF90b2tlbiIsInNjb3BlIjoib3BlbmlkIiwicmVzcG9uc2VfbW9kZSI6ImRpcmVjdF9wb3N0Iiwibm9uY2UiOiJub25jZSIsImNsaWVudF9tZXRhZGF0YSI6eyJjbGllbnRfbmFtZSI6IlVuaUNvcmUiLCJsb2dvX3VyaSI6Imh0dHBzOi8vaW1waWVyY2UuY29tL2ltYWdlcy9mYXZpY29uL2FwcGxlLXRvdWNoLWljb24ucG5nIiwic3ViamVjdF9zeW50YXhfdHlwZXNfc3VwcG9ydGVkIjpbImRpZDpqd2siLCJkaWQ6a2V5Il0sImlkX3Rva2VuX3NpZ25lZF9yZXNwb25zZV9hbGciOiJFZERTQSIsImlkX3Rva2VuX3NpZ25pbmdfYWxnX3ZhbHVlc19zdXBwb3J0ZWQiOlsiRWREU0EiXX19.caML3la0NDH51B6N4lXgAtt3vSCjhYQGalVDUfGcjwMJAVvCMXGUnfDNvA4IHGqHeAO3P6UDDSUe5NRN50rcBw";
+    const SIGNED_AUTHORIZATION_REQUEST_OBJECT_DID_JWK: &str = "eyJ0eXAiOiJvYXV0aC1hdXRoei1yZXErand0IiwiYWxnIjoiRWREU0EiLCJraWQiOiJkaWQ6andrOmV5SmhiR2NpT2lKRlpFUlRRU0lzSW1OeWRpSTZJa1ZrTWpVMU1Ua2lMQ0pyYVdRaU9pSmlVVXRSVW5waGIzQTNRMmRGZG5GV2NUaFZiR2RNUjNOa1JpMVNMV2h1VEVaclMwWmFjVmN5Vms0d0lpd2lhM1I1SWpvaVQwdFFJaXdpZUNJNklrZHNia3M1WlZCek9EQXlXSGhCWjJ4U1QxRjZiMGQxY20wNVVYQjJNRWxHVUVWaVpFMURTVXhPWDFVaWZRIzAifQ.eyJjbGllbnRfaWQiOiJkaWQ6andrOmV5SmhiR2NpT2lKRlpFUlRRU0lzSW1OeWRpSTZJa1ZrTWpVMU1Ua2lMQ0pyYVdRaU9pSmlVVXRSVW5waGIzQTNRMmRGZG5GV2NUaFZiR2RNUjNOa1JpMVNMV2h1VEVaclMwWmFjVmN5Vms0d0lpd2lhM1I1SWpvaVQwdFFJaXdpZUNJNklrZHNia3M1WlZCek9EQXlXSGhCWjJ4U1QxRjZiMGQxY20wNVVYQjJNRWxHVUVWaVpFMURTVXhPWDFVaWZRIiwicmVkaXJlY3RfdXJpIjoiaHR0cHM6Ly9teS1kb21haW4uZXhhbXBsZS5vcmcvcmVkaXJlY3QiLCJzdGF0ZSI6InN0YXRlIiwicmVzcG9uc2VfdHlwZSI6ImlkX3Rva2VuIiwic2NvcGUiOiJvcGVuaWQiLCJyZXNwb25zZV9tb2RlIjoiZGlyZWN0X3Bvc3QiLCJub25jZSI6Im5vbmNlIiwiY2xpZW50X21ldGFkYXRhIjp7ImNsaWVudF9uYW1lIjoiVW5pQ29yZSIsImxvZ29fdXJpIjoiaHR0cHM6Ly9pbXBpZXJjZS5jb20vaW1hZ2VzL2Zhdmljb24vYXBwbGUtdG91Y2gtaWNvbi5wbmciLCJzdWJqZWN0X3N5bnRheF90eXBlc19zdXBwb3J0ZWQiOlsiZGlkOmp3ayIsImRpZDprZXkiXSwiaWRfdG9rZW5fc2lnbmVkX3Jlc3BvbnNlX2FsZyI6IkVkRFNBIiwiaWRfdG9rZW5fc2lnbmluZ19hbGdfdmFsdWVzX3N1cHBvcnRlZCI6WyJFZERTQSJdfX0.H0GAqXL_P8GsIFL7_6ZTrZ5OG67iIt1dPDqiVQSCcbpU5Ky3ptwvAmYTNY4bKou76ChFMVj-MRnoVE1s5FbZBA";
 }


### PR DESCRIPTION
# Description of change
As title

## BREAKING CHANGE
BREAKING CHANGE:

- The `did:iota:rms` DID Method has been deprecated

- the following environment variables have been deprecated:
  - `UNICORE__SECRET_MANAGER__ISSUER_DID`
  - `UNICORE__SECRET_MANAGER__ISSUER_FRAGMENT`

## Links to any relevant issues
closes #167

## How the change has been tested
All remaining tests still pass

## Definition of Done checklist
Add an `x` to the boxes that are relevant to your changes.

- [x] I have followed the contribution guidelines for this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have successfully tested this change in a docker environment 
