### PR TITLE
ci: add `rustfmt` and `clippy` components to `rust-toolchain`

### DIFF
--- a/.github/workflows/format-lint-test.yaml
+++ b/.github/workflows/format-lint-test.yaml
@@ -16,6 +16,8 @@ jobs:
       - uses: actions/checkout@v4
 
       - uses: dtolnay/rust-toolchain@stable
+        with:
+          components: rustfmt, clippy
 
       - name: Format
         run: cargo fmt --all -- --check


### PR DESCRIPTION
# Description of change
Fix for [failing workflow](https://github.com/impierce/identity-wallet/actions/runs/18012805350/job/51312033585) due to `rustfmt` (and `clippy`)) not being installed. By adding the `rustfmt` and `clippy` components (as described [here](https://github.com/marketplace/actions/rustup-toolchain-install#inputs)) the workflow runs as intended.

## Links to any relevant issues
- https://github.com/impierce/identity-wallet/pull/626
- https://github.com/impierce/identity-wallet/actions/runs/18012805350/job/51312033585

## How the change has been tested
Workflow corresponding to this PR succeeds

## Definition of Done checklist
Add an `x` to the boxes that are relevant to your changes.

- [x] I have followed the contribution guidelines for this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
