### PR TITLE
fix: initialize database clients

### DIFF
--- a/agent_api_rest/src/verification/authorization_requests.rs
+++ b/agent_api_rest/src/verification/authorization_requests.rs
@@ -193,7 +193,7 @@ pub mod tests {
     #[tracing_test::traced_test]
     #[tokio::test]
     async fn test_authorization_requests_endpoint() {
-        let verification_state = verification_state::<InMemory>(Service::default(), Default::default()).await;
+        let verification_state = verification_state(&InMemory, Service::default(), Default::default()).await;
         let mut app = router(verification_state);
 
         let result = authorization_requests(&mut app).await;

--- a/agent_api_rest/src/verification/relying_party/redirect.rs
+++ b/agent_api_rest/src/verification/relying_party/redirect.rs
@@ -157,7 +157,7 @@ pub mod tests {
 
         let event_publishers = vec![Box::new(EventPublisherHttp::load().unwrap()) as Box<dyn EventPublisher>];
 
-        let verification_state = verification_state::<InMemory>(Service::default(), event_publishers).await;
+        let verification_state = verification_state(&InMemory, Service::default(), event_publishers).await;
 
         let mut app = router(verification_state);
 

--- a/agent_api_rest/src/verification/relying_party/request.rs
+++ b/agent_api_rest/src/verification/relying_party/request.rs
@@ -73,7 +73,7 @@ pub mod tests {
     #[tokio::test]
     #[tracing_test::traced_test]
     async fn test_request_endpoint() {
-        let verification_state = verification_state::<InMemory>(Service::default(), Default::default()).await;
+        let verification_state = verification_state(&InMemory, Service::default(), Default::default()).await;
 
         let mut app = router(verification_state);
 

--- a/agent_application/src/main.rs
+++ b/agent_application/src/main.rs
@@ -41,24 +41,48 @@ async fn main() -> io::Result<()> {
         vec![Box::new(EventPublisherHttp::load().unwrap())];
 
     let (identity_state, issuance_state, holder_state, verification_state) = match config().event_store.type_ {
-        EventStoreType::Postgres => (
-            agent_store::identity_state::<Postgres>(identity_services, identity_event_publishers).await,
-            postgres::issuance_state(issuance_services, issuance_event_publishers).await,
-            agent_store::holder_state::<Postgres>(holder_services, holder_event_publishers).await,
-            agent_store::verification_state::<Postgres>(verification_services, verification_event_publishers).await,
-        ),
-        EventStoreType::MongoDb => (
-            agent_store::identity_state::<MongoDB>(identity_services, identity_event_publishers).await,
-            mongodb::issuance_state(issuance_services, issuance_event_publishers).await,
-            agent_store::holder_state::<MongoDB>(holder_services, holder_event_publishers).await,
-            agent_store::verification_state::<MongoDB>(verification_services, verification_event_publishers).await,
-        ),
-        EventStoreType::InMemory => (
-            agent_store::identity_state::<InMemory>(identity_services, identity_event_publishers).await,
-            in_memory::issuance_state(issuance_services, issuance_event_publishers).await,
-            agent_store::holder_state::<InMemory>(holder_services, holder_event_publishers).await,
-            agent_store::verification_state::<InMemory>(verification_services, verification_event_publishers).await,
-        ),
+        EventStoreType::Postgres => {
+            let builder = Postgres;
+            (
+                agent_store::identity_state::<Postgres>(&builder, identity_services, identity_event_publishers).await,
+                postgres::issuance_state(issuance_services, issuance_event_publishers).await,
+                agent_store::holder_state::<Postgres>(&builder, holder_services, holder_event_publishers).await,
+                agent_store::verification_state::<Postgres>(
+                    &builder,
+                    verification_services,
+                    verification_event_publishers,
+                )
+                .await,
+            )
+        }
+        EventStoreType::MongoDb => {
+            let builder = MongoDB::new().await;
+            (
+                agent_store::identity_state::<MongoDB>(&builder, identity_services, identity_event_publishers).await,
+                mongodb::issuance_state(builder.client.clone(), issuance_services, issuance_event_publishers).await,
+                agent_store::holder_state::<MongoDB>(&builder, holder_services, holder_event_publishers).await,
+                agent_store::verification_state::<MongoDB>(
+                    &builder,
+                    verification_services,
+                    verification_event_publishers,
+                )
+                .await,
+            )
+        }
+        EventStoreType::InMemory => {
+            let builder = InMemory;
+            (
+                agent_store::identity_state::<InMemory>(&builder, identity_services, identity_event_publishers).await,
+                in_memory::issuance_state(issuance_services, issuance_event_publishers).await,
+                agent_store::holder_state::<InMemory>(&builder, holder_services, holder_event_publishers).await,
+                agent_store::verification_state::<InMemory>(
+                    &builder,
+                    verification_services,
+                    verification_event_publishers,
+                )
+                .await,
+            )
+        }
     };
 
     info!("{:?}", config());

--- a/agent_application/src/main.rs
+++ b/agent_application/src/main.rs
@@ -42,40 +42,25 @@ async fn main() -> io::Result<()> {
 
     let (identity_state, issuance_state, holder_state, verification_state) = match config().event_store.type_ {
         EventStoreType::Postgres => (
-            agent_store::identity_state::<Postgres>(&Postgres, identity_services, identity_event_publishers).await,
+            agent_store::identity_state(&Postgres, identity_services, identity_event_publishers).await,
             postgres::issuance_state(issuance_services, issuance_event_publishers).await,
-            agent_store::holder_state::<Postgres>(&Postgres, holder_services, holder_event_publishers).await,
-            agent_store::verification_state::<Postgres>(
-                &Postgres,
-                verification_services,
-                verification_event_publishers,
-            )
-            .await,
+            agent_store::holder_state(&Postgres, holder_services, holder_event_publishers).await,
+            agent_store::verification_state(&Postgres, verification_services, verification_event_publishers).await,
         ),
         EventStoreType::MongoDb => {
             let builder = MongoDB::new().await;
             (
-                agent_store::identity_state::<MongoDB>(&builder, identity_services, identity_event_publishers).await,
+                agent_store::identity_state(&builder, identity_services, identity_event_publishers).await,
                 mongodb::issuance_state(builder.client.clone(), issuance_services, issuance_event_publishers).await,
-                agent_store::holder_state::<MongoDB>(&builder, holder_services, holder_event_publishers).await,
-                agent_store::verification_state::<MongoDB>(
-                    &builder,
-                    verification_services,
-                    verification_event_publishers,
-                )
-                .await,
+                agent_store::holder_state(&builder, holder_services, holder_event_publishers).await,
+                agent_store::verification_state(&builder, verification_services, verification_event_publishers).await,
             )
         }
         EventStoreType::InMemory => (
-            agent_store::identity_state::<InMemory>(&InMemory, identity_services, identity_event_publishers).await,
+            agent_store::identity_state(&InMemory, identity_services, identity_event_publishers).await,
             in_memory::issuance_state(issuance_services, issuance_event_publishers).await,
-            agent_store::holder_state::<InMemory>(&InMemory, holder_services, holder_event_publishers).await,
-            agent_store::verification_state::<InMemory>(
-                &InMemory,
-                verification_services,
-                verification_event_publishers,
-            )
-            .await,
+            agent_store::holder_state(&InMemory, holder_services, holder_event_publishers).await,
+            agent_store::verification_state(&InMemory, verification_services, verification_event_publishers).await,
         ),
     };
 

--- a/agent_application/src/main.rs
+++ b/agent_application/src/main.rs
@@ -41,20 +41,17 @@ async fn main() -> io::Result<()> {
         vec![Box::new(EventPublisherHttp::load().unwrap())];
 
     let (identity_state, issuance_state, holder_state, verification_state) = match config().event_store.type_ {
-        EventStoreType::Postgres => {
-            let builder = Postgres;
-            (
-                agent_store::identity_state::<Postgres>(&builder, identity_services, identity_event_publishers).await,
-                postgres::issuance_state(issuance_services, issuance_event_publishers).await,
-                agent_store::holder_state::<Postgres>(&builder, holder_services, holder_event_publishers).await,
-                agent_store::verification_state::<Postgres>(
-                    &builder,
-                    verification_services,
-                    verification_event_publishers,
-                )
-                .await,
+        EventStoreType::Postgres => (
+            agent_store::identity_state::<Postgres>(&Postgres, identity_services, identity_event_publishers).await,
+            postgres::issuance_state(issuance_services, issuance_event_publishers).await,
+            agent_store::holder_state::<Postgres>(&Postgres, holder_services, holder_event_publishers).await,
+            agent_store::verification_state::<Postgres>(
+                &Postgres,
+                verification_services,
+                verification_event_publishers,
             )
-        }
+            .await,
+        ),
         EventStoreType::MongoDb => {
             let builder = MongoDB::new().await;
             (
@@ -69,20 +66,17 @@ async fn main() -> io::Result<()> {
                 .await,
             )
         }
-        EventStoreType::InMemory => {
-            let builder = InMemory;
-            (
-                agent_store::identity_state::<InMemory>(&builder, identity_services, identity_event_publishers).await,
-                in_memory::issuance_state(issuance_services, issuance_event_publishers).await,
-                agent_store::holder_state::<InMemory>(&builder, holder_services, holder_event_publishers).await,
-                agent_store::verification_state::<InMemory>(
-                    &builder,
-                    verification_services,
-                    verification_event_publishers,
-                )
-                .await,
+        EventStoreType::InMemory => (
+            agent_store::identity_state::<InMemory>(&InMemory, identity_services, identity_event_publishers).await,
+            in_memory::issuance_state(issuance_services, issuance_event_publishers).await,
+            agent_store::holder_state::<InMemory>(&InMemory, holder_services, holder_event_publishers).await,
+            agent_store::verification_state::<InMemory>(
+                &InMemory,
+                verification_services,
+                verification_event_publishers,
             )
-        }
+            .await,
+        ),
     };
 
     info!("{:?}", config());

--- a/agent_application/src/main.rs
+++ b/agent_application/src/main.rs
@@ -41,12 +41,15 @@ async fn main() -> io::Result<()> {
         vec![Box::new(EventPublisherHttp::load().unwrap())];
 
     let (identity_state, issuance_state, holder_state, verification_state) = match config().event_store.type_ {
-        EventStoreType::Postgres => (
-            agent_store::identity_state(&Postgres, identity_services, identity_event_publishers).await,
-            postgres::issuance_state(issuance_services, issuance_event_publishers).await,
-            agent_store::holder_state(&Postgres, holder_services, holder_event_publishers).await,
-            agent_store::verification_state(&Postgres, verification_services, verification_event_publishers).await,
-        ),
+        EventStoreType::Postgres => {
+            let builder = Postgres::new().await;
+            (
+                agent_store::identity_state(&builder, identity_services, identity_event_publishers).await,
+                postgres::issuance_state(builder.pool.clone(), issuance_services, issuance_event_publishers).await,
+                agent_store::holder_state(&builder, holder_services, holder_event_publishers).await,
+                agent_store::verification_state(&builder, verification_services, verification_event_publishers).await,
+            )
+        }
         EventStoreType::MongoDb => {
             let builder = MongoDB::new().await;
             (

--- a/agent_store/src/in_memory.rs
+++ b/agent_store/src/in_memory.rs
@@ -79,6 +79,7 @@ pub struct InMemory;
 
 impl CqrsComponentBuilder for InMemory {
     async fn commands_and_queries<V: View<A> + 'static, A: Aggregate + 'static, AV: View<A> + 'static>(
+        &self,
         services: A::Services,
         event_publishers: Vec<Box<dyn Query<A>>>,
     ) -> (

--- a/agent_store/src/lib.rs
+++ b/agent_store/src/lib.rs
@@ -137,6 +137,7 @@ pub type CqrsComponents<A, V, AV> = (
 /// including the command handler and view repositories.
 pub trait CqrsComponentBuilder {
     fn commands_and_queries<V: View<A> + 'static, A: Aggregate + 'static, AV: View<A> + 'static>(
+        &self,
         identity_services: A::Services,
         event_publishers: Vec<Box<dyn Query<A>>>,
     ) -> impl std::future::Future<Output = CqrsComponents<A, V, AV>> + Send
@@ -145,6 +146,7 @@ pub trait CqrsComponentBuilder {
 }
 
 pub async fn identity_state<CCB: CqrsComponentBuilder>(
+    builder: &CCB,
     services: Arc<IdentityServices>,
     event_publishers: Vec<Box<dyn EventPublisher>>,
 ) -> IdentityState {
@@ -156,20 +158,21 @@ pub async fn identity_state<CCB: CqrsComponentBuilder>(
         ..
     } = partition_event_publishers(event_publishers);
 
-    let (connection_command_handler, connection, all_connections) = CCB::commands_and_queries::<
-        Connection,
-        Connection,
-        AllConnectionsView,
-    >(services.clone(), connection_event_publishers)
-    .await;
-    let (document_command_handler, document, all_documents) =
-        CCB::commands_and_queries::<Document, Document, AllDocumentsView>(services.clone(), document_event_publishers)
-            .await;
-    let (profile_command_handler, profile, _all_profiles) =
-        CCB::commands_and_queries::<Profile, Profile, Profile>(services.clone(), vec![]).await;
-    let (service_command_handler, service, all_services) =
-        CCB::commands_and_queries::<Service, Service, AllServicesView>(services.clone(), service_event_publishers)
-            .await;
+    let (connection_command_handler, connection, all_connections) = builder
+        .commands_and_queries::<Connection, Connection, AllConnectionsView>(
+            services.clone(),
+            connection_event_publishers,
+        )
+        .await;
+    let (document_command_handler, document, all_documents) = builder
+        .commands_and_queries::<Document, Document, AllDocumentsView>(services.clone(), document_event_publishers)
+        .await;
+    let (profile_command_handler, profile, _all_profiles) = builder
+        .commands_and_queries::<Profile, Profile, Profile>(services.clone(), vec![])
+        .await;
+    let (service_command_handler, service, all_services) = builder
+        .commands_and_queries::<Service, Service, AllServicesView>(services.clone(), service_event_publishers)
+        .await;
 
     IdentityState {
         command: agent_identity::state::CommandHandlers {
@@ -191,6 +194,7 @@ pub async fn identity_state<CCB: CqrsComponentBuilder>(
 }
 
 pub async fn verification_state<CCB: CqrsComponentBuilder>(
+    builder: &CCB,
     services: Arc<VerificationServices>,
     event_publishers: Vec<Box<dyn EventPublisher>>,
 ) -> VerificationState {
@@ -200,8 +204,8 @@ pub async fn verification_state<CCB: CqrsComponentBuilder>(
         ..
     } = partition_event_publishers(event_publishers);
 
-    let (authorization_request_command_handler, authorization_request, all_authorization_requests) =
-        CCB::commands_and_queries::<AuthorizationRequest, AuthorizationRequest, AllAuthorizationRequestsView>(
+    let (authorization_request_command_handler, authorization_request, all_authorization_requests) = builder
+        .commands_and_queries::<AuthorizationRequest, AuthorizationRequest, AllAuthorizationRequestsView>(
             services.clone(),
             authorization_request_event_publishers,
         )
@@ -219,6 +223,7 @@ pub async fn verification_state<CCB: CqrsComponentBuilder>(
 }
 
 pub async fn holder_state<CCB: CqrsComponentBuilder>(
+    builder: &CCB,
     services: Arc<HolderServices>,
     event_publishers: Vec<Box<dyn EventPublisher>>,
 ) -> HolderState {
@@ -230,22 +235,22 @@ pub async fn holder_state<CCB: CqrsComponentBuilder>(
         ..
     } = partition_event_publishers(event_publishers);
 
-    let (holder_credential_command_handler, holder_credential, all_holder_credential) =
-        CCB::commands_and_queries::<HolderCredential, HolderCredential, AllHolderCredentialsView>(
+    let (holder_credential_command_handler, holder_credential, all_holder_credential) = builder
+        .commands_and_queries::<HolderCredential, HolderCredential, AllHolderCredentialsView>(
             services.clone(),
             holder_credential_publisher,
         )
         .await;
 
-    let (presentation_command_handler, presentation, all_presentations) =
-        CCB::commands_and_queries::<Presentation, Presentation, AllPresentationsView>(
+    let (presentation_command_handler, presentation, all_presentations) = builder
+        .commands_and_queries::<Presentation, Presentation, AllPresentationsView>(
             services.clone(),
             presentation_event_publishers,
         )
         .await;
 
-    let (received_offer_command_handler, received_offer, all_received_offers) =
-        CCB::commands_and_queries::<ReceivedOffer, ReceivedOffer, AllReceivedOffersView>(
+    let (received_offer_command_handler, received_offer, all_received_offers) = builder
+        .commands_and_queries::<ReceivedOffer, ReceivedOffer, AllReceivedOffersView>(
             services.clone(),
             received_offer_event_publishers,
         )

--- a/agent_store/src/mongodb.rs
+++ b/agent_store/src/mongodb.rs
@@ -28,10 +28,24 @@ where
     }
 }
 
-pub struct MongoDB;
+#[derive(Clone)]
+pub struct MongoDB {
+    pub client: Client,
+}
+
+impl MongoDB {
+    pub async fn new() -> Self {
+        let connection_string = config().event_store.connection_string.clone().expect(
+            "Missing config parameter `event_store.connection_string` or `UNICORE__EVENT_STORE__CONNECTION_STRING`",
+        );
+        let client = default_mongo_client(&connection_string).await;
+        Self { client }
+    }
+}
 
 impl CqrsComponentBuilder for MongoDB {
     async fn commands_and_queries<V: View<A> + 'static, A: Aggregate + 'static, AV: View<A> + 'static>(
+        &self,
         services: A::Services,
         event_publishers: Vec<Box<dyn Query<A>>>,
     ) -> (
@@ -42,27 +56,25 @@ impl CqrsComponentBuilder for MongoDB {
     where
         <A as Aggregate>::Command: Send + Sync,
     {
-        let connection_string = config().event_store.connection_string.clone().expect(
-            "Missing config parameter `event_store.connection_string` or `UNICORE__EVENT_STORE__CONNECTION_STRING`",
-        );
-
-        let client = default_mongo_client(&connection_string).await;
-
         let all_aggregates_name = format!("all_{}s", A::aggregate_type());
 
         // Initialize the MongoDB repositories.
         let aggregate: Arc<MongoViewRepository<V, A>> =
-            Arc::new(MongoViewRepository::new(&A::aggregate_type(), client.clone()));
+            Arc::new(MongoViewRepository::new(&A::aggregate_type(), self.client.clone()));
         let all_aggregates: Arc<MongoViewRepository<AV, A>> =
-            Arc::new(MongoViewRepository::new(&all_aggregates_name, client.clone()));
+            Arc::new(MongoViewRepository::new(&all_aggregates_name, self.client.clone()));
 
         (
-            Arc::new(AggregateHandler::new(client, services).await.with_parameters(
-                aggregate.clone(),
-                all_aggregates.clone(),
-                event_publishers,
-                &all_aggregates_name,
-            )),
+            Arc::new(
+                AggregateHandler::new(self.client.clone(), services)
+                    .await
+                    .with_parameters(
+                        aggregate.clone(),
+                        all_aggregates.clone(),
+                        event_publishers,
+                        &all_aggregates_name,
+                    ),
+            ),
             aggregate,
             all_aggregates,
         )
@@ -71,14 +83,10 @@ impl CqrsComponentBuilder for MongoDB {
 
 // TODO: make a generic function for this and move it to `lib.rs`.
 pub async fn issuance_state(
+    client: Client,
     issuance_services: Arc<IssuanceServices>,
     event_publishers: Vec<Box<dyn EventPublisher>>,
 ) -> IssuanceState {
-    let connection_string = config().event_store.connection_string.clone().expect(
-        "Missing config parameter `event_store.connection_string` or `UNICORE__EVENT_STORE__CONNECTION_STRING`",
-    );
-    let client = default_mongo_client(&connection_string).await;
-
     // Initialize the MongoDB repositories.
     let server_config = Arc::new(MongoViewRepository::new("server_config", client.clone()));
     let pre_authorized_code = Arc::new(MongoViewRepository::new("pre_authorized_code", client.clone()));

--- a/agent_store/src/mongodb.rs
+++ b/agent_store/src/mongodb.rs
@@ -40,6 +40,7 @@ impl MongoDB {
         let client = default_mongo_client(&connection_string).await;
         Self { client }
     }
+    // TODO: Run [Client::shutdown] during graceful shutdown to close all open connections.
 }
 
 impl CqrsComponentBuilder for MongoDB {

--- a/agent_store/src/mongodb.rs
+++ b/agent_store/src/mongodb.rs
@@ -28,7 +28,6 @@ where
     }
 }
 
-#[derive(Clone)]
 pub struct MongoDB {
     pub client: Client,
 }

--- a/agent_store/src/postgres.rs
+++ b/agent_store/src/postgres.rs
@@ -37,6 +37,7 @@ impl Postgres {
         let pool = default_postgress_pool(&connection_string).await;
         Self { pool }
     }
+    // TODO: Run [Pool::close] during graceful shutdown to close all open connections.
 }
 
 impl CqrsComponentBuilder for Postgres {

--- a/agent_store/src/postgres.rs
+++ b/agent_store/src/postgres.rs
@@ -25,7 +25,19 @@ where
     }
 }
 
-pub struct Postgres;
+pub struct Postgres {
+    pub pool: Pool<sqlx::Postgres>,
+}
+
+impl Postgres {
+    pub async fn new() -> Self {
+        let connection_string = config().event_store.connection_string.clone().expect(
+            "Missing config parameter `event_store.connection_string` or `UNICORE__EVENT_STORE__CONNECTION_STRING`",
+        );
+        let pool = default_postgress_pool(&connection_string).await;
+        Self { pool }
+    }
+}
 
 impl CqrsComponentBuilder for Postgres {
     async fn commands_and_queries<V: View<A> + 'static, A: Aggregate + 'static, AV: View<A> + 'static>(
@@ -40,21 +52,20 @@ impl CqrsComponentBuilder for Postgres {
     where
         <A as Aggregate>::Command: Send + Sync,
     {
-        let connection_string = config().event_store.connection_string.clone().expect(
-            "Missing config parameter `event_store.connection_string` or `UNICORE__EVENT_STORE__CONNECTION_STRING`",
-        );
-        let pool = default_postgress_pool(&connection_string).await;
-
         let all_aggregates_name = format!("all_{}s", A::aggregate_type());
 
         // Initialize the postgres repositories.
-        let aggregate: Arc<PostgresViewRepository<V, A>> =
-            Arc::new(PostgresViewRepository::<V, A>::new(&A::aggregate_type(), pool.clone()));
-        let all_aggregates: Arc<PostgresViewRepository<AV, A>> =
-            Arc::new(PostgresViewRepository::<AV, A>::new(&all_aggregates_name, pool.clone()));
+        let aggregate: Arc<PostgresViewRepository<V, A>> = Arc::new(PostgresViewRepository::<V, A>::new(
+            &A::aggregate_type(),
+            self.pool.clone(),
+        ));
+        let all_aggregates: Arc<PostgresViewRepository<AV, A>> = Arc::new(PostgresViewRepository::<AV, A>::new(
+            &all_aggregates_name,
+            self.pool.clone(),
+        ));
 
         (
-            Arc::new(AggregateHandler::new(pool, services).with_parameters(
+            Arc::new(AggregateHandler::new(self.pool.clone(), services).with_parameters(
                 aggregate.clone(),
                 all_aggregates.clone(),
                 event_publishers,
@@ -68,14 +79,10 @@ impl CqrsComponentBuilder for Postgres {
 
 // TODO: make a generic function for this and move it to `lib.rs`.
 pub async fn issuance_state(
+    pool: Pool<sqlx::Postgres>,
     issuance_services: Arc<IssuanceServices>,
     event_publishers: Vec<Box<dyn EventPublisher>>,
 ) -> IssuanceState {
-    let connection_string = config().event_store.connection_string.clone().expect(
-        "Missing config parameter `event_store.connection_string` or `UNICORE__EVENT_STORE__CONNECTION_STRING`",
-    );
-    let pool = default_postgress_pool(&connection_string).await;
-
     // Initialize the postgres repositories.
     let server_config = Arc::new(PostgresViewRepository::new("server_config", pool.clone()));
     let pre_authorized_code = Arc::new(PostgresViewRepository::new("pre_authorized_code", pool.clone()));

--- a/agent_store/src/postgres.rs
+++ b/agent_store/src/postgres.rs
@@ -29,6 +29,7 @@ pub struct Postgres;
 
 impl CqrsComponentBuilder for Postgres {
     async fn commands_and_queries<V: View<A> + 'static, A: Aggregate + 'static, AV: View<A> + 'static>(
+        &self,
         services: A::Services,
         event_publishers: Vec<Box<dyn Query<A>>>,
     ) -> (


### PR DESCRIPTION
# Description of change

Initialize the database clients (MongoDB, Postgres) just once and reuse them to reduce the amount of open connections.

## Links to any relevant issues
n/a

## How the change has been tested
n/a

## Definition of Done checklist
Add an `x` to the boxes that are relevant to your changes.

- [x] I have followed the contribution guidelines for this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have successfully tested this change in a docker environment 
