### PR TITLE
feat: support MongoDB event store

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -385,6 +385,8 @@ dependencies = [
  "agent_verification",
  "async-trait",
  "cqrs-es",
+ "mongo-es",
+ "mongodb",
  "postgres-es",
  "serde_json",
  "sqlx",
@@ -1505,7 +1507,7 @@ dependencies = [
  "bitflags 2.9.1",
  "cexpr",
  "clang-sys",
- "itertools 0.10.5",
+ "itertools 0.12.1",
  "lazy_static",
  "lazycell",
  "log",
@@ -1802,6 +1804,29 @@ checksum = "bf88ba1141d185c399bee5288d850d63b8369520c1eafc32a0430b5b6c287bf4"
 dependencies = [
  "sha2 0.10.9",
  "tinyvec",
+]
+
+[[package]]
+name = "bson"
+version = "2.15.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7969a9ba84b0ff843813e7249eed1678d9b6607ce5a3b8f0a47af3fcf7978e6e"
+dependencies = [
+ "ahash 0.8.12",
+ "base64 0.22.1",
+ "bitvec 1.0.1",
+ "getrandom 0.2.16",
+ "getrandom 0.3.3",
+ "hex",
+ "indexmap 2.9.0",
+ "js-sys",
+ "once_cell",
+ "rand 0.9.1",
+ "serde",
+ "serde_bytes",
+ "serde_json",
+ "time",
+ "uuid",
 ]
 
 [[package]]
@@ -2874,6 +2899,28 @@ dependencies = [
 ]
 
 [[package]]
+name = "derive-syn-parse"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d65d7ce8132b7c0e54497a4d9a55a1c2a0912a0d786cf894472ba818fba45762"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.104",
+]
+
+[[package]]
+name = "derive-where"
+version = "1.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ef941ded77d15ca19b40374869ac6000af1c9f2a4c0f3d4c70926287e6364a8f"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.104",
+]
+
+[[package]]
 name = "derive_arbitrary"
 version = "1.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3447,6 +3494,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "75030f3c4f45dafd7586dd6780965a8c7e8e285a5ecb86713e63a79c5b2766f3"
 dependencies = [
  "cfg-if",
+]
+
+[[package]]
+name = "enum-as-inner"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a1e6a265c649f3f5979b601d26f1d05ada116434c87741c9493cb56218f76cbc"
+dependencies = [
+ "heck 0.5.0",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.104",
 ]
 
 [[package]]
@@ -4433,6 +4492,51 @@ name = "hex-literal"
 version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6fe2267d4ed49bc07b63801559be28c718ea06c4738b7a03c94df7386d2cde46"
+
+[[package]]
+name = "hickory-proto"
+version = "0.24.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "92652067c9ce6f66ce53cc38d1169daa36e6e7eb7dd3b63b5103bd9d97117248"
+dependencies = [
+ "async-trait",
+ "cfg-if",
+ "data-encoding",
+ "enum-as-inner",
+ "futures-channel",
+ "futures-io",
+ "futures-util",
+ "idna",
+ "ipnet",
+ "once_cell",
+ "rand 0.8.5",
+ "thiserror 1.0.69",
+ "tinyvec",
+ "tokio",
+ "tracing",
+ "url",
+]
+
+[[package]]
+name = "hickory-resolver"
+version = "0.24.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cbb117a1ca520e111743ab2f6688eddee69db4e0ea242545a604dce8a66fd22e"
+dependencies = [
+ "cfg-if",
+ "futures-util",
+ "hickory-proto",
+ "ipconfig",
+ "lru-cache",
+ "once_cell",
+ "parking_lot 0.12.4",
+ "rand 0.8.5",
+ "resolv-conf",
+ "smallvec",
+ "thiserror 1.0.69",
+ "tokio",
+ "tracing",
+]
 
 [[package]]
 name = "hkdf"
@@ -5627,7 +5731,7 @@ name = "iota-open-rpc-macros"
 version = "0.12.0-rc"
 source = "git+https://github.com/impierce/iota?branch=temp/fix#90084d420f010226775f389547d03fe3d2df81a9"
 dependencies = [
- "derive-syn-parse",
+ "derive-syn-parse 0.1.5",
  "itertools 0.13.0",
  "proc-macro2",
  "quote",
@@ -6002,6 +6106,18 @@ dependencies = [
  "stronghold_engine",
  "thiserror 1.0.69",
  "zeroize",
+]
+
+[[package]]
+name = "ipconfig"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b58db92f96b720de98181bbbe63c831e87005ab460c1bf306eb2622b4707997f"
+dependencies = [
+ "socket2",
+ "widestring",
+ "windows-sys 0.48.0",
+ "winreg",
 ]
 
 [[package]]
@@ -6882,7 +6998,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "07033963ba89ebaf1584d767badaa2e8fcec21aedea6b8c0346d487d49c28667"
 dependencies = [
  "cfg-if",
- "windows-targets 0.48.5",
+ "windows-targets 0.53.2",
 ]
 
 [[package]]
@@ -7064,6 +7180,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "lru-cache"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "31e24f1ad8321ca0e8a1e0ac13f23cb668e6f5466c2c57319f6a5cf1cc8e3b1c"
+dependencies = [
+ "linked-hash-map",
+]
+
+[[package]]
 name = "lru-slab"
 version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7089,6 +7214,54 @@ source = "git+https://github.com/impierce/digital-credential-data-models?rev=9f1
 dependencies = [
  "convert_case 0.6.0",
  "proc-macro2",
+ "quote",
+ "syn 2.0.104",
+]
+
+[[package]]
+name = "macro_magic"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cc33f9f0351468d26fbc53d9ce00a096c8522ecb42f19b50f34f2c422f76d21d"
+dependencies = [
+ "macro_magic_core",
+ "macro_magic_macros",
+ "quote",
+ "syn 2.0.104",
+]
+
+[[package]]
+name = "macro_magic_core"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1687dc887e42f352865a393acae7cf79d98fab6351cde1f58e9e057da89bf150"
+dependencies = [
+ "const-random",
+ "derive-syn-parse 0.2.0",
+ "macro_magic_core_macros",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.104",
+]
+
+[[package]]
+name = "macro_magic_core_macros"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b02abfe41815b5bd98dbd4260173db2c116dda171dc0fe7838cb206333b83308"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.104",
+]
+
+[[package]]
+name = "macro_magic_macros"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "73ea28ee64b88876bf45277ed9a5817c1817df061a74f2b988971a12570e5869"
+dependencies = [
+ "macro_magic_core",
  "quote",
  "syn 2.0.104",
 ]
@@ -7191,6 +7364,81 @@ dependencies = [
  "libc",
  "wasi 0.11.1+wasi-snapshot-preview1",
  "windows-sys 0.59.0",
+]
+
+[[package]]
+name = "mongo-es"
+version = "0.1.0"
+source = "git+https://github.com/impierce/mongo-es?rev=f75b93e#f75b93e7032e9059b8ff5ecf8d4d8cf6cfeb896b"
+dependencies = [
+ "async-trait",
+ "cqrs-es",
+ "futures",
+ "mongodb",
+ "serde",
+ "serde_json",
+ "tokio",
+]
+
+[[package]]
+name = "mongodb"
+version = "3.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d0f8c69f13acf07eae386a2974f48ffd9187ea2aba8defbea9aa34e7e272c5f3"
+dependencies = [
+ "async-trait",
+ "base64 0.13.1",
+ "bitflags 1.3.2",
+ "bson",
+ "chrono",
+ "derive-where",
+ "derive_more 0.99.20",
+ "futures-core",
+ "futures-executor",
+ "futures-io",
+ "futures-util",
+ "hex",
+ "hickory-proto",
+ "hickory-resolver",
+ "hmac 0.12.1",
+ "macro_magic",
+ "md-5",
+ "mongodb-internal-macros",
+ "once_cell",
+ "pbkdf2 0.11.0",
+ "percent-encoding",
+ "rand 0.8.5",
+ "rustc_version_runtime",
+ "rustls 0.21.12",
+ "rustls-pemfile 1.0.4",
+ "serde",
+ "serde_bytes",
+ "serde_with 3.13.0",
+ "sha1",
+ "sha2 0.10.9",
+ "socket2",
+ "stringprep",
+ "strsim 0.11.1",
+ "take_mut",
+ "thiserror 1.0.69",
+ "tokio",
+ "tokio-rustls 0.24.1",
+ "tokio-util",
+ "typed-builder",
+ "uuid",
+ "webpki-roots 0.25.4",
+]
+
+[[package]]
+name = "mongodb-internal-macros"
+version = "3.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b9202de265a3a8bbb43f9fe56db27c93137d4f9fb04c093f47e9c7de0c61ac7d"
+dependencies = [
+ "macro_magic",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.104",
 ]
 
 [[package]]
@@ -9593,6 +9841,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "resolv-conf"
+version = "0.7.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "95325155c684b1c89f7765e30bc1c42e4a6da51ca513615660cb8a62ef9a88e3"
+
+[[package]]
 name = "retry-policies"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -9861,6 +10115,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "rustc_version_runtime"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2dd18cd2bae1820af0b6ad5e54f4a51d0f3fcc53b05f845675074efcc7af071d"
+dependencies = [
+ "rustc_version",
+ "semver",
+]
+
+[[package]]
 name = "rusticata-macros"
 version = "4.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -9879,7 +10143,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys 0.4.15",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -11684,6 +11948,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "take_mut"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f764005d11ee5f36500a149ace24e00e3da98b0158b3e2d53a7495660d3f4d60"
+
+[[package]]
 name = "tap"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -12392,6 +12662,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "typed-builder"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "89851716b67b937e393b3daa8423e67ddfc4bbbf1654bcf05488e95e0828db0c"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 1.0.109",
+]
+
+[[package]]
 name = "typed-store-error"
 version = "0.12.0-rc"
 source = "git+https://github.com/impierce/iota?branch=temp/fix#90084d420f010226775f389547d03fe3d2df81a9"
@@ -12923,6 +13204,12 @@ dependencies = [
  "redox_syscall 0.5.13",
  "wasite",
 ]
+
+[[package]]
+name = "widestring"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dd7cf3379ca1aac9eea11fba24fd7e315d621f8dfe35c8d7d2be8b793726e07d"
 
 [[package]]
 name = "winapi"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7368,12 +7368,14 @@ dependencies = [
 
 [[package]]
 name = "mongo-es"
-version = "0.1.0"
-source = "git+https://github.com/impierce/mongo-es?rev=f75b93e#f75b93e7032e9059b8ff5ecf8d4d8cf6cfeb896b"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "79e2cc82dfc3e6742f467c41b83cadfcf8f26049c92e46093d43223815733baf"
 dependencies = [
  "async-trait",
  "cqrs-es",
  "futures",
+ "log",
  "mongodb",
  "serde",
  "serde_json",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -386,7 +386,6 @@ dependencies = [
  "async-trait",
  "cqrs-es",
  "mongo-es",
- "mongodb",
  "postgres-es",
  "serde_json",
  "sqlx",

--- a/agent_application/src/main.rs
+++ b/agent_application/src/main.rs
@@ -12,6 +12,7 @@ use agent_secret_manager::{service::Service as _, subject::Subject};
 use agent_shared::config::{config, EventStoreType};
 use agent_store::{
     in_memory::{self, InMemory},
+    mongodb::{self, MongoDB},
     postgres::{self, Postgres},
     EventPublisher,
 };
@@ -45,6 +46,12 @@ async fn main() -> io::Result<()> {
             postgres::issuance_state(issuance_services, issuance_event_publishers).await,
             agent_store::holder_state::<Postgres>(holder_services, holder_event_publishers).await,
             agent_store::verification_state::<Postgres>(verification_services, verification_event_publishers).await,
+        ),
+        EventStoreType::MongoDb => (
+            agent_store::identity_state::<MongoDB>(identity_services, identity_event_publishers).await,
+            mongodb::issuance_state(issuance_services, issuance_event_publishers).await,
+            agent_store::holder_state::<MongoDB>(holder_services, holder_event_publishers).await,
+            agent_store::verification_state::<MongoDB>(verification_services, verification_event_publishers).await,
         ),
         EventStoreType::InMemory => (
             agent_store::identity_state::<InMemory>(identity_services, identity_event_publishers).await,

--- a/agent_shared/src/config/mod.rs
+++ b/agent_shared/src/config/mod.rs
@@ -436,6 +436,7 @@ pub struct EventStoreConfig {
 pub enum EventStoreType {
     InMemory,
     #[default]
+    #[serde(rename = "mongodb")]
     MongoDb,
     // Postgres(EventStorePostgresConfig), // <== TODO: "config-rs" panics with "unreachable code", other solution?
     Postgres,

--- a/agent_shared/src/config/mod.rs
+++ b/agent_shared/src/config/mod.rs
@@ -435,6 +435,7 @@ pub struct EventStoreConfig {
 #[serde(rename_all = "snake_case")]
 pub enum EventStoreType {
     InMemory,
+    MongoDb,
     // Postgres(EventStorePostgresConfig), // <== TODO: "config-rs" panics with "unreachable code", other solution?
     #[default]
     Postgres,

--- a/agent_shared/src/config/mod.rs
+++ b/agent_shared/src/config/mod.rs
@@ -435,9 +435,9 @@ pub struct EventStoreConfig {
 #[serde(rename_all = "snake_case")]
 pub enum EventStoreType {
     InMemory,
+    #[default]
     MongoDb,
     // Postgres(EventStorePostgresConfig), // <== TODO: "config-rs" panics with "unreachable code", other solution?
-    #[default]
     Postgres,
 }
 

--- a/agent_store/Cargo.toml
+++ b/agent_store/Cargo.toml
@@ -13,7 +13,6 @@ agent_verification = { path = "../agent_verification" }
 
 async-trait.workspace = true
 cqrs-es.workspace = true
-mongodb = "3.2"
 mongo-es = "0.3"
 postgres-es = "0.4.12"
 serde_json.workspace = true

--- a/agent_store/Cargo.toml
+++ b/agent_store/Cargo.toml
@@ -13,6 +13,8 @@ agent_verification = { path = "../agent_verification" }
 
 async-trait.workspace = true
 cqrs-es.workspace = true
+mongodb = "3.2"
+mongo-es = { git = "https://github.com/impierce/mongo-es", rev = "f75b93e" }
 postgres-es = "0.4.12"
 serde_json.workspace = true
 sqlx = { version = "0.8", features = [

--- a/agent_store/Cargo.toml
+++ b/agent_store/Cargo.toml
@@ -14,7 +14,7 @@ agent_verification = { path = "../agent_verification" }
 async-trait.workspace = true
 cqrs-es.workspace = true
 mongodb = "3.2"
-mongo-es = { git = "https://github.com/impierce/mongo-es", rev = "f75b93e" }
+mongo-es = "0.3"
 postgres-es = "0.4.12"
 serde_json.workspace = true
 sqlx = { version = "0.8", features = [

--- a/agent_store/src/lib.rs
+++ b/agent_store/src/lib.rs
@@ -33,6 +33,7 @@ use std::collections::HashMap;
 use std::sync::Arc;
 
 pub mod in_memory;
+pub mod mongodb;
 pub mod postgres;
 
 /// A generic command handler for a specific aggregate.

--- a/agent_store/src/mongodb.rs
+++ b/agent_store/src/mongodb.rs
@@ -10,15 +10,17 @@ use agent_shared::{
 };
 use cqrs_es::{persist::PersistedEventStore, CqrsFramework};
 use cqrs_es::{persist::ViewRepository, Aggregate, Query, View};
-use mongo_es::{Client, MongoEventRepository, MongoViewRepository};
+use mongo_es::{default_mongo_client, Client, MongoEventRepository, MongoViewRepository};
 use std::sync::Arc;
 
 impl<A> AggregateHandler<A, PersistedEventStore<MongoEventRepository, A>>
 where
     A: Aggregate,
 {
-    fn new(client: Client, services: A::Services) -> Self {
-        let repo = MongoEventRepository::new(client);
+    async fn new(client: Client, services: A::Services) -> Self {
+        let repo = MongoEventRepository::new(client)
+            .await
+            .expect("Failed to create MongoEventRepository");
         let store = PersistedEventStore::new_event_store(repo);
         Self {
             cqrs: CqrsFramework::new(store, vec![], services),
@@ -44,20 +46,18 @@ impl CqrsComponentBuilder for MongoDB {
             "Missing config parameter `event_store.connection_string` or `UNICORE__EVENT_STORE__CONNECTION_STRING`",
         );
 
-        let client = mongodb::Client::with_uri_str(&connection_string)
-            .await
-            .expect("Failed to connect to MongoDB");
+        let client = default_mongo_client(&connection_string).await;
 
         let all_aggregates_name = format!("all_{}s", A::aggregate_type());
 
-        // Initialize the mongo repositories.
+        // Initialize the MongoDB repositories.
         let aggregate: Arc<MongoViewRepository<V, A>> =
             Arc::new(MongoViewRepository::new(&A::aggregate_type(), client.clone()));
         let all_aggregates: Arc<MongoViewRepository<AV, A>> =
             Arc::new(MongoViewRepository::new(&all_aggregates_name, client.clone()));
 
         (
-            Arc::new(AggregateHandler::new(client, services).with_parameters(
+            Arc::new(AggregateHandler::new(client, services).await.with_parameters(
                 aggregate.clone(),
                 all_aggregates.clone(),
                 event_publishers,
@@ -77,11 +77,9 @@ pub async fn issuance_state(
     let connection_string = config().event_store.connection_string.clone().expect(
         "Missing config parameter `event_store.connection_string` or `UNICORE__EVENT_STORE__CONNECTION_STRING`",
     );
-    let client = mongodb::Client::with_uri_str(&connection_string)
-        .await
-        .expect("Failed to connect to MongoDB");
+    let client = default_mongo_client(&connection_string).await;
 
-    // Initialize the mongo repositories.
+    // Initialize the MongoDB repositories.
     let server_config = Arc::new(MongoViewRepository::new("server_config", client.clone()));
     let pre_authorized_code = Arc::new(MongoViewRepository::new("pre_authorized_code", client.clone()));
     let access_token = Arc::new(MongoViewRepository::new("access_token", client.clone()));
@@ -111,6 +109,7 @@ pub async fn issuance_state(
             server_config: Arc::new(
                 server_config_event_publishers.into_iter().fold(
                     AggregateHandler::new(client.clone(), ())
+                        .await
                         .append_query(SimpleLoggingQuery {})
                         .append_query(generic_query(server_config.clone())),
                     |aggregate_handler, event_publisher| aggregate_handler.append_event_publisher(event_publisher),
@@ -119,6 +118,7 @@ pub async fn issuance_state(
             credential: Arc::new(
                 credential_event_publishers.into_iter().fold(
                     AggregateHandler::new(client.clone(), issuance_services.clone())
+                        .await
                         .append_query(SimpleLoggingQuery {})
                         .append_query(generic_query(credential.clone()))
                         .append_query(all_credentials_query),
@@ -128,6 +128,7 @@ pub async fn issuance_state(
             offer: Arc::new(
                 offer_event_publishers.into_iter().fold(
                     AggregateHandler::new(client.clone(), issuance_services.clone())
+                        .await
                         .append_query(SimpleLoggingQuery {})
                         .append_query(generic_query(offer.clone()))
                         .append_query(all_offers_query)

--- a/agent_store/src/mongodb.rs
+++ b/agent_store/src/mongodb.rs
@@ -10,8 +10,7 @@ use agent_shared::{
 };
 use cqrs_es::{persist::PersistedEventStore, CqrsFramework};
 use cqrs_es::{persist::ViewRepository, Aggregate, Query, View};
-use mongo_es::{MongoEventRepository, MongoViewRepository};
-use mongodb::Client;
+use mongo_es::{Client, MongoEventRepository, MongoViewRepository};
 use std::sync::Arc;
 
 impl<A> AggregateHandler<A, PersistedEventStore<MongoEventRepository, A>>

--- a/agent_store/src/mongodb.rs
+++ b/agent_store/src/mongodb.rs
@@ -1,0 +1,152 @@
+use crate::{partition_event_publishers, AggregateHandler, CqrsComponentBuilder, EventPublisher, Partitions};
+use agent_issuance::{
+    offer::queries::{access_token::AccessTokenQuery, pre_authorized_code::PreAuthorizedCodeQuery},
+    services::IssuanceServices,
+    state::IssuanceState,
+    SimpleLoggingQuery,
+};
+use agent_shared::{
+    application_state::Command, config::config, custom_queries::ListAllQuery, generic_query::generic_query,
+};
+use cqrs_es::{persist::PersistedEventStore, CqrsFramework};
+use cqrs_es::{persist::ViewRepository, Aggregate, Query, View};
+use mongo_es::{MongoEventRepository, MongoViewRepository};
+use mongodb::Client;
+use std::sync::Arc;
+
+impl<A> AggregateHandler<A, PersistedEventStore<MongoEventRepository, A>>
+where
+    A: Aggregate,
+{
+    fn new(client: Client, services: A::Services) -> Self {
+        let repo = MongoEventRepository::new(client);
+        let store = PersistedEventStore::new_event_store(repo);
+        Self {
+            cqrs: CqrsFramework::new(store, vec![], services),
+        }
+    }
+}
+
+pub struct MongoDB;
+
+impl CqrsComponentBuilder for MongoDB {
+    async fn commands_and_queries<V: View<A> + 'static, A: Aggregate + 'static, AV: View<A> + 'static>(
+        services: A::Services,
+        event_publishers: Vec<Box<dyn Query<A>>>,
+    ) -> (
+        Arc<dyn Command<A> + Send + Sync>,
+        Arc<dyn ViewRepository<V, A>>,
+        Arc<dyn ViewRepository<AV, A>>,
+    )
+    where
+        <A as Aggregate>::Command: Send + Sync,
+    {
+        let connection_string = config().event_store.connection_string.clone().expect(
+            "Missing config parameter `event_store.connection_string` or `UNICORE__EVENT_STORE__CONNECTION_STRING`",
+        );
+
+        let client = mongodb::Client::with_uri_str(&connection_string)
+            .await
+            .expect("Failed to connect to MongoDB");
+
+        let all_aggregates_name = format!("all_{}s", A::aggregate_type());
+
+        // Initialize the postgres repositories.
+        let aggregate: Arc<MongoViewRepository<V, A>> =
+            Arc::new(MongoViewRepository::new(&A::aggregate_type(), client.clone()));
+        let all_aggregates: Arc<MongoViewRepository<AV, A>> =
+            Arc::new(MongoViewRepository::new(&all_aggregates_name, client.clone()));
+
+        (
+            Arc::new(AggregateHandler::new(client, services).with_parameters(
+                aggregate.clone(),
+                all_aggregates.clone(),
+                event_publishers,
+                &all_aggregates_name,
+            )),
+            aggregate,
+            all_aggregates,
+        )
+    }
+}
+
+// TODO: make a generic function for this and move it to `lib.rs`.
+pub async fn issuance_state(
+    issuance_services: Arc<IssuanceServices>,
+    event_publishers: Vec<Box<dyn EventPublisher>>,
+) -> IssuanceState {
+    let connection_string = config().event_store.connection_string.clone().expect(
+        "Missing config parameter `event_store.connection_string` or `UNICORE__EVENT_STORE__CONNECTION_STRING`",
+    );
+    let client = mongodb::Client::with_uri_str(&connection_string)
+        .await
+        .expect("Failed to connect to MongoDB");
+
+    // Initialize the postgres repositories.
+    let server_config = Arc::new(MongoViewRepository::new("server_config", client.clone()));
+    let pre_authorized_code = Arc::new(MongoViewRepository::new("pre_authorized_code", client.clone()));
+    let access_token = Arc::new(MongoViewRepository::new("access_token", client.clone()));
+    let credential = Arc::new(MongoViewRepository::new("credential", client.clone()));
+    let all_credentials = Arc::new(MongoViewRepository::new("all_credentials", client.clone()));
+    let offer = Arc::new(MongoViewRepository::new("offer", client.clone()));
+    let all_offers = Arc::new(MongoViewRepository::new("all_offers", client.clone()));
+
+    // Create custom-queries for the offer aggregate.
+    let pre_authorized_code_query = PreAuthorizedCodeQuery::new(pre_authorized_code.clone());
+    let access_token_query = AccessTokenQuery::new(access_token.clone());
+
+    // Partition the event_publishers into the different aggregates.
+    let Partitions {
+        server_config_event_publishers,
+        credential_event_publishers,
+        offer_event_publishers,
+        ..
+    } = partition_event_publishers(event_publishers);
+
+    // Create custom-queries for the offer aggregate.
+    let all_credentials_query = ListAllQuery::new(all_credentials.clone(), "all_credentials");
+    let all_offers_query = ListAllQuery::new(all_offers.clone(), "all_offers");
+
+    IssuanceState {
+        command: agent_issuance::state::CommandHandlers {
+            server_config: Arc::new(
+                server_config_event_publishers.into_iter().fold(
+                    AggregateHandler::new(client.clone(), ())
+                        .append_query(SimpleLoggingQuery {})
+                        .append_query(generic_query(server_config.clone())),
+                    |aggregate_handler, event_publisher| aggregate_handler.append_event_publisher(event_publisher),
+                ),
+            ),
+            credential: Arc::new(
+                credential_event_publishers.into_iter().fold(
+                    AggregateHandler::new(client.clone(), issuance_services.clone())
+                        .append_query(SimpleLoggingQuery {})
+                        .append_query(generic_query(credential.clone()))
+                        .append_query(all_credentials_query),
+                    |aggregate_handler, event_publisher| aggregate_handler.append_event_publisher(event_publisher),
+                ),
+            ),
+            offer: Arc::new(
+                offer_event_publishers.into_iter().fold(
+                    AggregateHandler::new(client.clone(), issuance_services.clone())
+                        .append_query(SimpleLoggingQuery {})
+                        .append_query(generic_query(offer.clone()))
+                        .append_query(all_offers_query)
+                        .append_query(pre_authorized_code_query)
+                        .append_query(access_token_query),
+                    |aggregate_handler, event_publisher| aggregate_handler.append_event_publisher(event_publisher),
+                ),
+            ),
+        },
+        query: agent_issuance::state::ViewRepositories {
+            server_config,
+            pre_authorized_code,
+            access_token,
+            credential,
+            all_credentials,
+            offer,
+            all_offers,
+        },
+        signer: issuance_services.issuer.clone(),
+    }
+}

--- a/agent_store/src/mongodb.rs
+++ b/agent_store/src/mongodb.rs
@@ -51,7 +51,7 @@ impl CqrsComponentBuilder for MongoDB {
 
         let all_aggregates_name = format!("all_{}s", A::aggregate_type());
 
-        // Initialize the postgres repositories.
+        // Initialize the mongo repositories.
         let aggregate: Arc<MongoViewRepository<V, A>> =
             Arc::new(MongoViewRepository::new(&A::aggregate_type(), client.clone()));
         let all_aggregates: Arc<MongoViewRepository<AV, A>> =
@@ -82,7 +82,7 @@ pub async fn issuance_state(
         .await
         .expect("Failed to connect to MongoDB");
 
-    // Initialize the postgres repositories.
+    // Initialize the mongo repositories.
     let server_config = Arc::new(MongoViewRepository::new("server_config", client.clone()));
     let pre_authorized_code = Arc::new(MongoViewRepository::new("pre_authorized_code", client.clone()));
     let access_token = Arc::new(MongoViewRepository::new("access_token", client.clone()));

--- a/docs/configuration/CONFIGURATION.md
+++ b/docs/configuration/CONFIGURATION.md
@@ -249,7 +249,8 @@ The event store is used to persist events and serves as UniCore's persistence la
 
 ##### `type`
 
-- `postgres` _(default)_
+- `mongodb` _(default)_
+- `postgres`
 - `in_memory`
 
 ##### `connection_string`


### PR DESCRIPTION
# Description of change
This pull request introduces support for MongoDB as a persistent event store backend, providing a concrete alternative to the existing `InMemory` and `Postgres` implementations.

This is achieved by leveraging the `CqrsComponentBuilder` trait that was recently introduced in https://github.com/impierce/ssi-agent/pull/169 to abstract the storage layer.

* **MongoDB Backend**: A new `mongodb.rs` module has been added to `agent_store`, which implements the `CqrsComponentBuilder` trait for a `MongoDB` type.
* **Configuration**: The `EventStoreType` enum in `agent_shared` has been updated to include `MongoDb`, making it a configurable option (e.g.: `UNICORE__EVENT_STORE__TYPE=mongo_db`)
* **Application Wiring**: The `main.rs` file now includes a match arm to initialize all application states using the new MongoDB backend when configured.
* **Dependencies**: The `mongodb` and `mongo-es` crates have been added to `Cargo.toml` to support this new functionality

**Blocked by**
- https://github.com/impierce/mongo-es/tree/alpha
- #169

## Links to any relevant issues
n/a

## How the change has been tested
n/a

## Definition of Done checklist
Add an `x` to the boxes that are relevant to your changes.

- [x] I have followed the contribution guidelines for this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] I have successfully tested this change in a docker environment 
