### PR TITLE
refactor: move token status list functionality to issuance domain

### DIFF
--- a/agent_api_rest/src/issuance/credential_issuer/token_status_list.rs
+++ b/agent_api_rest/src/issuance/credential_issuer/token_status_list.rs
@@ -51,6 +51,8 @@ pub mod tests {
     use crate::issuance::router;
     use tower::Service as _;
 
+    /// This test calls the token status list endpoint which in turn calls the function above.
+    /// The remainder of the test breaks down the Token Status List response in various steps and checks these steps one by one.
     #[tokio::test]
     pub async fn test_token_status_list() {
         let issuance_state = in_memory::issuance_state(Service::default(), Default::default()).await;

--- a/agent_api_rest/src/issuance/credential_issuer/token_status_list.rs
+++ b/agent_api_rest/src/issuance/credential_issuer/token_status_list.rs
@@ -1,5 +1,5 @@
 use agent_issuance::{
-    credential::application::token_status_list_service::create_gzip_status_list_jwt_token, state::IssuanceState,
+    credential::application::token_status_list_service::TokenStatusListService, state::IssuanceState,
 };
 use axum::{
     extract::{Path, State},
@@ -15,7 +15,9 @@ pub async fn token_status_list(
     State(state): State<IssuanceState>,
     Path(status_list_number): Path<usize>,
 ) -> Result<Response, PublicError> {
-    let compressed_jwt_token = create_gzip_status_list_jwt_token(status_list_number, state)
+    let token_status_list_service = TokenStatusListService {};
+    let compressed_jwt_token = token_status_list_service
+        .create_gzip_status_list_jwt_token(status_list_number, state)
         .await
         .map_err(|_| PublicError::InternalServerError)?;
 

--- a/agent_api_rest/src/issuance/credential_issuer/token_status_list.rs
+++ b/agent_api_rest/src/issuance/credential_issuer/token_status_list.rs
@@ -1,6 +1,5 @@
-use agent_issuance::{credential::aggregate::CredentialStatus, state::IssuanceState};
-use agent_shared::config::{
-    config, get_preferred_did_method, get_preferred_signing_algorithm, BITS_PER_STATUS, STATUS_LIST_BYTES_AMOUNT,
+use agent_issuance::{
+    credential::application::token_status_list_service::create_gzip_status_list_jwt_token, state::IssuanceState,
 };
 use axum::{
     extract::{Path, State},
@@ -8,107 +7,17 @@ use axum::{
 };
 use http::StatusCode;
 use hyper::header;
-use oauth_tsl::{
-    relying_party::StatusListTokenResponseType,
-    status_list::{Bits, EncodedStatusList, StatusList, StatusType},
-    tokens::status_list_token::{compress_gzip, StatusListToken, StatusListTokenClaims},
-};
-use oid4vc_core::jwt::encode;
-use rand::Rng;
+use oauth_tsl::relying_party::StatusListTokenResponseType;
 
-use crate::{handlers::query_handler, issuance::error::PublicError};
+use crate::issuance::error::PublicError;
 
 pub async fn token_status_list(
     State(state): State<IssuanceState>,
     Path(status_list_number): Path<usize>,
 ) -> Result<Response, PublicError> {
-    let all_credentials = query_handler("all_credentials", &state.query.all_credentials)
-        .await?
-        .map(|all_credentials_view| all_credentials_view.credentials.into_values().collect::<Vec<_>>())
-        .unwrap_or_default();
-
-    let amount_indices = STATUS_LIST_BYTES_AMOUNT * 8 / BITS_PER_STATUS as usize;
-
-    let lower_bound = status_list_number * amount_indices;
-    let upper_bound = (status_list_number + 1) * amount_indices;
-
-    let mut used_indices: Vec<CredentialStatus> = all_credentials
-        .iter()
-        .filter_map(|c| {
-            let index = c.credential_status.index;
-            if index >= lower_bound && index < upper_bound {
-                Some(c.credential_status.clone())
-            } else {
-                None
-            }
-        })
-        .collect();
-
-    // This block ensures that the remaining empty 30% of a status list is filled with random values.
-    // This block works in tandem with the part of `fn patch_credential` which only fills 70% of a status list.
-    used_indices = {
-        let mut indices = used_indices.clone();
-
-        let mut rng = rand::rng();
-        while indices.len() < amount_indices {
-            let random_index = rng.random_range(lower_bound..upper_bound);
-            if !indices
-                .iter()
-                .any(|credential_status| credential_status.index == random_index)
-            {
-                // the range is 0..2 because BITS_PER_STATUS is set to 2, meaning 4 options, but we only have 3 options defined (VALID, UNVALID, SUSPENDED)
-                let status_type = rng.random_range(0..2);
-                indices.push(CredentialStatus {
-                    index: random_index,
-                    status: status_type.try_into().map_err(|_| PublicError::InternalServerError)?,
-                });
-            }
-        }
-
-        indices
-    };
-
-    used_indices.sort_by_key(|credential_status| credential_status.index);
-
-    let mut status_list = StatusList {
-        status_size: Bits::try_from(BITS_PER_STATUS).map_err(|_| PublicError::InternalServerError)?,
-        ..Default::default()
-    };
-    status_list
-        .pack_statuses_into_bytes(used_indices.iter().map(|s| s.status).collect::<Vec<StatusType>>())
+    let compressed_jwt_token = create_gzip_status_list_jwt_token(status_list_number, state)
+        .await
         .map_err(|_| PublicError::InternalServerError)?;
-
-    let mut sub_url = config().ietf_oauth_token_status_list_uri.clone();
-    sub_url
-        .path_segments_mut()
-        .map_err(|_| PublicError::InternalServerError)?
-        .push(&status_list_number.to_string());
-
-    let status_list_claims = StatusListTokenClaims {
-        sub: sub_url.to_string(),
-        iat: chrono::Utc::now().timestamp(),
-        exp: None,
-        ttl: None,
-        encoded_status_list: EncodedStatusList::try_from(status_list).map_err(|_| PublicError::InternalServerError)?,
-    };
-
-    let mut status_list_token = StatusListToken {
-        claims: status_list_claims,
-        ..Default::default()
-    };
-    status_list_token.header.alg = get_preferred_signing_algorithm();
-    let default_did_method = get_preferred_did_method().to_string();
-
-    let jwt_token = encode(
-        state.signer,
-        status_list_token.header,
-        status_list_token.claims,
-        &default_did_method,
-    )
-    .await
-    .map_err(|_| PublicError::InternalServerError)?;
-
-    let compressed_jwt_token = compress_gzip(&jwt_token).map_err(|_| PublicError::InternalServerError)?;
 
     Ok((
         StatusCode::OK,

--- a/agent_issuance/src/credential/application/mod.rs
+++ b/agent_issuance/src/credential/application/mod.rs
@@ -1,0 +1,1 @@
+pub mod token_status_list_service;

--- a/agent_issuance/src/credential/application/token_status_list_service.rs
+++ b/agent_issuance/src/credential/application/token_status_list_service.rs
@@ -16,116 +16,121 @@ use thiserror::Error;
 
 use crate::{credential::aggregate::CredentialStatus, state::IssuanceState};
 
-/// This function creates a gzip compressed JWT token containing a status list for credentials.
-/// The status list is created just-in-time based on a slice of the credentials queried from the store.
-/// This slice is in turn derived from the status list number specified in the last path segment of the url used to call the endpoint.
-/// The status list is then filled up to 30% with random values to enhance privacy and security.
-/// At last the remaining steps are executed according to the OAuth TSL specification to encode and compress the Status List Token.
-pub async fn create_gzip_status_list_jwt_token(
-    status_list_number: usize,
-    state: IssuanceState,
-) -> Result<Vec<u8>, TokenStatusListError> {
-    let all_credentials = query_handler("all_credentials", &state.query.all_credentials)
-        .await?
-        .map(|all_credentials_view| all_credentials_view.credentials.into_values().collect::<Vec<_>>())
-        .unwrap_or_default();
+pub struct TokenStatusListService {}
 
-    let amount_indices = STATUS_LIST_BYTES_AMOUNT * 8 / BITS_PER_STATUS as usize;
+impl TokenStatusListService {
+    /// This function creates a gzip compressed JWT token containing a status list for credentials.
+    /// The status list is created just-in-time based on a slice of the credentials queried from the store.
+    /// This slice is in turn derived from the status list number specified in the last path segment of the url used to call the endpoint.
+    /// The status list is then filled up to 30% with random values to enhance privacy and security.
+    /// At last the remaining steps are executed according to the OAuth TSL specification to encode and compress the Status List Token.
+    pub async fn create_gzip_status_list_jwt_token(
+        self,
+        status_list_number: usize,
+        state: IssuanceState,
+    ) -> Result<Vec<u8>, TokenStatusListError> {
+        let all_credentials = query_handler("all_credentials", &state.query.all_credentials)
+            .await?
+            .map(|all_credentials_view| all_credentials_view.credentials.into_values().collect::<Vec<_>>())
+            .unwrap_or_default();
 
-    let lower_bound = status_list_number * amount_indices;
-    let upper_bound = (status_list_number + 1) * amount_indices;
+        let amount_indices = STATUS_LIST_BYTES_AMOUNT * 8 / BITS_PER_STATUS as usize;
 
-    let mut used_indices: Vec<CredentialStatus> = all_credentials
-        .iter()
-        .filter_map(|c| {
-            let index = c.credential_status.index;
-            if index >= lower_bound && index < upper_bound {
-                Some(c.credential_status.clone())
-            } else {
-                None
+        let lower_bound = status_list_number * amount_indices;
+        let upper_bound = (status_list_number + 1) * amount_indices;
+
+        let mut used_indices: Vec<CredentialStatus> = all_credentials
+            .iter()
+            .filter_map(|c| {
+                let index = c.credential_status.index;
+                if index >= lower_bound && index < upper_bound {
+                    Some(c.credential_status.clone())
+                } else {
+                    None
+                }
+            })
+            .collect();
+
+        // TODO move this block to a separate function in the library oauth_tsl. Argument should be the indices and either
+        // - the status_list size from which we can derive that the difference is to be filled with random values,
+        // - or the percentage of random values desired (e.g. 30%). One is from a payload/latency perspective, the other from a privacy/security perspective.
+
+        // This block ensures that the remaining empty 30% of a status list is filled with random values.
+        // This block works in tandem with the part of `fn patch_credential` which only fills 70% of a status list.
+        used_indices = {
+            let mut indices = used_indices.clone();
+
+            let mut rng = rand::rng();
+            while indices.len() < amount_indices {
+                let random_index = rng.random_range(lower_bound..upper_bound);
+                if !indices
+                    .iter()
+                    .any(|credential_status| credential_status.index == random_index)
+                {
+                    // the range is 0..2 because BITS_PER_STATUS is set to 2, meaning 4 options, but we only have 3 options defined (VALID, UNVALID, SUSPENDED)
+                    let status_type = rng.random_range(0..2);
+                    indices.push(CredentialStatus {
+                        index: random_index,
+                        status: status_type.try_into().map_err(TokenStatusListError::StatusTypeError)?,
+                    });
+                }
             }
-        })
-        .collect();
 
-    // TODO move this block to a separate function in the library oauth_tsl. Argument should be the indices and either
-    // - the status_list size from which we can derive that the difference is to be filled with random values,
-    // - or the percentage of random values desired (e.g. 30%). One is from a payload/latency perspective, the other from a privacy/security perspective.
+            indices
+        };
 
-    // This block ensures that the remaining empty 30% of a status list is filled with random values.
-    // This block works in tandem with the part of `fn patch_credential` which only fills 70% of a status list.
-    used_indices = {
-        let mut indices = used_indices.clone();
+        used_indices.sort_by_key(|credential_status| credential_status.index);
 
-        let mut rng = rand::rng();
-        while indices.len() < amount_indices {
-            let random_index = rng.random_range(lower_bound..upper_bound);
-            if !indices
-                .iter()
-                .any(|credential_status| credential_status.index == random_index)
-            {
-                // the range is 0..2 because BITS_PER_STATUS is set to 2, meaning 4 options, but we only have 3 options defined (VALID, UNVALID, SUSPENDED)
-                let status_type = rng.random_range(0..2);
-                indices.push(CredentialStatus {
-                    index: random_index,
-                    status: status_type.try_into().map_err(TokenStatusListError::StatusTypeError)?,
-                });
-            }
-        }
+        // TODO move whats below to a builder function in the library oauth_tsl.
+        // - sensible default bitsize = 2
+        // - sensible default random percentage = 30%
+        // - amount of statuses is derived from the input vector of indices
 
-        indices
-    };
+        let mut status_list = StatusList {
+            status_size: Bits::try_from(BITS_PER_STATUS).map_err(TokenStatusListError::InvalidStatusSize)?,
+            ..Default::default()
+        };
+        status_list
+            .pack_statuses_into_bytes(used_indices.iter().map(|s| s.status).collect::<Vec<StatusType>>())
+            .map_err(TokenStatusListError::InvalidStatusSize)?;
 
-    used_indices.sort_by_key(|credential_status| credential_status.index);
+        let mut sub_url = config().ietf_oauth_token_status_list_uri.clone();
+        sub_url
+            .path_segments_mut()
+            .map_err(|_| TokenStatusListError::SubUrlParsingError())?
+            .push(&status_list_number.to_string());
 
-    // TODO move whats below to a builder function in the library oauth_tsl.
-    // - sensible default bitsize = 2
-    // - sensible default random percentage = 30%
-    // - amount of statuses is derived from the input vector of indices
+        let status_list_claims = StatusListTokenClaims {
+            sub: sub_url.to_string(),
+            iat: chrono::Utc::now().timestamp(),
+            exp: None,
+            ttl: None,
+            encoded_status_list: EncodedStatusList::try_from(status_list)
+                .map_err(TokenStatusListError::StatusListEncodingError)?,
+        };
 
-    let mut status_list = StatusList {
-        status_size: Bits::try_from(BITS_PER_STATUS).map_err(TokenStatusListError::InvalidStatusSize)?,
-        ..Default::default()
-    };
-    status_list
-        .pack_statuses_into_bytes(used_indices.iter().map(|s| s.status).collect::<Vec<StatusType>>())
-        .map_err(TokenStatusListError::InvalidStatusSize)?;
+        let mut status_list_token = StatusListToken {
+            claims: status_list_claims,
+            ..Default::default()
+        };
 
-    let mut sub_url = config().ietf_oauth_token_status_list_uri.clone();
-    sub_url
-        .path_segments_mut()
-        .map_err(|_| TokenStatusListError::SubUrlParsingError())?
-        .push(&status_list_number.to_string());
+        // This remaining block stays in ssi-agent
+        status_list_token.header.alg = get_preferred_signing_algorithm();
+        let default_did_method = get_preferred_did_method().to_string();
 
-    let status_list_claims = StatusListTokenClaims {
-        sub: sub_url.to_string(),
-        iat: chrono::Utc::now().timestamp(),
-        exp: None,
-        ttl: None,
-        encoded_status_list: EncodedStatusList::try_from(status_list)
-            .map_err(TokenStatusListError::StatusListEncodingError)?,
-    };
+        let jwt_token = encode(
+            state.signer,
+            status_list_token.header,
+            status_list_token.claims,
+            &default_did_method,
+        )
+        .await
+        .map_err(|_| TokenStatusListError::JwtEncodeError)?;
 
-    let mut status_list_token = StatusListToken {
-        claims: status_list_claims,
-        ..Default::default()
-    };
+        let compressed_jwt_token = compress_gzip(&jwt_token).map_err(|_| TokenStatusListError::GzipCompressionError)?;
 
-    // This remaining block stays in ssi-agent
-    status_list_token.header.alg = get_preferred_signing_algorithm();
-    let default_did_method = get_preferred_did_method().to_string();
-
-    let jwt_token = encode(
-        state.signer,
-        status_list_token.header,
-        status_list_token.claims,
-        &default_did_method,
-    )
-    .await
-    .map_err(|_| TokenStatusListError::JwtEncodeError)?;
-
-    let compressed_jwt_token = compress_gzip(&jwt_token).map_err(|_| TokenStatusListError::GzipCompressionError)?;
-
-    Ok(compressed_jwt_token)
+        Ok(compressed_jwt_token)
+    }
 }
 
 #[derive(Error, Debug)]

--- a/agent_issuance/src/credential/application/token_status_list_service.rs
+++ b/agent_issuance/src/credential/application/token_status_list_service.rs
@@ -143,7 +143,7 @@ pub enum TokenStatusListError {
     StatusTypeError(OAuthTSLError),
     #[error("Invalid status size: {0:?}")]
     InvalidStatusSize(OAuthTSLError),
-    #[error("Failed to parse the sub url for the status list")]
+    #[error("Failed to parse the `sub` url for the status list")]
     SubUrlParsingError,
     #[error("Failed to encode the status list token as JWT.")]
     JwtEncodeError,

--- a/agent_issuance/src/credential/application/token_status_list_service.rs
+++ b/agent_issuance/src/credential/application/token_status_list_service.rs
@@ -1,0 +1,142 @@
+use agent_shared::{
+    config::{
+        config, get_preferred_did_method, get_preferred_signing_algorithm, BITS_PER_STATUS, STATUS_LIST_BYTES_AMOUNT,
+    },
+    handlers::query_handler,
+};
+use cqrs_es::persist::PersistenceError;
+use oauth_tsl::{
+    error::OAuthTSLError,
+    status_list::{Bits, EncodedStatusList, StatusList, StatusType},
+    tokens::status_list_token::{compress_gzip, StatusListToken, StatusListTokenClaims},
+};
+use oid4vc_core::jwt::encode;
+use rand::Rng;
+use thiserror::Error;
+
+use crate::{credential::aggregate::CredentialStatus, state::IssuanceState};
+
+pub async fn create_gzip_status_list_jwt_token(
+    status_list_number: usize,
+    state: IssuanceState,
+) -> Result<Vec<u8>, TokenStatusListError> {
+    let all_credentials = query_handler("all_credentials", &state.query.all_credentials)
+        .await?
+        .map(|all_credentials_view| all_credentials_view.credentials.into_values().collect::<Vec<_>>())
+        .unwrap_or_default();
+
+    let amount_indices = STATUS_LIST_BYTES_AMOUNT * 8 / BITS_PER_STATUS as usize;
+
+    let lower_bound = status_list_number * amount_indices;
+    let upper_bound = (status_list_number + 1) * amount_indices;
+
+    let mut used_indices: Vec<CredentialStatus> = all_credentials
+        .iter()
+        .filter_map(|c| {
+            let index = c.credential_status.index;
+            if index >= lower_bound && index < upper_bound {
+                Some(c.credential_status.clone())
+            } else {
+                None
+            }
+        })
+        .collect();
+
+    // TODO move this block to a separate function in the library oauth_tsl. Argument should be the indices and either
+    // - the status_list size from which we can derive that the difference is to be filled with random values,
+    // - or the percentage of random values desired (e.g. 30%). One is from a payload/latency perspective, the other from a privacy/security perspective.
+
+    // This block ensures that the remaining empty 30% of a status list is filled with random values.
+    // This block works in tandem with the part of `fn patch_credential` which only fills 70% of a status list.
+    used_indices = {
+        let mut indices = used_indices.clone();
+
+        let mut rng = rand::rng();
+        while indices.len() < amount_indices {
+            let random_index = rng.random_range(lower_bound..upper_bound);
+            if !indices
+                .iter()
+                .any(|credential_status| credential_status.index == random_index)
+            {
+                // the range is 0..2 because BITS_PER_STATUS is set to 2, meaning 4 options, but we only have 3 options defined (VALID, UNVALID, SUSPENDED)
+                let status_type = rng.random_range(0..2);
+                indices.push(CredentialStatus {
+                    index: random_index,
+                    status: status_type.try_into().map_err(TokenStatusListError::StatusTypeError)?,
+                });
+            }
+        }
+
+        indices
+    };
+
+    used_indices.sort_by_key(|credential_status| credential_status.index);
+
+    // TODO move whats below to a builder function in the library oauth_tsl.
+    // - sensible default bitsize = 2
+    // - sensible default random percentage = 30%
+    // - amount of statuses is derived from the input vector of indices
+
+    let mut status_list = StatusList {
+        status_size: Bits::try_from(BITS_PER_STATUS).map_err(TokenStatusListError::InvalidStatusSize)?,
+        ..Default::default()
+    };
+    status_list
+        .pack_statuses_into_bytes(used_indices.iter().map(|s| s.status).collect::<Vec<StatusType>>())
+        .map_err(TokenStatusListError::InvalidStatusSize)?;
+
+    let mut sub_url = config().ietf_oauth_token_status_list_uri.clone();
+    sub_url
+        .path_segments_mut()
+        .map_err(|_| TokenStatusListError::SubUrlParsingError())?
+        .push(&status_list_number.to_string());
+
+    let status_list_claims = StatusListTokenClaims {
+        sub: sub_url.to_string(),
+        iat: chrono::Utc::now().timestamp(),
+        exp: None,
+        ttl: None,
+        encoded_status_list: EncodedStatusList::try_from(status_list)
+            .map_err(TokenStatusListError::StatusListEncodingError)?,
+    };
+
+    let mut status_list_token = StatusListToken {
+        claims: status_list_claims,
+        ..Default::default()
+    };
+
+    // This remaining block stays in ssi-agent
+    status_list_token.header.alg = get_preferred_signing_algorithm();
+    let default_did_method = get_preferred_did_method().to_string();
+
+    let jwt_token = encode(
+        state.signer,
+        status_list_token.header,
+        status_list_token.claims,
+        &default_did_method,
+    )
+    .await
+    .map_err(|_| TokenStatusListError::JwtEncodeError)?;
+
+    let compressed_jwt_token = compress_gzip(&jwt_token).map_err(|_| TokenStatusListError::GzipCompressionError)?;
+
+    Ok(compressed_jwt_token)
+}
+
+#[derive(Error, Debug)]
+pub enum TokenStatusListError {
+    #[error("Failed to query credentials in order to create the status list token: {0}")]
+    QueryCredentialsError(#[from] PersistenceError),
+    #[error("Failed to encode and compress the status list claim: {0:?}")]
+    StatusListEncodingError(OAuthTSLError),
+    #[error("Failed to convert/parse status type: {0:?}")]
+    StatusTypeError(OAuthTSLError),
+    #[error("Invalid status size: {0:?}")]
+    InvalidStatusSize(OAuthTSLError),
+    #[error("Failed to parse the sub url for the status list")]
+    SubUrlParsingError(),
+    #[error("Failed to encode the status list token as JWT.")]
+    JwtEncodeError,
+    #[error("Failed to Gzip compress the JWT token.")]
+    GzipCompressionError,
+}

--- a/agent_issuance/src/credential/application/token_status_list_service.rs
+++ b/agent_issuance/src/credential/application/token_status_list_service.rs
@@ -97,7 +97,7 @@ impl TokenStatusListService {
         let mut sub_url = config().ietf_oauth_token_status_list_uri.clone();
         sub_url
             .path_segments_mut()
-            .map_err(|_| TokenStatusListError::SubUrlParsingError())?
+            .map_err(|_| TokenStatusListError::SubUrlParsingError)?
             .push(&status_list_number.to_string());
 
         let status_list_claims = StatusListTokenClaims {
@@ -144,7 +144,7 @@ pub enum TokenStatusListError {
     #[error("Invalid status size: {0:?}")]
     InvalidStatusSize(OAuthTSLError),
     #[error("Failed to parse the sub url for the status list")]
-    SubUrlParsingError(),
+    SubUrlParsingError,
     #[error("Failed to encode the status list token as JWT.")]
     JwtEncodeError,
     #[error("Failed to Gzip compress the JWT token.")]

--- a/agent_issuance/src/credential/application/token_status_list_service.rs
+++ b/agent_issuance/src/credential/application/token_status_list_service.rs
@@ -16,6 +16,11 @@ use thiserror::Error;
 
 use crate::{credential::aggregate::CredentialStatus, state::IssuanceState};
 
+/// This function creates a gzip compressed JWT token containing a status list for credentials.
+/// The status list is created just-in-time based on a slice of the credentials queried from the store.
+/// This slice is in turn derived from the status list number specified in the last path segment of the url used to call the endpoint.
+/// The status list is then filled up to 30% with random values to enhance privacy and security.
+/// At last the remaining steps are executed according to the OAuth TSL specification to encode and compress the Status List Token.
 pub async fn create_gzip_status_list_jwt_token(
     status_list_number: usize,
     state: IssuanceState,

--- a/agent_issuance/src/credential/mod.rs
+++ b/agent_issuance/src/credential/mod.rs
@@ -1,4 +1,5 @@
 pub mod aggregate;
+pub mod application;
 pub mod command;
 pub mod entity;
 pub mod error;


### PR DESCRIPTION
# Description of change
To stay true to the DDD design of UniCore we moved the Token Status List functionality to the Issuance domain as service since it has no aggregate.

## Links to any relevant issues
Fixes issue 
- #208 

## How the change has been tested
The existing unit test still passes.

## Definition of Done checklist
Add an `x` to the boxes that are relevant to your changes.

- [x] I have followed the contribution guidelines for this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] I have successfully tested this change in a docker environment 
