### PR TITLE
fix: use `hostname` as `display` default in `production` profile

### DIFF
--- a/agent_identity/src/state.rs
+++ b/agent_identity/src/state.rs
@@ -121,7 +121,7 @@ pub async fn initialize(state: &IdentityState) -> anyhow::Result<()> {
 pub async fn query_profile(state: &IdentityState) -> Result<(), PersistenceError> {
     match query_handler(PROFILE_ID, &state.query.profile).await? {
         Some(Profile { display_name, logo, .. }) => {
-            let application_url = config().application_url.to_string();
+            let application_url = config().application_url.host_str().unwrap_or_default().to_string();
             let display = &mut config_mut().display;
             if let Some(display) = display.first_mut() {
                 display.name = display_name.unwrap_or_default();

--- a/agent_identity/src/state.rs
+++ b/agent_identity/src/state.rs
@@ -121,14 +121,14 @@ pub async fn initialize(state: &IdentityState) -> anyhow::Result<()> {
 pub async fn query_profile(state: &IdentityState) -> Result<(), PersistenceError> {
     match query_handler(PROFILE_ID, &state.query.profile).await? {
         Some(Profile { display_name, logo, .. }) => {
-            let application_url = config().application_url.host_str().unwrap_or_default().to_string();
+            let hostname = config().application_url.host_str().unwrap_or_default().to_string();
             let display = &mut config_mut().display;
             if let Some(display) = display.first_mut() {
                 display.name = display_name.unwrap_or_default();
                 display.logo = logo;
             } else {
                 display.push(Display {
-                    name: display_name.unwrap_or(application_url),
+                    name: display_name.unwrap_or(hostname),
                     logo,
                     ..Default::default()
                 });

--- a/agent_identity/src/state.rs
+++ b/agent_identity/src/state.rs
@@ -13,7 +13,7 @@ use crate::{
     service::{aggregate::Service, command::ServiceCommand, views::ServiceView},
 };
 use agent_shared::config::{
-    config, config_mut, get_all_enabled_signing_algorithms_supported, SupportedDidMethod, ToggleOptions,
+    config, config_mut, get_all_enabled_signing_algorithms_supported, Display, SupportedDidMethod, ToggleOptions,
 };
 use agent_shared::handlers::command_handler;
 use agent_shared::{application_state::CommandHandler, handlers::query_handler};
@@ -121,9 +121,17 @@ pub async fn initialize(state: &IdentityState) -> anyhow::Result<()> {
 pub async fn query_profile(state: &IdentityState) -> Result<(), PersistenceError> {
     match query_handler(PROFILE_ID, &state.query.profile).await? {
         Some(Profile { display_name, logo, .. }) => {
-            if let Some(display) = config_mut().display.first_mut() {
+            let application_url = config().application_url.to_string();
+            let display = &mut config_mut().display;
+            if let Some(display) = display.first_mut() {
                 display.name = display_name.unwrap_or_default();
                 display.logo = logo;
+            } else {
+                display.push(Display {
+                    name: display_name.unwrap_or(application_url),
+                    logo,
+                    ..Default::default()
+                });
             }
 
             Ok(())

--- a/agent_shared/src/config/mod.rs
+++ b/agent_shared/src/config/mod.rs
@@ -274,7 +274,9 @@ pub struct ApplicationConfiguration {
             ]
         )")]
     pub signing_algorithms_supported: HashMap<Algorithm, ToggleOptions>,
-    #[config(development_default = r#"vec![
+    #[config(
+        default,
+        development_default = r#"vec![
             Display {
                 name: "UniCore".to_string(),
                 locale: Some("en".to_string()),
@@ -284,7 +286,8 @@ pub struct ApplicationConfiguration {
                 }),
                 country: None
             }
-        ]"#)]
+        ]"#
+    )]
     pub display: Vec<Display>,
     #[config(default)]
     pub event_publishers: EventPublishers,


### PR DESCRIPTION
# Description of change
These changes use the `application_url` value as a sensible default for the applications display name. This ensures that the agent can be booted without the need to configure the display name/logo.

closes https://github.com/impierce/ssi-agent/issues/227

## Links to any relevant issues
- https://github.com/impierce/ssi-agent/issues/227

## How the change has been tested
Manually tested using Postman and UniMe.

## Definition of Done checklist
Add an `x` to the boxes that are relevant to your changes.

- [x] I have followed the contribution guidelines for this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] I have successfully tested this change in a docker environment 
