### PR TITLE
fix: pin Debian version of `rust` base image

### DIFF
--- a/agent_application/docker/Dockerfile
+++ b/agent_application/docker/Dockerfile
@@ -1,6 +1,6 @@
 # https://github.com/LukeMathWalker/cargo-chef
 
-FROM rust:1 AS chef
+FROM rust:1-bookworm AS chef
 RUN cargo install cargo-chef
 WORKDIR /app
 


### PR DESCRIPTION
# Description of change

The `rust` base image uses a different `glibc` version than the version from the "runtime". This results in a broken image. It is fixed by explicitly using the same Debian version in both stages.

## Links to any relevant issues
n/a

## How the change has been tested
n/a

## Definition of Done checklist
Add an `x` to the boxes that are relevant to your changes.

- [ ] I have followed the contribution guidelines for this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] I have successfully tested this change in a docker environment 
