### PR TITLE
feat: initialize `IssuerMetadataSynchronizationPolicy`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -316,6 +316,7 @@ version = "0.1.0"
 dependencies = [
  "agent_holder",
  "agent_issuance",
+ "agent_library",
  "agent_secret_manager",
  "agent_shared",
  "anyhow",

--- a/agent_api_rest/src/authorization/authorization_server/authorize.rs
+++ b/agent_api_rest/src/authorization/authorization_server/authorize.rs
@@ -12,10 +12,11 @@ use axum::{
 };
 use http::header;
 use oid4vci::wallet::AuthorizationRequestByReference;
+use std::sync::Arc;
 
 #[axum_macros::debug_handler]
 pub(crate) async fn authorize(
-    State(state): State<AuthorizationState>,
+    State(state): State<Arc<AuthorizationState>>,
     Query(authorization_request): Query<AuthorizationRequestByReference>,
 ) -> Result<Response, PublicError> {
     match OAuth2AuthorizationService::handle_authorization_request(&state, authorization_request)
@@ -109,7 +110,7 @@ pub mod tests {
     #[serial_test::serial]
     #[tokio::test]
     async fn test_authorization_endpoint() {
-        let issuance_state = issuance_state(&InMemory, Service::default(), Default::default()).await;
+        let issuance_state = Arc::new(issuance_state(&InMemory, Service::default(), Default::default()).await);
 
         agent_issuance::state::initialize(&issuance_state).await.unwrap();
 
@@ -120,7 +121,8 @@ pub mod tests {
         let AuthorizationCode { issuer_state, .. } = authorization_code.unwrap();
         let issuer_state = issuer_state.unwrap();
 
-        let authorization_state = authorization_state(&InMemory, Service::default(), Default::default()).await;
+        let authorization_state =
+            Arc::new(authorization_state(&InMemory, Service::default(), Default::default()).await);
         agent_authorization::state::initialize(&authorization_state)
             .await
             .unwrap();

--- a/agent_api_rest/src/authorization/authorization_server/consent.rs
+++ b/agent_api_rest/src/authorization/authorization_server/consent.rs
@@ -12,11 +12,12 @@ use axum::{
 };
 use http::{header, StatusCode};
 use serde::{Deserialize, Serialize};
+use std::sync::Arc;
 use tracing::info;
 
 #[axum_macros::debug_handler]
 pub(crate) async fn get_consent(
-    State(state): State<AuthorizationState>,
+    State(state): State<Arc<AuthorizationState>>,
     StringifiedQuery(GetConsentQuery { request_uri }): StringifiedQuery<GetConsentQuery>,
 ) -> Result<Response, PublicError> {
     let ConsentPageViewModel {
@@ -47,7 +48,7 @@ pub struct ConsentForm {
 
 // TODO: investigate replay attacks as described here: https://github.com/impierce/ssi-agent/issues/241
 pub async fn post_consent(
-    State(state): State<AuthorizationState>,
+    State(state): State<Arc<AuthorizationState>>,
     Form(ConsentForm {
         client_id,
         request_uri,

--- a/agent_api_rest/src/authorization/authorization_server/par.rs
+++ b/agent_api_rest/src/authorization/authorization_server/par.rs
@@ -7,10 +7,11 @@ use axum::{
     response::{IntoResponse, Response},
 };
 use oid4vci::authorization_request::AuthorizationRequest;
+use std::sync::Arc;
 
 #[axum_macros::debug_handler]
 pub(crate) async fn par(
-    State(state): State<AuthorizationState>,
+    State(state): State<Arc<AuthorizationState>>,
     StringifiedForm(pushed_authorization_request): StringifiedForm<AuthorizationRequest>,
 ) -> Result<Response, PublicError> {
     let pushed_authorization_response =
@@ -103,7 +104,7 @@ pub mod tests {
     #[serial_test::serial]
     #[tokio::test]
     async fn test_pushed_authorization_request_endpoint() {
-        let issuance_state = issuance_state(&InMemory, Service::default(), Default::default()).await;
+        let issuance_state = Arc::new(issuance_state(&InMemory, Service::default(), Default::default()).await);
 
         agent_issuance::state::initialize(&issuance_state).await.unwrap();
 
@@ -114,7 +115,8 @@ pub mod tests {
         let AuthorizationCode { issuer_state, .. } = authorization_code.unwrap();
         let issuer_state = issuer_state.unwrap();
 
-        let authorization_state = authorization_state(&InMemory, Service::default(), Default::default()).await;
+        let authorization_state =
+            Arc::new(authorization_state(&InMemory, Service::default(), Default::default()).await);
         agent_authorization::state::initialize(&authorization_state)
             .await
             .unwrap();

--- a/agent_api_rest/src/authorization/authorization_server/token.rs
+++ b/agent_api_rest/src/authorization/authorization_server/token.rs
@@ -9,10 +9,11 @@ use axum::{
     Form,
 };
 use oid4vci::token_request::TokenRequest;
+use std::sync::Arc;
 
 #[axum_macros::debug_handler]
 pub(crate) async fn token(
-    State((authorization_state, issuance_state)): State<(AuthorizationState, IssuanceState)>,
+    State((authorization_state, issuance_state)): State<(Arc<AuthorizationState>, Arc<IssuanceState>)>,
     Form(token_request): Form<TokenRequest>,
 ) -> Result<Response, PublicError> {
     let token_response =
@@ -138,7 +139,7 @@ pub mod tests {
     #[serial_test::serial]
     #[tokio::test]
     async fn test_token_endpoint(#[case] is_pre_authorized: bool) {
-        let issuance_state = issuance_state(&InMemory, Service::default(), Default::default()).await;
+        let issuance_state = Arc::new(issuance_state(&InMemory, Service::default(), Default::default()).await);
 
         agent_issuance::state::initialize(&issuance_state).await.unwrap();
 
@@ -153,7 +154,8 @@ pub mod tests {
         credentials(&mut app, &credential_configuration_id).await;
         let grants = offers(&mut app, &credential_configuration_id).await.unwrap();
 
-        let authorization_state = authorization_state(&InMemory, Service::default(), Default::default()).await;
+        let authorization_state =
+            Arc::new(authorization_state(&InMemory, Service::default(), Default::default()).await);
 
         agent_authorization::state::initialize(&authorization_state)
             .await

--- a/agent_api_rest/src/authorization/mod.rs
+++ b/agent_api_rest/src/authorization/mod.rs
@@ -1,3 +1,4 @@
+// Endpoint handlers
 pub mod authorization_server;
 
 pub mod error;

--- a/agent_api_rest/src/authorization/mod.rs
+++ b/agent_api_rest/src/authorization/mod.rs
@@ -9,8 +9,9 @@ use agent_issuance::state::IssuanceState;
 use authorization_server::{authorize::authorize, par::par, token::token};
 use axum::routing::get;
 use axum::{routing::post, Router};
+use std::sync::Arc;
 
-pub fn router((authorization_state, issuance_state): (AuthorizationState, IssuanceState)) -> Router {
+pub fn router((authorization_state, issuance_state): (Arc<AuthorizationState>, Arc<IssuanceState>)) -> Router {
     Router::new()
         .nest(API_VERSION, Router::new())
         .route("/auth/consent", get(get_consent).post(post_consent))

--- a/agent_api_rest/src/holder/holder/credentials/mod.rs
+++ b/agent_api_rest/src/holder/holder/credentials/mod.rs
@@ -9,9 +9,10 @@ use http_api_problem::ApiError;
 use hyper::StatusCode;
 use identity_credential::credential::Jwt;
 use serde::{Deserialize, Serialize};
+use std::sync::Arc;
 
 #[axum_macros::debug_handler]
-pub(crate) async fn credentials(State(state): State<HolderState>) -> Result<Response, ApiError> {
+pub(crate) async fn credentials(State(state): State<Arc<HolderState>>) -> Result<Response, ApiError> {
     let all_credentials = query_handler("all_holder_credentials", &state.query.all_holder_credentials)
         .await?
         .map(|all_credentials_view| all_credentials_view.credentials.into_values().collect::<Vec<_>>())
@@ -28,7 +29,7 @@ pub struct HolderCredentialsEndpointRequest {
 
 #[axum_macros::debug_handler]
 pub(crate) async fn post_credentials(
-    State(state): State<HolderState>,
+    State(state): State<Arc<HolderState>>,
     Json(HolderCredentialsEndpointRequest { credential }): Json<HolderCredentialsEndpointRequest>,
 ) -> Result<Response, ApiError> {
     let holder_credential_id = uuid::Uuid::new_v4().to_string();
@@ -50,7 +51,7 @@ pub(crate) async fn post_credentials(
 
 #[axum_macros::debug_handler]
 pub(crate) async fn credential(
-    State(state): State<HolderState>,
+    State(state): State<Arc<HolderState>>,
     Path(holder_credential_id): Path<String>,
 ) -> Result<Response, ApiError> {
     query_handler(&holder_credential_id, &state.query.holder_credential)

--- a/agent_api_rest/src/holder/holder/offers/accept.rs
+++ b/agent_api_rest/src/holder/holder/offers/accept.rs
@@ -11,10 +11,11 @@ use axum::{
 };
 use http_api_problem::ApiError;
 use hyper::StatusCode;
+use std::sync::Arc;
 
 #[axum_macros::debug_handler]
 pub(crate) async fn accept(
-    State(state): State<HolderState>,
+    State(state): State<Arc<HolderState>>,
     Path(received_offer_id): Path<String>,
 ) -> Result<Response, ApiError> {
     // TODO: General note that also applies to other endpoints: currently we are using Application Layer logic in the

--- a/agent_api_rest/src/holder/holder/offers/mod.rs
+++ b/agent_api_rest/src/holder/holder/offers/mod.rs
@@ -10,9 +10,10 @@ use axum::{
 };
 use http_api_problem::ApiError;
 use hyper::StatusCode;
+use std::sync::Arc;
 
 #[axum_macros::debug_handler]
-pub(crate) async fn offers(State(state): State<HolderState>) -> Result<Response, ApiError> {
+pub(crate) async fn offers(State(state): State<Arc<HolderState>>) -> Result<Response, ApiError> {
     let all_received_offers = query_handler("all_received_offers", &state.query.all_received_offers)
         .await?
         .map(|all_received_offers_view| {
@@ -28,7 +29,7 @@ pub(crate) async fn offers(State(state): State<HolderState>) -> Result<Response,
 
 #[axum_macros::debug_handler]
 pub(crate) async fn offer(
-    State(state): State<HolderState>,
+    State(state): State<Arc<HolderState>>,
     Path(received_offer_id): Path<String>,
 ) -> Result<Response, ApiError> {
     query_handler(&received_offer_id, &state.query.received_offer)

--- a/agent_api_rest/src/holder/holder/offers/reject.rs
+++ b/agent_api_rest/src/holder/holder/offers/reject.rs
@@ -6,10 +6,11 @@ use axum::{
 };
 use http_api_problem::ApiError;
 use hyper::StatusCode;
+use std::sync::Arc;
 
 #[axum_macros::debug_handler]
 pub(crate) async fn reject(
-    State(state): State<HolderState>,
+    State(state): State<Arc<HolderState>>,
     Path(received_offer_id): Path<String>,
 ) -> Result<Response, ApiError> {
     let command = OfferCommand::RejectCredentialOffer {

--- a/agent_api_rest/src/holder/holder/presentations/mod.rs
+++ b/agent_api_rest/src/holder/holder/presentations/mod.rs
@@ -12,9 +12,10 @@ use axum::{
 use http_api_problem::ApiError;
 use hyper::StatusCode;
 use serde::{Deserialize, Serialize};
+use std::sync::Arc;
 
 #[axum_macros::debug_handler]
-pub(crate) async fn get_presentations(State(state): State<HolderState>) -> Result<Response, ApiError> {
+pub(crate) async fn get_presentations(State(state): State<Arc<HolderState>>) -> Result<Response, ApiError> {
     let all_presentations = query_handler("all_presentations", &state.query.all_presentations)
         .await?
         .map(|all_presentations_view| all_presentations_view.presentations.into_values().collect::<Vec<_>>())
@@ -25,7 +26,7 @@ pub(crate) async fn get_presentations(State(state): State<HolderState>) -> Resul
 
 #[axum_macros::debug_handler]
 pub(crate) async fn presentation(
-    State(state): State<HolderState>,
+    State(state): State<Arc<HolderState>>,
     Path(presentation_id): Path<String>,
 ) -> Result<Response, ApiError> {
     query_handler(&presentation_id, &state.query.presentation)
@@ -42,7 +43,7 @@ pub struct PresentationsEndpointRequest {
 
 #[axum_macros::debug_handler]
 pub(crate) async fn post_presentations(
-    State(state): State<HolderState>,
+    State(state): State<Arc<HolderState>>,
     Json(PresentationsEndpointRequest { credential_ids }): Json<PresentationsEndpointRequest>,
 ) -> Result<Response, ApiError> {
     let mut credentials = vec![];

--- a/agent_api_rest/src/holder/holder/presentations/presentation_signed.rs
+++ b/agent_api_rest/src/holder/holder/presentations/presentation_signed.rs
@@ -6,10 +6,11 @@ use axum::{
 };
 use http_api_problem::ApiError;
 use hyper::{header, StatusCode};
+use std::sync::Arc;
 
 #[axum_macros::debug_handler]
 pub(crate) async fn presentation_signed(
-    State(state): State<HolderState>,
+    State(state): State<Arc<HolderState>>,
     Path(presentation_id): Path<String>,
 ) -> Result<Response, ApiError> {
     match query_handler(&presentation_id, &state.query.presentation).await? {

--- a/agent_api_rest/src/holder/mod.rs
+++ b/agent_api_rest/src/holder/mod.rs
@@ -1,5 +1,6 @@
 // TODO: further refactor the API's folder structure to reflect the API's routes.
 #[allow(clippy::module_inception)]
+// Endpoint handlers
 pub mod holder;
 pub mod openid4vci;
 

--- a/agent_api_rest/src/holder/mod.rs
+++ b/agent_api_rest/src/holder/mod.rs
@@ -17,8 +17,9 @@ use holder::{
     credentials::{credential, post_credentials},
     presentations::{get_presentations, post_presentations, presentation, presentation_signed::presentation_signed},
 };
+use std::sync::Arc;
 
-pub fn router(holder_state: HolderState) -> Router {
+pub fn router(holder_state: Arc<HolderState>) -> Router {
     Router::new()
         .nest(
             API_VERSION,

--- a/agent_api_rest/src/holder/openid4vci/mod.rs
+++ b/agent_api_rest/src/holder/openid4vci/mod.rs
@@ -9,11 +9,12 @@ use http_api_problem::ApiError;
 use hyper::StatusCode;
 use oid4vci::credential_offer::CredentialOffer;
 use serde_json::Value;
+use std::sync::Arc;
 use tracing::info;
 
 #[axum_macros::debug_handler]
 pub(crate) async fn offers_params(
-    State(state): State<HolderState>,
+    State(state): State<Arc<HolderState>>,
     // TODO: Can this be changed to `StringifiedForm`?
     Form(payload): Form<serde_json::Value>,
 ) -> Result<Response, ApiError> {

--- a/agent_api_rest/src/identity/connections/mod.rs
+++ b/agent_api_rest/src/identity/connections/mod.rs
@@ -1,3 +1,5 @@
+use std::sync::Arc;
+
 use crate::handlers::{command_handler, query_handler};
 use crate::API_VERSION;
 use agent_identity::{connection::command::ConnectionCommand, state::IdentityState};
@@ -28,7 +30,7 @@ pub struct PostConnectionsEndpointRequest {
 
 #[axum_macros::debug_handler]
 pub(crate) async fn post_connections(
-    State(state): State<IdentityState>,
+    State(state): State<Arc<IdentityState>>,
     Json(PostConnectionsEndpointRequest {
         alias,
         domain,
@@ -76,7 +78,7 @@ pub struct GetConnectionsEndpointRequest {
 
 #[axum_macros::debug_handler]
 pub(crate) async fn get_connections(
-    State(state): State<IdentityState>,
+    State(state): State<Arc<IdentityState>>,
     Form(GetConnectionsEndpointRequest { alias, domain, did }): Form<GetConnectionsEndpointRequest>,
 ) -> Result<Response, ApiError> {
     debug!("Request Params - alias: {alias:?}, domain: {domain:?}, did: {did:?}");
@@ -107,7 +109,7 @@ pub(crate) async fn get_connections(
 
 #[axum_macros::debug_handler]
 pub(crate) async fn get_connection(
-    State(state): State<IdentityState>,
+    State(state): State<Arc<IdentityState>>,
     Path(connection_id): Path<String>,
 ) -> Result<Response, ApiError> {
     query_handler(&connection_id, &state.query.connection)

--- a/agent_api_rest/src/identity/documents/mod.rs
+++ b/agent_api_rest/src/identity/documents/mod.rs
@@ -9,6 +9,7 @@ use axum::{
 use http_api_problem::ApiError;
 use hyper::StatusCode;
 use serde::{Deserialize, Serialize};
+use std::sync::Arc;
 use tracing::debug;
 
 #[derive(Deserialize, Serialize)]
@@ -18,7 +19,7 @@ pub struct GetDocumentsEndpoint {
 }
 
 pub(crate) async fn get_documents(
-    State(state): State<IdentityState>,
+    State(state): State<Arc<IdentityState>>,
     Form(GetDocumentsEndpoint { did_method }): Form<GetDocumentsEndpoint>,
 ) -> Result<Response, ApiError> {
     debug!("Request Params - did_method: {did_method:?}");
@@ -45,7 +46,7 @@ pub(crate) async fn get_documents(
 
 #[axum_macros::debug_handler]
 pub(crate) async fn get_document(
-    State(state): State<IdentityState>,
+    State(state): State<Arc<IdentityState>>,
     Path(document_id): Path<String>,
 ) -> Result<Response, ApiError> {
     query_handler(&document_id, &state.query.document)

--- a/agent_api_rest/src/identity/mod.rs
+++ b/agent_api_rest/src/identity/mod.rs
@@ -6,6 +6,8 @@ pub mod well_known;
 
 pub mod error;
 
+use std::sync::Arc;
+
 use agent_identity::state::IdentityState;
 use axum::{
     routing::{get, post},
@@ -21,7 +23,7 @@ use crate::{
     API_VERSION,
 };
 
-pub fn router(identity_state: IdentityState) -> Router {
+pub fn router(identity_state: Arc<IdentityState>) -> Router {
     Router::new()
         .nest(
             API_VERSION,

--- a/agent_api_rest/src/identity/mod.rs
+++ b/agent_api_rest/src/identity/mod.rs
@@ -1,3 +1,4 @@
+// Endpoint handlers
 pub mod connections;
 pub mod documents;
 pub mod profiles;
@@ -5,8 +6,6 @@ pub mod services;
 pub mod well_known;
 
 pub mod error;
-
-use std::sync::Arc;
 
 use agent_identity::state::IdentityState;
 use axum::{
@@ -16,6 +15,7 @@ use axum::{
 use connections::{get_connection, get_connections, post_connections};
 use documents::{get_document, get_documents};
 use services::{linked_vp::linked_vp, service, services};
+use std::sync::Arc;
 use well_known::{did::did, did_configuration::did_configuration};
 
 use crate::{

--- a/agent_api_rest/src/identity/profiles/mod.rs
+++ b/agent_api_rest/src/identity/profiles/mod.rs
@@ -15,6 +15,7 @@ use http_api_problem::ApiError;
 use hyper::StatusCode;
 use serde::{Deserialize, Serialize};
 use serde_with::skip_serializing_none;
+use std::sync::Arc;
 
 #[derive(Deserialize, Serialize)]
 #[serde(rename_all = "camelCase")]
@@ -29,7 +30,7 @@ pub struct PatchProfileEndpointRequest {
 
 #[axum_macros::debug_handler]
 pub(crate) async fn patch_profile(
-    State(state): State<IdentityState>,
+    State(state): State<Arc<IdentityState>>,
     Json(PatchProfileEndpointRequest {
         display_name,
         logo,
@@ -81,7 +82,7 @@ struct GetProfileEndpointResponse {
 }
 
 #[axum_macros::debug_handler]
-pub(crate) async fn get_profile(State(state): State<IdentityState>) -> Result<Response, ApiError> {
+pub(crate) async fn get_profile(State(state): State<Arc<IdentityState>>) -> Result<Response, ApiError> {
     query_handler(PROFILE_ID, &state.query.profile)
         .await?
         .map(|profile_view| {

--- a/agent_api_rest/src/identity/services/linked_vp.rs
+++ b/agent_api_rest/src/identity/services/linked_vp.rs
@@ -13,6 +13,7 @@ use axum::{
 use http_api_problem::ApiError;
 use hyper::StatusCode;
 use serde::{Deserialize, Serialize};
+use std::sync::Arc;
 
 #[derive(Deserialize, Serialize)]
 #[serde(rename_all = "camelCase")]
@@ -22,7 +23,7 @@ pub struct LinkedVPEndpointRequest {
 
 #[axum_macros::debug_handler]
 pub(crate) async fn linked_vp(
-    State(state): State<IdentityState>,
+    State(state): State<Arc<IdentityState>>,
     Json(LinkedVPEndpointRequest { presentation_ids }): Json<LinkedVPEndpointRequest>,
 ) -> Result<Response, ApiError> {
     let service_id = "linked-verifiable-presentation-service".to_string();

--- a/agent_api_rest/src/identity/services/mod.rs
+++ b/agent_api_rest/src/identity/services/mod.rs
@@ -9,9 +9,10 @@ use axum::{
 };
 use http_api_problem::ApiError;
 use hyper::StatusCode;
+use std::sync::Arc;
 
 #[axum_macros::debug_handler]
-pub(crate) async fn services(State(state): State<IdentityState>) -> Result<Response, ApiError> {
+pub(crate) async fn services(State(state): State<Arc<IdentityState>>) -> Result<Response, ApiError> {
     let all_services = query_handler("all_services", &state.query.all_services)
         .await?
         .map(|all_services_view| all_services_view.services.into_values().collect::<Vec<_>>())
@@ -22,7 +23,7 @@ pub(crate) async fn services(State(state): State<IdentityState>) -> Result<Respo
 
 #[axum_macros::debug_handler]
 pub(crate) async fn service(
-    State(state): State<IdentityState>,
+    State(state): State<Arc<IdentityState>>,
     Path(service_id): Path<String>,
 ) -> Result<Response, ApiError> {
     query_handler(&service_id, &state.query.service)

--- a/agent_api_rest/src/identity/well_known/did.rs
+++ b/agent_api_rest/src/identity/well_known/did.rs
@@ -8,9 +8,10 @@ use axum::{
 };
 use http_api_problem::ApiError;
 use hyper::StatusCode;
+use std::sync::Arc;
 
 #[axum_macros::debug_handler]
-pub(crate) async fn did(State(state): State<IdentityState>) -> Result<Response, ApiError> {
+pub(crate) async fn did(State(state): State<Arc<IdentityState>>) -> Result<Response, ApiError> {
     query_handler("all_documents", &state.query.all_documents)
         .await?
         .and_then(|all_documents_view| {

--- a/agent_api_rest/src/identity/well_known/did_configuration.rs
+++ b/agent_api_rest/src/identity/well_known/did_configuration.rs
@@ -10,9 +10,10 @@ use axum::{
 };
 use http_api_problem::ApiError;
 use hyper::StatusCode;
+use std::sync::Arc;
 
 #[axum_macros::debug_handler]
-pub(crate) async fn did_configuration(State(state): State<IdentityState>) -> Result<Response, ApiError> {
+pub(crate) async fn did_configuration(State(state): State<Arc<IdentityState>>) -> Result<Response, ApiError> {
     // Get the DID Configuration Resource if it exists.
     match query_handler(DOMAIN_LINKAGE_SERVICE_ID, &state.query.service).await? {
         Some(ServiceView {

--- a/agent_api_rest/src/issuance/credential_configurations.rs
+++ b/agent_api_rest/src/issuance/credential_configurations.rs
@@ -8,10 +8,11 @@ use axum::{
     response::{IntoResponse, Response},
 };
 use http_api_problem::ApiError;
+use std::sync::Arc;
 
 #[axum_macros::debug_handler]
 pub(crate) async fn credential_configurations(
-    State(state): State<IssuanceState>,
+    State(state): State<Arc<IssuanceState>>,
     Json(credential_configuration): Json<CredentialConfiguration>,
 ) -> Result<Response, ApiError> {
     let command = ServerConfigCommand::UpdateCredentialConfiguration {

--- a/agent_api_rest/src/issuance/credential_issuer/credential.rs
+++ b/agent_api_rest/src/issuance/credential_issuer/credential.rs
@@ -21,6 +21,7 @@ use axum::{
 use axum_auth::AuthBearer;
 use oid4vci::credential_request::CredentialRequest;
 use oid4vci::errors::CredentialErrorResponse;
+use std::sync::Arc;
 use tokio::time::sleep;
 use tracing::error;
 
@@ -28,7 +29,7 @@ const POLLING_INTERVAL_MS: u64 = 100;
 
 #[axum_macros::debug_handler]
 pub(crate) async fn credential(
-    State(state): State<IssuanceState>,
+    State(state): State<Arc<IssuanceState>>,
     AuthBearer(access_token): AuthBearer,
     Json(credential_request): Json<CredentialRequest>,
 ) -> Result<Response, PublicError> {
@@ -351,7 +352,7 @@ pub mod tests {
             (None, Default::default())
         };
 
-        let issuance_state = issuance_state(&InMemory, Service::default(), issuance_event_publishers).await;
+        let issuance_state = Arc::new(issuance_state(&InMemory, Service::default(), issuance_event_publishers).await);
         agent_issuance::state::initialize(&issuance_state).await.unwrap();
 
         let mut issuance_app = router(issuance_state.clone());
@@ -381,7 +382,8 @@ pub mod tests {
 
         let grants = offers(&mut issuance_app, &credential_configuration_id).await.unwrap();
 
-        let authorization_state = authorization_state(&InMemory, Service::default(), Default::default()).await;
+        let authorization_state =
+            Arc::new(authorization_state(&InMemory, Service::default(), Default::default()).await);
         agent_authorization::state::initialize(&authorization_state)
             .await
             .unwrap();

--- a/agent_api_rest/src/issuance/credential_issuer/credential_offer.rs
+++ b/agent_api_rest/src/issuance/credential_issuer/credential_offer.rs
@@ -8,10 +8,11 @@ use axum::{
 use http_api_problem::ApiError;
 use hyper::StatusCode;
 use oid4vci::credential_offer::CredentialOffer;
+use std::sync::Arc;
 
 #[axum_macros::debug_handler]
 pub(crate) async fn credential_offer_uri(
-    State(state): State<IssuanceState>,
+    State(state): State<Arc<IssuanceState>>,
     Path(offer_id): Path<String>,
 ) -> Result<Response, ApiError> {
     match query_handler(&offer_id, &state.query.offer).await? {

--- a/agent_api_rest/src/issuance/credential_issuer/notification.rs
+++ b/agent_api_rest/src/issuance/credential_issuer/notification.rs
@@ -11,6 +11,7 @@ use axum_auth::AuthBearer;
 use oid4vci::errors::NotificationErrorResponse;
 use oid4vci::notification_request::NotificationRequest;
 use serde_json::json;
+use std::sync::Arc;
 
 use tracing::info;
 /// The HTTP response MUST use the HTTP status code 400 (Bad Request) and set the content type to application/json.
@@ -18,7 +19,7 @@ use tracing::info;
 
 #[axum_macros::debug_handler]
 pub async fn notification(
-    State(state): State<IssuanceState>,
+    State(state): State<Arc<IssuanceState>>,
     AuthBearer(access_token): AuthBearer,
     Json(raw_value): Json<serde_json::Value>,
 ) -> Result<Response, PublicError> {
@@ -79,14 +80,15 @@ mod tests {
     #[serial_test::serial]
     #[tokio::test]
     async fn test_valid_notification_request() {
-        let issuance_state = issuance_state(&InMemory, Service::default(), Default::default()).await;
+        let issuance_state = Arc::new(issuance_state(&InMemory, Service::default(), Default::default()).await);
         agent_issuance::state::initialize(&issuance_state).await.unwrap();
         let mut issuance_app = issuance::router(issuance_state.clone());
 
         credentials(&mut issuance_app, "001").await;
         let grants = offers(&mut issuance_app, "001").await.unwrap();
 
-        let authorization_state = authorization_state(&InMemory, Service::default(), Default::default()).await;
+        let authorization_state =
+            Arc::new(authorization_state(&InMemory, Service::default(), Default::default()).await);
         agent_authorization::state::initialize(&authorization_state)
             .await
             .unwrap();
@@ -117,14 +119,15 @@ mod tests {
 
     #[tokio::test]
     async fn test_invalid_notification_request() {
-        let issuance_state = issuance_state(&InMemory, Service::default(), Default::default()).await;
+        let issuance_state = Arc::new(issuance_state(&InMemory, Service::default(), Default::default()).await);
         agent_issuance::state::initialize(&issuance_state).await.unwrap();
         let mut issuance_app = issuance::router(issuance_state.clone());
 
         credentials(&mut issuance_app, "001").await;
         let grants = offers(&mut issuance_app, "001").await.unwrap();
 
-        let authorization_state = authorization_state(&InMemory, Service::default(), Default::default()).await;
+        let authorization_state =
+            Arc::new(authorization_state(&InMemory, Service::default(), Default::default()).await);
         agent_authorization::state::initialize(&authorization_state)
             .await
             .unwrap();

--- a/agent_api_rest/src/issuance/credential_issuer/token_status_list.rs
+++ b/agent_api_rest/src/issuance/credential_issuer/token_status_list.rs
@@ -1,3 +1,5 @@
+use std::sync::Arc;
+
 use agent_issuance::{
     credential::application::token_status_list_service::TokenStatusListService, state::IssuanceState,
 };
@@ -12,12 +14,12 @@ use oauth_tsl::relying_party::StatusListTokenResponseType;
 use crate::issuance::error::PublicError;
 
 pub async fn token_status_list(
-    State(state): State<IssuanceState>,
+    State(state): State<Arc<IssuanceState>>,
     Path(status_list_number): Path<usize>,
 ) -> Result<Response, PublicError> {
     let token_status_list_service = TokenStatusListService {};
     let compressed_jwt_token = token_status_list_service
-        .create_gzip_status_list_jwt_token(status_list_number, state)
+        .create_gzip_status_list_jwt_token(status_list_number, &state)
         .await
         .map_err(|_| PublicError::InternalServerError)?;
 
@@ -37,6 +39,8 @@ pub async fn token_status_list(
 
 #[cfg(test)]
 pub mod tests {
+    use std::sync::Arc;
+
     use agent_issuance::state::initialize;
     use agent_secret_manager::{service::Service, subject::Subject};
     use agent_shared::config::{config, BITS_PER_STATUS, STATUS_LIST_BYTES_AMOUNT};
@@ -57,7 +61,7 @@ pub mod tests {
     /// The remainder of the test breaks down the Token Status List response in various steps and checks these steps one by one.
     #[tokio::test]
     pub async fn test_token_status_list() {
-        let issuance_state = issuance_state(&InMemory, Service::default(), Default::default()).await;
+        let issuance_state = Arc::new(issuance_state(&InMemory, Service::default(), Default::default()).await);
         initialize(&issuance_state).await.unwrap();
 
         let relying_party_state = Subject::default();

--- a/agent_api_rest/src/issuance/credential_issuer/well_known/oauth_authorization_server.rs
+++ b/agent_api_rest/src/issuance/credential_issuer/well_known/oauth_authorization_server.rs
@@ -9,10 +9,11 @@ use axum::{
     response::{IntoResponse, Response},
 };
 use http_api_problem::ApiError;
+use std::sync::Arc;
 
 // TODO: move this to `authorization/authorization_server/well_known.rs`!
 #[axum_macros::debug_handler]
-pub(crate) async fn oauth_authorization_server(State(state): State<IssuanceState>) -> Result<Response, ApiError> {
+pub(crate) async fn oauth_authorization_server(State(state): State<Arc<IssuanceState>>) -> Result<Response, ApiError> {
     match query_handler(SERVER_CONFIG_ID, &state.query.server_config).await? {
         Some(ServerConfigView {
             authorization_server_metadata,
@@ -73,7 +74,7 @@ mod tests {
 
     #[tokio::test]
     async fn test_oauth_authorization_server_endpoint() {
-        let issuance_state = issuance_state(&InMemory, Service::default(), Default::default()).await;
+        let issuance_state = Arc::new(issuance_state(&InMemory, Service::default(), Default::default()).await);
         initialize(&issuance_state).await.unwrap();
 
         let mut app = router(issuance_state);

--- a/agent_api_rest/src/issuance/credential_issuer/well_known/openid_credential_issuer.rs
+++ b/agent_api_rest/src/issuance/credential_issuer/well_known/openid_credential_issuer.rs
@@ -11,9 +11,10 @@ use axum::{
 };
 use http_api_problem::ApiError;
 use serde_json::json;
+use std::sync::Arc;
 
 #[axum_macros::debug_handler]
-pub(crate) async fn openid_credential_issuer(State(state): State<IssuanceState>) -> Result<Response, ApiError> {
+pub(crate) async fn openid_credential_issuer(State(state): State<Arc<IssuanceState>>) -> Result<Response, ApiError> {
     match query_handler(SERVER_CONFIG_ID, &state.query.server_config).await? {
         Some(ServerConfigView {
             mut credential_issuer_metadata,
@@ -70,7 +71,7 @@ mod tests {
 
     #[tokio::test]
     async fn test_openid_credential_issuer_endpoint() {
-        let issuance_state = issuance_state(&InMemory, Service::default(), Default::default()).await;
+        let issuance_state = Arc::new(issuance_state(&InMemory, Service::default(), Default::default()).await);
         initialize(&issuance_state).await.unwrap();
 
         let mut app = router(issuance_state);

--- a/agent_api_rest/src/issuance/credentials.rs
+++ b/agent_api_rest/src/issuance/credentials.rs
@@ -18,13 +18,14 @@ use oauth_tsl::status_list::StatusType;
 use oid4vci::credential_offer::GrantType;
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
+use std::sync::Arc;
 
 #[cfg(feature = "test_utils")]
 pub const TESTINDEX: usize = 123;
 
 #[axum_macros::debug_handler]
 pub(crate) async fn credential(
-    State(state): State<IssuanceState>,
+    State(state): State<Arc<IssuanceState>>,
     Path(credential_id): Path<String>,
 ) -> Result<Response, ApiError> {
     query_handler(&credential_id, &state.query.credential)
@@ -46,7 +47,7 @@ pub struct CredentialsEndpointRequest {
 
 #[axum_macros::debug_handler]
 pub(crate) async fn credentials(
-    State(state): State<IssuanceState>,
+    State(state): State<Arc<IssuanceState>>,
     Json(CredentialsEndpointRequest {
         offer_id,
         credential,
@@ -196,7 +197,7 @@ pub(crate) async fn credentials(
 }
 
 #[axum_macros::debug_handler]
-pub(crate) async fn all_credentials(State(state): State<IssuanceState>) -> Result<Response, ApiError> {
+pub(crate) async fn all_credentials(State(state): State<Arc<IssuanceState>>) -> Result<Response, ApiError> {
     let all_credentials = query_handler("all_credentials", &state.query.all_credentials)
         .await?
         .map(|all_credentials_view| all_credentials_view.credentials.into_values().collect::<Vec<_>>())
@@ -213,7 +214,7 @@ pub struct PatchCredentialEndpointRequest {
 
 /// Currently, this endpoint only supports patching the CredentialStatus of a credential according to the IETF OAuth Token Status List spec.
 pub async fn patch_credential(
-    State(state): State<IssuanceState>,
+    State(state): State<Arc<IssuanceState>>,
     Path(credential_id): Path<String>,
     Json(PatchCredentialEndpointRequest {
         credential_status: status,
@@ -409,7 +410,7 @@ pub mod tests {
 
     #[tokio::test]
     async fn test_patch_credential() {
-        let issuance_state = issuance_state(&InMemory, Service::default(), Default::default()).await;
+        let issuance_state = Arc::new(issuance_state(&InMemory, Service::default(), Default::default()).await);
         initialize(&issuance_state).await.unwrap();
 
         let mut app = router(issuance_state);
@@ -420,7 +421,7 @@ pub mod tests {
     #[tokio::test]
     #[tracing_test::traced_test]
     async fn test_credentials_endpoint() {
-        let issuance_state = issuance_state(&InMemory, Service::default(), Default::default()).await;
+        let issuance_state = Arc::new(issuance_state(&InMemory, Service::default(), Default::default()).await);
         initialize(&issuance_state).await.unwrap();
 
         let mut app = router(issuance_state);

--- a/agent_api_rest/src/issuance/mod.rs
+++ b/agent_api_rest/src/issuance/mod.rs
@@ -23,8 +23,9 @@ use crate::API_VERSION;
 use agent_issuance::state::IssuanceState;
 use axum::routing::get;
 use axum::{routing::post, Router};
+use std::sync::Arc;
 
-pub fn router(issuance_state: IssuanceState) -> Router {
+pub fn router(issuance_state: Arc<IssuanceState>) -> Router {
     Router::new()
         .nest(
             API_VERSION,

--- a/agent_api_rest/src/issuance/mod.rs
+++ b/agent_api_rest/src/issuance/mod.rs
@@ -1,3 +1,4 @@
+// Endpoint handlers
 pub mod credential_configurations;
 pub mod credential_issuer;
 pub mod credentials;

--- a/agent_api_rest/src/issuance/offers/mod.rs
+++ b/agent_api_rest/src/issuance/offers/mod.rs
@@ -17,6 +17,7 @@ use http_api_problem::ApiError;
 use hyper::header;
 use oid4vci::credential_offer::GrantType;
 use serde::{Deserialize, Serialize};
+use std::sync::Arc;
 
 #[derive(Deserialize, Serialize)]
 #[serde(rename_all = "camelCase")]
@@ -28,7 +29,7 @@ pub struct OffersEndpointRequest {
 
 #[axum_macros::debug_handler]
 pub(crate) async fn offers(
-    State(state): State<IssuanceState>,
+    State(state): State<Arc<IssuanceState>>,
     Json(OffersEndpointRequest {
         offer_id,
         credential_configuration_ids,
@@ -103,7 +104,7 @@ pub(crate) async fn offers(
 }
 
 #[axum_macros::debug_handler]
-pub(crate) async fn all_offers(State(state): State<IssuanceState>) -> Result<Response, ApiError> {
+pub(crate) async fn all_offers(State(state): State<Arc<IssuanceState>>) -> Result<Response, ApiError> {
     let all_offers = query_handler("all_offers", &state.query.all_offers)
         .await?
         .map(|all_offers_view| all_offers_view.offers.into_values().collect::<Vec<_>>())
@@ -114,7 +115,7 @@ pub(crate) async fn all_offers(State(state): State<IssuanceState>) -> Result<Res
 
 #[axum_macros::debug_handler]
 pub(crate) async fn offer(
-    State(state): State<IssuanceState>,
+    State(state): State<Arc<IssuanceState>>,
     Path(offer_id): Path<String>,
 ) -> Result<Response, ApiError> {
     query_handler(&offer_id, &state.query.offer)
@@ -218,7 +219,7 @@ pub mod tests {
     #[tokio::test]
     #[tracing_test::traced_test]
     async fn test_offers_endpoint() {
-        let issuance_state = issuance_state(&InMemory, Service::default(), Default::default()).await;
+        let issuance_state = Arc::new(issuance_state(&InMemory, Service::default(), Default::default()).await);
         initialize(&issuance_state).await.unwrap();
 
         let mut app = router(issuance_state);
@@ -232,7 +233,7 @@ pub mod tests {
     #[tracing_test::traced_test]
     async fn test_offers_endpoint_by_reference() {
         set_config().credential_offer_by_value_enabled = false;
-        let issuance_state = issuance_state(&InMemory, Service::default(), Default::default()).await;
+        let issuance_state = Arc::new(issuance_state(&InMemory, Service::default(), Default::default()).await);
         initialize(&issuance_state).await.unwrap();
 
         let mut app = router(issuance_state);

--- a/agent_api_rest/src/issuance/offers/send.rs
+++ b/agent_api_rest/src/issuance/offers/send.rs
@@ -8,6 +8,7 @@ use axum::{
 use http_api_problem::ApiError;
 use hyper::StatusCode;
 use serde::{Deserialize, Serialize};
+use std::sync::Arc;
 use url::Url;
 
 #[derive(Deserialize, Serialize)]
@@ -19,7 +20,7 @@ pub struct SendOfferEndpointRequest {
 
 #[axum_macros::debug_handler]
 pub(crate) async fn send(
-    State(state): State<IssuanceState>,
+    State(state): State<Arc<IssuanceState>>,
     Json(SendOfferEndpointRequest { offer_id, target_url }): Json<SendOfferEndpointRequest>,
 ) -> Result<Response, ApiError> {
     let command = OfferCommand::SendCredentialOffer {

--- a/agent_api_rest/src/lib.rs
+++ b/agent_api_rest/src/lib.rs
@@ -27,7 +27,7 @@ use axum::{
 };
 use http_body_util::BodyExt as _;
 use hyper::StatusCode;
-use std::time::Duration;
+use std::{sync::Arc, time::Duration};
 use tower::ServiceBuilder;
 use tower_http::trace::TraceLayer;
 use tracing::{debug, info, info_span, Span};
@@ -38,12 +38,12 @@ pub const DOCUMENTATION_URL: &str = "https://beta.docs.impierce.com/unicore/";
 
 #[derive(Default)]
 pub struct ApplicationState {
-    pub identity_state: Option<IdentityState>,
-    pub library_state: Option<LibraryState>,
-    pub authorization_state: Option<AuthorizationState>,
-    pub issuance_state: Option<IssuanceState>,
-    pub holder_state: Option<HolderState>,
-    pub verification_state: Option<VerificationState>,
+    pub identity_state: Option<Arc<IdentityState>>,
+    pub library_state: Option<Arc<LibraryState>>,
+    pub authorization_state: Option<Arc<AuthorizationState>>,
+    pub issuance_state: Option<Arc<IssuanceState>>,
+    pub holder_state: Option<Arc<HolderState>>,
+    pub verification_state: Option<Arc<VerificationState>>,
 }
 
 pub fn app(

--- a/agent_api_rest/src/library/mod.rs
+++ b/agent_api_rest/src/library/mod.rs
@@ -3,13 +3,14 @@ pub mod templates;
 
 use agent_library::state::LibraryState;
 use axum::{routing::get, Router};
+use std::sync::Arc;
 
 use crate::{
     library::templates::{get_template, get_templates, patch_template, post_templates},
     API_VERSION,
 };
 
-pub fn router(library_state: LibraryState) -> Router {
+pub fn router(library_state: Arc<LibraryState>) -> Router {
     Router::new()
         .nest(
             API_VERSION,

--- a/agent_api_rest/src/library/mod.rs
+++ b/agent_api_rest/src/library/mod.rs
@@ -1,5 +1,7 @@
-pub mod error;
+// Endpoint handlers
 pub mod templates;
+
+pub mod error;
 
 use agent_library::state::LibraryState;
 use axum::{routing::get, Router};

--- a/agent_api_rest/src/library/templates/mod.rs
+++ b/agent_api_rest/src/library/templates/mod.rs
@@ -17,6 +17,7 @@ use tracing::debug;
 #[derive(Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct TemplateDto {
+    #[serde(rename = "id")]
     pub template_id: String,
     pub title: Option<String>,
     pub display: Option<Display>,
@@ -316,7 +317,7 @@ mod tests {
         let response = TemplateDto::from(template);
         let json = serde_json::json!(&response);
 
-        assert_eq!(json["templateId"], "test-id");
+        assert_eq!(json["id"], "test-id");
         assert_eq!(json["title"], "Test Title");
         assert_eq!(json["holderType"], "individual");
     }

--- a/agent_api_rest/src/library/templates/mod.rs
+++ b/agent_api_rest/src/library/templates/mod.rs
@@ -1,7 +1,7 @@
 use crate::handlers::{command_handler, query_handler};
 use crate::API_VERSION;
 use agent_library::state::LibraryState;
-pub use agent_library::template::aggregate::{CredentialFormat, Display, HolderType, Status, Visibility};
+use agent_library::template::aggregate::{CredentialFormat, Display, HolderType, Status, Template, Visibility};
 use agent_library::template::command::TemplateCommand;
 use axum::{
     extract::{Path, State},
@@ -12,6 +12,45 @@ use http_api_problem::ApiError;
 use hyper::{header, StatusCode};
 use serde::{Deserialize, Serialize};
 use tracing::debug;
+
+/// Data transfer object for Templates.
+#[derive(Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct TemplateDto {
+    pub template_id: String,
+    pub title: Option<String>,
+    pub display: Option<Display>,
+    pub credential_format: Option<CredentialFormat>,
+    pub creator: Option<String>,
+    pub holder_type: Option<HolderType>,
+    pub modified_at: Option<String>,
+    pub tags: Vec<String>,
+    pub status: Status,
+    pub visibility: Visibility,
+    pub description: Option<String>,
+    pub r#type: Vec<String>,
+    pub schema: Option<serde_json::Value>,
+}
+
+impl From<Template> for TemplateDto {
+    fn from(value: Template) -> Self {
+        Self {
+            template_id: value.template_id,
+            title: value.title,
+            display: value.display,
+            credential_format: value.credential_format,
+            creator: value.creator,
+            holder_type: value.holder_type,
+            modified_at: value.modified_at,
+            tags: value.tags,
+            status: value.status,
+            visibility: value.visibility,
+            description: value.description,
+            r#type: value.r#type,
+            schema: value.schema,
+        }
+    }
+}
 
 #[derive(Deserialize, Serialize, Default)]
 #[serde(default, rename_all = "camelCase")]
@@ -72,7 +111,7 @@ pub(crate) async fn post_templates(
             (
                 StatusCode::CREATED,
                 [(header::LOCATION, &format!("{API_VERSION}/templates/{template_id}"))],
-                Json(template_view),
+                Json(TemplateDto::from(template_view)),
             )
                 .into_response()
         })
@@ -221,12 +260,13 @@ pub(crate) async fn get_templates(
     let filtered_templates = query_handler("all_templates", &state.query.all_templates)
         .await?
         .map(|all_templates_view| {
-            let filtered_templates: Vec<_> = all_templates_view
+            let filtered_templates: Vec<TemplateDto> = all_templates_view
                 .templates
                 .into_values()
                 .filter(|_template|
                     // TODO: Apply filtering logic based on request parameters
                     true)
+                .map(TemplateDto::from)
                 .collect();
 
             filtered_templates
@@ -243,6 +283,41 @@ pub(crate) async fn get_template(
 ) -> Result<Response, ApiError> {
     query_handler(&template_id, &state.query.template)
         .await?
-        .map(|template_view| (StatusCode::OK, Json(template_view)).into_response())
+        .map(|template_view| (StatusCode::OK, Json(TemplateDto::from(template_view))).into_response())
         .ok_or_else(|| ApiError::new(StatusCode::NOT_FOUND))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use {Display, Template};
+
+    #[test]
+    fn test_template_response_serialization() {
+        let template = Template {
+            template_id: "test-id".to_string(),
+            title: Some("Test Title".to_string()),
+            display: Some(Display {
+                name: "Test Display".to_string(),
+                logo: None,
+            }),
+            credential_format: None,
+            creator: None,
+            holder_type: Some(HolderType::Individual),
+            modified_at: None,
+            tags: vec![],
+            status: Default::default(),
+            visibility: Default::default(),
+            description: None,
+            r#type: vec![],
+            schema: None,
+        };
+
+        let response = TemplateDto::from(template);
+        let json = serde_json::json!(&response);
+
+        assert_eq!(json["templateId"], "test-id");
+        assert_eq!(json["title"], "Test Title");
+        assert_eq!(json["holderType"], "individual");
+    }
 }

--- a/agent_api_rest/src/library/templates/mod.rs
+++ b/agent_api_rest/src/library/templates/mod.rs
@@ -11,6 +11,7 @@ use axum::{
 use http_api_problem::ApiError;
 use hyper::{header, StatusCode};
 use serde::{Deserialize, Serialize};
+use std::sync::Arc;
 use tracing::debug;
 
 /// Data transfer object for Templates.
@@ -71,7 +72,7 @@ pub struct PostTemplatesEndpointRequest {
 
 #[axum_macros::debug_handler]
 pub(crate) async fn post_templates(
-    State(state): State<LibraryState>,
+    State(state): State<Arc<LibraryState>>,
     Json(PostTemplatesEndpointRequest {
         title,
         display,
@@ -138,7 +139,7 @@ pub struct PatchTemplatesEndpointRequest {
 
 #[axum_macros::debug_handler]
 pub(crate) async fn patch_template(
-    State(state): State<LibraryState>,
+    State(state): State<Arc<LibraryState>>,
     Path(template_id): Path<String>,
     Json(PatchTemplatesEndpointRequest {
         title,
@@ -253,7 +254,7 @@ pub struct GetTemplatesEndpointRequest {
 
 #[axum_macros::debug_handler]
 pub(crate) async fn get_templates(
-    State(state): State<LibraryState>,
+    State(state): State<Arc<LibraryState>>,
     Form(GetTemplatesEndpointRequest {}): Form<GetTemplatesEndpointRequest>,
 ) -> Result<Response, ApiError> {
     debug!("Request Params - ");
@@ -279,7 +280,7 @@ pub(crate) async fn get_templates(
 
 #[axum_macros::debug_handler]
 pub(crate) async fn get_template(
-    State(state): State<LibraryState>,
+    State(state): State<Arc<LibraryState>>,
     Path(template_id): Path<String>,
 ) -> Result<Response, ApiError> {
     query_handler(&template_id, &state.query.template)

--- a/agent_api_rest/src/verification/authorization_requests.rs
+++ b/agent_api_rest/src/verification/authorization_requests.rs
@@ -14,9 +14,12 @@ use http_api_problem::ApiError;
 use hyper::header;
 use oid4vp::dcql::dcql_query::DcqlQuery;
 use serde::{Deserialize, Serialize};
+use std::sync::Arc;
 
 #[axum_macros::debug_handler]
-pub(crate) async fn all_authorization_requests(State(state): State<VerificationState>) -> Result<Response, ApiError> {
+pub(crate) async fn all_authorization_requests(
+    State(state): State<Arc<VerificationState>>,
+) -> Result<Response, ApiError> {
     let all_authorization_requests =
         query_handler("all_authorization_requests", &state.query.all_authorization_requests)
             .await?
@@ -33,7 +36,7 @@ pub(crate) async fn all_authorization_requests(State(state): State<VerificationS
 
 #[axum_macros::debug_handler]
 pub(crate) async fn authorization_request(
-    State(state): State<VerificationState>,
+    State(state): State<Arc<VerificationState>>,
     Path(authorization_request_id): Path<String>,
 ) -> Result<Response, ApiError> {
     query_handler(&authorization_request_id, &state.query.authorization_request)
@@ -51,7 +54,7 @@ pub struct AuthorizationRequestsEndpointRequest {
 
 #[axum_macros::debug_handler]
 pub(crate) async fn authorization_requests(
-    State(verification_state): State<VerificationState>,
+    State(verification_state): State<Arc<VerificationState>>,
     Json(AuthorizationRequestsEndpointRequest {
         nonce,
         state,
@@ -193,7 +196,7 @@ pub mod tests {
     #[tracing_test::traced_test]
     #[tokio::test]
     async fn test_authorization_requests_endpoint() {
-        let verification_state = verification_state(&InMemory, Service::default(), Default::default()).await;
+        let verification_state = Arc::new(verification_state(&InMemory, Service::default(), Default::default()).await);
         let mut app = router(verification_state);
 
         let result = authorization_requests(&mut app).await;

--- a/agent_api_rest/src/verification/mod.rs
+++ b/agent_api_rest/src/verification/mod.rs
@@ -1,3 +1,4 @@
+// Endpoint handlers
 pub mod authorization_requests;
 pub mod relying_party;
 

--- a/agent_api_rest/src/verification/mod.rs
+++ b/agent_api_rest/src/verification/mod.rs
@@ -7,6 +7,7 @@ use agent_verification::state::VerificationState;
 use authorization_requests::all_authorization_requests;
 use axum::routing::get;
 use axum::{routing::post, Router};
+use std::sync::Arc;
 
 use crate::verification::{
     authorization_requests::authorization_request, authorization_requests::authorization_requests,
@@ -14,7 +15,7 @@ use crate::verification::{
 };
 use crate::API_VERSION;
 
-pub fn router(verification_state: VerificationState) -> Router {
+pub fn router(verification_state: Arc<VerificationState>) -> Router {
     Router::new()
         .nest(
             API_VERSION,

--- a/agent_api_rest/src/verification/relying_party/redirect.rs
+++ b/agent_api_rest/src/verification/relying_party/redirect.rs
@@ -11,10 +11,11 @@ use axum::{
 };
 use http_api_problem::ApiError;
 use oid4vc_core::utils::form_urlencoded::from_form_urlencoded_string;
+use std::sync::Arc;
 
 #[axum_macros::debug_handler]
 pub(crate) async fn redirect(
-    State(verification_state): State<VerificationState>,
+    State(verification_state): State<Arc<VerificationState>>,
     body: String,
 ) -> Result<Response, ApiError> {
     let authorization_response: GenericAuthorizationResponse = from_form_urlencoded_string(&body).map_err(|e| {
@@ -157,7 +158,7 @@ pub mod tests {
 
         let event_publishers = vec![Box::new(EventPublisherHttp::load().unwrap()) as Box<dyn EventPublisher>];
 
-        let verification_state = verification_state(&InMemory, Service::default(), event_publishers).await;
+        let verification_state = Arc::new(verification_state(&InMemory, Service::default(), event_publishers).await);
 
         let mut app = router(verification_state);
 

--- a/agent_api_rest/src/verification/relying_party/request.rs
+++ b/agent_api_rest/src/verification/relying_party/request.rs
@@ -7,13 +7,14 @@ use axum::{
 };
 use http_api_problem::ApiError;
 use hyper::header;
+use std::sync::Arc;
 
 /// Instead of directly embedding the Authorization Request into a QR-code or deeplink, the `Relying Party` can embed a
 /// `request_uri` that points to this endpoint from where the Authorization Request Object can be retrieved.
 /// As described here: https://www.rfc-editor.org/rfc/rfc9101.html#name-passing-a-request-object-by-
 #[axum_macros::debug_handler]
 pub(crate) async fn request(
-    State(verification_state): State<VerificationState>,
+    State(verification_state): State<Arc<VerificationState>>,
     Path(request_id): Path<String>,
 ) -> Result<Response, ApiError> {
     query_handler(&request_id, &verification_state.query.authorization_request)
@@ -73,7 +74,7 @@ pub mod tests {
     #[tokio::test]
     #[tracing_test::traced_test]
     async fn test_request_endpoint() {
-        let verification_state = verification_state(&InMemory, Service::default(), Default::default()).await;
+        let verification_state = Arc::new(verification_state(&InMemory, Service::default(), Default::default()).await);
 
         let mut app = router(verification_state);
 

--- a/agent_application/src/main.rs
+++ b/agent_application/src/main.rs
@@ -12,7 +12,10 @@ use agent_authorization::services::AuthorizationServices;
 use agent_event_publisher_http::EventPublisherHttp;
 use agent_holder::services::HolderServices;
 use agent_identity::services::IdentityServices;
-use agent_issuance::services::IssuanceServices;
+use agent_issuance::{
+    application::policies::issuer_metadata_synchronization_policy::IssuerMetadataSynchronizationPolicy,
+    services::IssuanceServices,
+};
 use agent_secret_manager::{service::Service as _, subject::Subject};
 use agent_shared::config::{config, EventStoreType};
 use agent_store::{in_memory::InMemory, mongodb::MongoDB, postgres::Postgres, EventPublisher};
@@ -45,43 +48,119 @@ async fn main() -> io::Result<()> {
     let verification_event_publishers: Vec<Box<dyn EventPublisher>> =
         vec![Box::new(EventPublisherHttp::load().unwrap())];
 
+    // TODO: Refactor this to reduce code duplication.
     let (identity_state, library_state, authorization_state, issuance_state, holder_state, verification_state) =
         match config().event_store.type_ {
             EventStoreType::Postgres => {
                 let builder = Postgres::new().await;
+
+                let issuance_state =
+                    Arc::new(agent_store::issuance_state(&builder, issuance_services, issuance_event_publishers).await);
+
+                let issuer_metadata_synchronization_policy =
+                    IssuerMetadataSynchronizationPolicy::new(issuance_state.clone());
+
                 (
-                    agent_store::identity_state(&builder, identity_services, identity_event_publishers).await,
-                    agent_store::library_state(&builder, library_event_publishers).await,
-                    agent_store::authorization_state(&builder, authorization_services, authorization_event_publishers)
+                    Arc::new(agent_store::identity_state(&builder, identity_services, identity_event_publishers).await),
+                    Arc::new(
+                        agent_store::library_state(
+                            &builder,
+                            library_event_publishers,
+                            vec![Box::new(issuer_metadata_synchronization_policy)],
+                        )
                         .await,
-                    agent_store::issuance_state(&builder, issuance_services, issuance_event_publishers).await,
-                    agent_store::holder_state(&builder, holder_services, holder_event_publishers).await,
-                    agent_store::verification_state(&builder, verification_services, verification_event_publishers)
+                    ),
+                    Arc::new(
+                        agent_store::authorization_state(
+                            &builder,
+                            authorization_services,
+                            authorization_event_publishers,
+                        )
                         .await,
+                    ),
+                    issuance_state,
+                    Arc::new(agent_store::holder_state(&builder, holder_services, holder_event_publishers).await),
+                    Arc::new(
+                        agent_store::verification_state(&builder, verification_services, verification_event_publishers)
+                            .await,
+                    ),
                 )
             }
             EventStoreType::MongoDb => {
                 let builder = MongoDB::new().await;
+
+                let issuance_state =
+                    Arc::new(agent_store::issuance_state(&builder, issuance_services, issuance_event_publishers).await);
+
+                let issuer_metadata_synchronization_policy =
+                    IssuerMetadataSynchronizationPolicy::new(issuance_state.clone());
+
                 (
-                    agent_store::identity_state(&builder, identity_services, identity_event_publishers).await,
-                    agent_store::library_state(&builder, library_event_publishers).await,
-                    agent_store::authorization_state(&builder, authorization_services, authorization_event_publishers)
+                    Arc::new(agent_store::identity_state(&builder, identity_services, identity_event_publishers).await),
+                    Arc::new(
+                        agent_store::library_state(
+                            &builder,
+                            library_event_publishers,
+                            vec![Box::new(issuer_metadata_synchronization_policy)],
+                        )
                         .await,
-                    agent_store::issuance_state(&builder, issuance_services, issuance_event_publishers).await,
-                    agent_store::holder_state(&builder, holder_services, holder_event_publishers).await,
-                    agent_store::verification_state(&builder, verification_services, verification_event_publishers)
+                    ),
+                    Arc::new(
+                        agent_store::authorization_state(
+                            &builder,
+                            authorization_services,
+                            authorization_event_publishers,
+                        )
                         .await,
+                    ),
+                    issuance_state,
+                    Arc::new(agent_store::holder_state(&builder, holder_services, holder_event_publishers).await),
+                    Arc::new(
+                        agent_store::verification_state(&builder, verification_services, verification_event_publishers)
+                            .await,
+                    ),
                 )
             }
-            EventStoreType::InMemory => (
-                agent_store::identity_state(&InMemory, identity_services, identity_event_publishers).await,
-                agent_store::library_state(&InMemory, library_event_publishers).await,
-                agent_store::authorization_state(&InMemory, authorization_services, authorization_event_publishers)
-                    .await,
-                agent_store::issuance_state(&InMemory, issuance_services, issuance_event_publishers).await,
-                agent_store::holder_state(&InMemory, holder_services, holder_event_publishers).await,
-                agent_store::verification_state(&InMemory, verification_services, verification_event_publishers).await,
-            ),
+            EventStoreType::InMemory => {
+                let issuance_state = Arc::new(
+                    agent_store::issuance_state(&InMemory, issuance_services, issuance_event_publishers).await,
+                );
+
+                let issuer_metadata_synchronization_policy =
+                    IssuerMetadataSynchronizationPolicy::new(issuance_state.clone());
+
+                (
+                    Arc::new(
+                        agent_store::identity_state(&InMemory, identity_services, identity_event_publishers).await,
+                    ),
+                    Arc::new(
+                        agent_store::library_state(
+                            &InMemory,
+                            library_event_publishers,
+                            vec![Box::new(issuer_metadata_synchronization_policy)],
+                        )
+                        .await,
+                    ),
+                    Arc::new(
+                        agent_store::authorization_state(
+                            &InMemory,
+                            authorization_services,
+                            authorization_event_publishers,
+                        )
+                        .await,
+                    ),
+                    issuance_state,
+                    Arc::new(agent_store::holder_state(&InMemory, holder_services, holder_event_publishers).await),
+                    Arc::new(
+                        agent_store::verification_state(
+                            &InMemory,
+                            verification_services,
+                            verification_event_publishers,
+                        )
+                        .await,
+                    ),
+                )
+            }
         };
 
     info!("{:?}", config());

--- a/agent_holder/src/offer/aggregate.rs
+++ b/agent_holder/src/offer/aggregate.rs
@@ -349,11 +349,12 @@ pub mod tests {
         config_mut().credential_endpoint = application_url.join("openid4vci/credential").unwrap();
         config_mut().credential_offer_uri = application_url.join("openid4vci/credential-offer/").unwrap();
 
-        let issuance_state = issuance_state(&InMemory, Service::default(), Default::default()).await;
+        let issuance_state = Arc::new(issuance_state(&InMemory, Service::default(), Default::default()).await);
         agent_issuance::state::initialize(&issuance_state).await.unwrap();
         let mut credential_isser = issuance::router(issuance_state.clone());
 
-        let authorization_state = authorization_state(&InMemory, Service::default(), Default::default()).await;
+        let authorization_state =
+            Arc::new(authorization_state(&InMemory, Service::default(), Default::default()).await);
         agent_authorization::state::initialize(&authorization_state)
             .await
             .unwrap();

--- a/agent_issuance/Cargo.toml
+++ b/agent_issuance/Cargo.toml
@@ -5,6 +5,7 @@ edition.workspace = true
 rust-version.workspace = true
 
 [dependencies]
+agent_library = { path = "../agent_library" }
 agent_shared = { path = "../agent_shared" }
 agent_secret_manager = { path = "../agent_secret_manager" }
 

--- a/agent_issuance/src/application/mod.rs
+++ b/agent_issuance/src/application/mod.rs
@@ -1,1 +1,2 @@
 pub mod access_token_validation_service;
+pub mod policies;

--- a/agent_issuance/src/application/policies/issuer_metadata_synchronization_policy.rs
+++ b/agent_issuance/src/application/policies/issuer_metadata_synchronization_policy.rs
@@ -1,0 +1,38 @@
+use crate::state::IssuanceState;
+use agent_library::template::aggregate::Template;
+use async_trait::async_trait;
+use cqrs_es::{EventEnvelope, Query};
+use std::sync::Arc;
+
+pub struct IssuerMetadataSynchronizationPolicy {
+    // TODO: Actually use this.
+    _issuance_state: Arc<IssuanceState>,
+}
+
+impl IssuerMetadataSynchronizationPolicy {
+    pub fn new(issuance_state: Arc<IssuanceState>) -> Self {
+        Self {
+            _issuance_state: issuance_state,
+        }
+    }
+}
+
+#[async_trait]
+impl Query<Template> for IssuerMetadataSynchronizationPolicy {
+    async fn dispatch(&self, _aggregate_id: &str, events: &[EventEnvelope<Template>]) {
+        use agent_library::template::event::TemplateEvent::*;
+
+        for event in events {
+            // TODO: Remove this when we implement the actual issuer metadata synchronization policy.
+            #[allow(clippy::single_match)]
+            match &event.payload {
+                TemplateCreated {
+                    title: Some(_title), ..
+                } => {
+                    // TODO: Update issuer metadata.
+                }
+                _ => {}
+            }
+        }
+    }
+}

--- a/agent_issuance/src/application/policies/mod.rs
+++ b/agent_issuance/src/application/policies/mod.rs
@@ -1,0 +1,1 @@
+pub mod issuer_metadata_synchronization_policy;

--- a/agent_issuance/src/credential/application/token_status_list_service.rs
+++ b/agent_issuance/src/credential/application/token_status_list_service.rs
@@ -27,7 +27,7 @@ impl TokenStatusListService {
     pub async fn create_gzip_status_list_jwt_token(
         self,
         status_list_number: usize,
-        state: IssuanceState,
+        state: &IssuanceState,
     ) -> Result<Vec<u8>, TokenStatusListError> {
         let all_credentials = query_handler("all_credentials", &state.query.all_credentials)
             .await?
@@ -119,7 +119,7 @@ impl TokenStatusListService {
         let default_did_method = get_preferred_did_method().to_string();
 
         let jwt_token = encode(
-            state.subject,
+            state.subject.clone(),
             status_list_token.header,
             status_list_token.claims,
             &default_did_method,

--- a/agent_library/src/template/event.rs
+++ b/agent_library/src/template/event.rs
@@ -8,6 +8,7 @@ use strum::Display;
 pub enum TemplateEvent {
     TemplateCreated {
         template_id: String,
+        // TODO: Make this a required field.
         title: Option<String>,
         display: Option<Display>,
         credential_format: Option<CredentialFormat>,

--- a/agent_store/src/lib.rs
+++ b/agent_store/src/lib.rs
@@ -218,15 +218,20 @@ pub async fn identity_state<CCB: CqrsComponentBuilder>(
 pub async fn library_state<CCB: CqrsComponentBuilder>(
     builder: &CCB,
     event_publishers: Vec<Box<dyn EventPublisher>>,
+    template_policies: Vec<Box<dyn Query<Template>>>,
 ) -> LibraryState {
     // Partition the event_publishers into the different aggregates.
     let Partitions {
-        template_event_publishers,
+        template_event_publishers: mut queries,
         ..
     } = partition_event_publishers(event_publishers);
 
+    for policy in template_policies {
+        queries.push(policy);
+    }
+
     let (template_command_handler, template, all_templates) = builder
-        .commands_and_queries::<Template, Template, AllTemplatesView>((), template_event_publishers)
+        .commands_and_queries::<Template, Template, AllTemplatesView>((), queries)
         .await;
 
     LibraryState {


### PR DESCRIPTION
# Description of change
This PR introduces the `IssuerMetadataSynchronizationPolicy` in the Issuance domain that will listen for specific `TemplateEvent`s from the Library Domain. In a near future update this policy will dispatch `ServerConfigCommand`s in order to update the Credential Issuer Metadata in order to keep the `credential_configurations_supported` field in sync with the Templates stored in `agent_library`.

In order to facilitate this, the Policy needs a reference to the `IssuanceState`:
```rust
pub struct IssuerMetadataSynchronizationPolicy {
    // TODO: Actually use this.
    _issuance_state: Arc<IssuanceState>,
}
```

This meant that `ApplicationState` cannot have sole ownership anymore over `IssuanceState` and therefore it has been wrapped into an `Arc`. The result of that is that many files in `agent_api_rest` had to be updated in order to wrap the state into `Arc`s.

This PR also includes a fix for the HTTP Response of the `GET /v0/templates/` and  `GET /v0/templates/<template_id>` endpoints that ensures that the responses are returned in camelCase.

## Links to any relevant issues
- #202

## How the change has been tested
* Since this merely an initialization of the Policy the only real 'proof' of the code working is that it compiles. The actual workings of the Policy will be implemented in https://github.com/impierce/ssi-agent/pull/245
* camelCase responses are tested through `test_template_response_serialization`.


## Definition of Done checklist
Add an `x` to the boxes that are relevant to your changes.

- [x] I have followed the contribution guidelines for this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] I have successfully tested this change in a docker environment 
