### PR TITLE
feat: set PIN code requirement in template

### DIFF
--- a/agent_api_rest/src/library/mod.rs
+++ b/agent_api_rest/src/library/mod.rs
@@ -2,10 +2,13 @@ pub mod error;
 pub mod templates;
 
 use agent_library::state::LibraryState;
-use axum::{routing::get, Router};
+use axum::{
+    routing::{get, post},
+    Router,
+};
 
 use crate::{
-    library::templates::{get_template, get_templates, patch_template, post_templates},
+    library::templates::{get_template, get_templates, patch_template, post_templates, require_pin_code},
     API_VERSION,
 };
 
@@ -15,7 +18,8 @@ pub fn router(library_state: LibraryState) -> Router {
             API_VERSION,
             Router::new()
                 .route("/templates", get(get_templates).post(post_templates))
-                .route("/templates/{template_id}", get(get_template).patch(patch_template)),
+                .route("/templates/{template_id}", get(get_template).patch(patch_template))
+                .route("/templates/require-pin-code", post(require_pin_code)),
         )
         .with_state(library_state)
 }

--- a/agent_api_rest/src/library/templates/mod.rs
+++ b/agent_api_rest/src/library/templates/mod.rs
@@ -23,6 +23,7 @@ pub struct PostTemplatesEndpointRequest {
     pub holder_type: Option<HolderType>,
     pub tags: Vec<String>,
     pub status: Status,
+    pub require_pin_code: Option<bool>,
     pub visibility: Visibility,
     pub description: Option<String>,
     pub r#type: Vec<String>,
@@ -40,6 +41,7 @@ pub(crate) async fn post_templates(
         holder_type,
         tags,
         status,
+        require_pin_code,
         visibility,
         description,
         r#type,
@@ -57,6 +59,7 @@ pub(crate) async fn post_templates(
         holder_type,
         tags,
         status,
+        require_pin_code,
         visibility,
         description,
         r#type,
@@ -201,6 +204,30 @@ pub(crate) async fn patch_template(
         };
         command_handler(&template_id, &state.command.template, command).await?;
     }
+
+    Ok(StatusCode::NO_CONTENT.into_response())
+}
+
+#[derive(Deserialize, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct RequirePinCodeRequest {
+    pub template_id: String,
+    pub require_pin_code: bool,
+}
+
+#[axum_macros::debug_handler]
+pub(crate) async fn require_pin_code(
+    State(state): State<LibraryState>,
+    Json(RequirePinCodeRequest {
+        template_id,
+        require_pin_code,
+    }): Json<RequirePinCodeRequest>,
+) -> Result<Response, ApiError> {
+    let command = TemplateCommand::RequirePinCode {
+        template_id: template_id.clone(),
+        require_pin_code,
+    };
+    command_handler(&template_id, &state.command.template, command).await?;
 
     Ok(StatusCode::NO_CONTENT.into_response())
 }

--- a/agent_library/src/template/aggregate.rs
+++ b/agent_library/src/template/aggregate.rs
@@ -1,3 +1,5 @@
+use std::pin::Pin;
+
 use async_trait::async_trait;
 use cqrs_es::Aggregate;
 use serde::{Deserialize, Serialize};
@@ -70,6 +72,7 @@ pub struct Template {
     pub modified_at: Option<String>,
     pub tags: Vec<String>,
     pub status: Status,
+    pub require_pin_code: Option<bool>,
     pub visibility: Visibility,
     pub description: Option<String>,
     pub r#type: Vec<String>,
@@ -107,6 +110,7 @@ impl Aggregate for Template {
                 holder_type,
                 tags,
                 status,
+                require_pin_code,
                 visibility,
                 description,
                 r#type,
@@ -127,6 +131,7 @@ impl Aggregate for Template {
                     modified_at,
                     tags,
                     status,
+                    require_pin_code,
                     visibility,
                     description,
                     r#type,
@@ -277,6 +282,21 @@ impl Aggregate for Template {
                     modified_at,
                 }])
             }
+            RequirePinCode {
+                template_id,
+                require_pin_code,
+            } => {
+                #[cfg(not(test))]
+                let modified_at = chrono::Utc::now().to_rfc3339();
+                #[cfg(test)]
+                let modified_at = test_utils::modified_at();
+
+                Ok(vec![PinCodeRequired {
+                    template_id,
+                    require_pin_code,
+                    modified_at,
+                }])
+            }
         }
     }
 
@@ -296,6 +316,7 @@ impl Aggregate for Template {
                 modified_at,
                 tags,
                 status,
+                require_pin_code,
                 visibility,
                 description,
                 r#type,
@@ -310,6 +331,7 @@ impl Aggregate for Template {
                 self.modified_at.replace(modified_at);
                 self.tags = tags;
                 self.status = status;
+                self.require_pin_code = require_pin_code;
                 self.visibility = visibility;
                 self.description = description;
                 self.r#type = r#type;
@@ -403,6 +425,14 @@ impl Aggregate for Template {
                 self.schema = Some(schema);
                 self.modified_at.replace(modified_at);
             }
+            PinCodeRequired {
+                template_id: _,
+                require_pin_code,
+                modified_at,
+            } => {
+                self.require_pin_code = Some(require_pin_code);
+                self.modified_at.replace(modified_at);
+            }
         }
     }
 }
@@ -429,6 +459,7 @@ pub mod document_tests {
         modified_at: String,
         tags: Vec<String>,
         status: Status,
+        require_pin_code: Option<bool>,
         visibility: Visibility,
         description: Option<String>,
         r#type: Vec<String>,
@@ -445,6 +476,7 @@ pub mod document_tests {
                 holder_type: holder_type.clone(),
                 tags: tags.clone(),
                 status: status.clone(),
+                require_pin_code: require_pin_code.clone(),
                 visibility: visibility.clone(),
                 description: description.clone(),
                 r#type: r#type.clone(),
@@ -460,6 +492,7 @@ pub mod document_tests {
                 modified_at,
                 tags,
                 status,
+                require_pin_code,
                 visibility,
                 description,
                 r#type,
@@ -519,6 +552,11 @@ pub mod test_utils {
     #[fixture]
     pub fn status() -> Status {
         Status::Draft
+    }
+
+    #[fixture]
+    pub fn require_pin_code() -> Option<bool> {
+        Some(true)
     }
 
     #[fixture]

--- a/agent_library/src/template/command.rs
+++ b/agent_library/src/template/command.rs
@@ -13,6 +13,7 @@ pub enum TemplateCommand {
         holder_type: Option<HolderType>,
         tags: Vec<String>,
         status: Status,
+        require_pin_code: Option<bool>,
         visibility: Visibility,
         description: Option<String>,
         r#type: Vec<String>,
@@ -61,5 +62,9 @@ pub enum TemplateCommand {
     UpdateSchema {
         template_id: String,
         schema: serde_json::Value,
+    },
+    RequirePinCode {
+        template_id: String,
+        require_pin_code: bool,
     },
 }

--- a/agent_library/src/template/event.rs
+++ b/agent_library/src/template/event.rs
@@ -16,6 +16,7 @@ pub enum TemplateEvent {
         modified_at: String,
         tags: Vec<String>,
         status: Status,
+        require_pin_code: Option<bool>,
         visibility: Visibility,
         description: Option<String>,
         r#type: Vec<String>,
@@ -74,6 +75,11 @@ pub enum TemplateEvent {
     SchemaUpdated {
         template_id: String,
         schema: serde_json::Value,
+        modified_at: String,
+    },
+    PinCodeRequired {
+        template_id: String,
+        require_pin_code: bool,
         modified_at: String,
     },
 }

--- a/agent_library/src/template/views/mod.rs
+++ b/agent_library/src/template/views/mod.rs
@@ -21,6 +21,7 @@ impl View<Template> for Template {
                 modified_at,
                 tags,
                 status,
+                require_pin_code,
                 visibility,
                 description,
                 r#type,
@@ -35,6 +36,7 @@ impl View<Template> for Template {
                 self.modified_at.replace(modified_at.clone());
                 self.tags.clone_from(tags);
                 self.status.clone_from(status);
+                self.require_pin_code.clone_from(require_pin_code);
                 self.visibility.clone_from(visibility);
                 self.description.clone_from(description);
                 self.r#type.clone_from(r#type);
@@ -126,6 +128,14 @@ impl View<Template> for Template {
                 modified_at,
             } => {
                 self.schema.replace(schema.clone());
+                self.modified_at.replace(modified_at.clone());
+            }
+            PinCodeRequired {
+                template_id: _,
+                require_pin_code,
+                modified_at,
+            } => {
+                self.require_pin_code.replace(require_pin_code.clone());
                 self.modified_at.replace(modified_at.clone());
             }
         }


### PR DESCRIPTION
# Description of change
Templates are extended by another setting that stores if a PIN code is asked from the holder on issuance.

## Links to any relevant issues
- this setting needs to bind to the `authorization` implemented in #245 

## How the change has been tested
Describe the tests that you ran to verify your changes.
Make sure to provide instructions for the maintainer as well as any relevant configurations.

## Definition of Done checklist
Add an `x` to the boxes that are relevant to your changes.

- [ ] I have followed the contribution guidelines for this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] I have successfully tested this change in a docker environment 
