### PR TITLE
fix: remove duplicate OID4VP authorization response validation

### DIFF
--- a/agent_verification/src/authorization_request/aggregate.rs
+++ b/agent_verification/src/authorization_request/aggregate.rs
@@ -195,7 +195,7 @@ impl Aggregate for AuthorizationRequest {
                         }])
                     }
                     GenericAuthorizationResponse::OID4VP(oid4vp_authorization_response) => {
-                        let _ = relying_party
+                        let decoded_vp_token = relying_party
                             .validate_response(&oid4vp_authorization_response)
                             .await
                             .map_err(InvalidOID4VPAuthorizationResponse)?;
@@ -220,15 +220,12 @@ impl Aggregate for AuthorizationRequest {
                                 builder = builder.add_presentation(credential_id.clone(), presentation.clone());
                             }
                         }
+
                         builder.build().map_err(|_| {
                             AuthorizationRequestError::InvalidOID4VPAuthorizationResponse(anyhow::anyhow!(
                                 "VpToken validation failed against DCQL query"
                             ))
                         })?;
-                        let decoded_vp_token = relying_party
-                            .validate_response(&oid4vp_authorization_response)
-                            .await
-                            .map_err(InvalidOID4VPAuthorizationResponse)?;
 
                         Ok(vec![OID4VPAuthorizationResponseVerified {
                             vp_token: decoded_vp_token,


### PR DESCRIPTION
# Description of change
This PR eliminates redundant validation of the OID4VP authorization response in the `AuthorizationRequest` aggregate. The response is now validated only once, and the decoded VP token is reused, improving efficiency and code clarity.
This change is necessary because the validation function is relatively time consuming.

## Links to any relevant issues
n/a

## How the change has been tested
Tested manually in a Docker container against UniMe.

## Definition of Done checklist
Add an `x` to the boxes that are relevant to your changes.

- [x] I have followed the contribution guidelines for this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have successfully tested this change in a docker environment 
