### PR TITLE
feat: configure IOTA node URL and Basic Auth

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2433,7 +2433,7 @@ checksum = "7c74b8349d32d297c9134b8c88677813a227df8f779daa29bfc29c183fe3dca6"
 [[package]]
 name = "consumer"
 version = "0.1.0"
-source = "git+https://github.com/impierce/did-manager?rev=v1.0.0-beta.7#5ce0c7ddeebf0d3326a24717b470654c12d35e16"
+source = "git+https://github.com/impierce/did-manager?tag=v1.0.0-beta.7#5ce0c7ddeebf0d3326a24717b470654c12d35e16"
 dependencies = [
  "did_iota",
  "did_jwk",
@@ -3192,7 +3192,7 @@ dependencies = [
 [[package]]
 name = "did_iota"
 version = "0.1.0"
-source = "git+https://github.com/impierce/did-manager?rev=v1.0.0-beta.7#5ce0c7ddeebf0d3326a24717b470654c12d35e16"
+source = "git+https://github.com/impierce/did-manager?tag=v1.0.0-beta.7#5ce0c7ddeebf0d3326a24717b470654c12d35e16"
 dependencies = [
  "anyhow",
  "identity_iota",
@@ -3207,7 +3207,7 @@ dependencies = [
 [[package]]
 name = "did_jwk"
 version = "0.1.0"
-source = "git+https://github.com/impierce/did-manager?rev=v1.0.0-beta.7#5ce0c7ddeebf0d3326a24717b470654c12d35e16"
+source = "git+https://github.com/impierce/did-manager?tag=v1.0.0-beta.7#5ce0c7ddeebf0d3326a24717b470654c12d35e16"
 dependencies = [
  "did-jwk",
  "identity_iota",
@@ -3224,7 +3224,7 @@ dependencies = [
 [[package]]
 name = "did_key"
 version = "0.1.0"
-source = "git+https://github.com/impierce/did-manager?rev=v1.0.0-beta.7#5ce0c7ddeebf0d3326a24717b470654c12d35e16"
+source = "git+https://github.com/impierce/did-manager?tag=v1.0.0-beta.7#5ce0c7ddeebf0d3326a24717b470654c12d35e16"
 dependencies = [
  "did-method-key",
  "identity_iota",
@@ -3271,7 +3271,7 @@ dependencies = [
 [[package]]
 name = "did_web"
 version = "0.1.0"
-source = "git+https://github.com/impierce/did-manager?rev=v1.0.0-beta.7#5ce0c7ddeebf0d3326a24717b470654c12d35e16"
+source = "git+https://github.com/impierce/did-manager?tag=v1.0.0-beta.7#5ce0c7ddeebf0d3326a24717b470654c12d35e16"
 dependencies = [
  "did-web",
  "identity_iota",
@@ -5281,7 +5281,7 @@ dependencies = [
 [[package]]
 name = "identity_stronghold_ext"
 version = "0.1.0"
-source = "git+https://github.com/impierce/did-manager?rev=v1.0.0-beta.7#5ce0c7ddeebf0d3326a24717b470654c12d35e16"
+source = "git+https://github.com/impierce/did-manager?tag=v1.0.0-beta.7#5ce0c7ddeebf0d3326a24717b470654c12d35e16"
 dependencies = [
  "async-trait",
  "elliptic-curve 0.13.8",
@@ -11184,7 +11184,7 @@ dependencies = [
 [[package]]
 name = "shared"
 version = "0.1.0"
-source = "git+https://github.com/impierce/did-manager?rev=v1.0.0-beta.7#5ce0c7ddeebf0d3326a24717b470654c12d35e16"
+source = "git+https://github.com/impierce/did-manager?tag=v1.0.0-beta.7#5ce0c7ddeebf0d3326a24717b470654c12d35e16"
 dependencies = [
  "identity_iota",
  "identity_storage",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2433,7 +2433,6 @@ checksum = "7c74b8349d32d297c9134b8c88677813a227df8f779daa29bfc29c183fe3dca6"
 [[package]]
 name = "consumer"
 version = "0.1.0"
-source = "git+https://github.com/impierce/did-manager?rev=00baa2a#00baa2a0f752c5c9f9d355faf6a1979eaab79c0c"
 dependencies = [
  "did_iota",
  "did_jwk",
@@ -3192,7 +3191,6 @@ dependencies = [
 [[package]]
 name = "did_iota"
 version = "0.1.0"
-source = "git+https://github.com/impierce/did-manager?rev=00baa2a#00baa2a0f752c5c9f9d355faf6a1979eaab79c0c"
 dependencies = [
  "anyhow",
  "identity_iota",
@@ -3207,7 +3205,6 @@ dependencies = [
 [[package]]
 name = "did_jwk"
 version = "0.1.0"
-source = "git+https://github.com/impierce/did-manager?rev=00baa2a#00baa2a0f752c5c9f9d355faf6a1979eaab79c0c"
 dependencies = [
  "did-jwk",
  "identity_iota",
@@ -3224,7 +3221,6 @@ dependencies = [
 [[package]]
 name = "did_key"
 version = "0.1.0"
-source = "git+https://github.com/impierce/did-manager?rev=00baa2a#00baa2a0f752c5c9f9d355faf6a1979eaab79c0c"
 dependencies = [
  "did-method-key",
  "identity_iota",
@@ -3271,7 +3267,6 @@ dependencies = [
 [[package]]
 name = "did_web"
 version = "0.1.0"
-source = "git+https://github.com/impierce/did-manager?rev=00baa2a#00baa2a0f752c5c9f9d355faf6a1979eaab79c0c"
 dependencies = [
  "did-web",
  "identity_iota",
@@ -5281,7 +5276,6 @@ dependencies = [
 [[package]]
 name = "identity_stronghold_ext"
 version = "0.1.0"
-source = "git+https://github.com/impierce/did-manager?rev=00baa2a#00baa2a0f752c5c9f9d355faf6a1979eaab79c0c"
 dependencies = [
  "async-trait",
  "elliptic-curve 0.13.8",
@@ -5314,9 +5308,9 @@ dependencies = [
 
 [[package]]
 name = "idna"
-version = "1.0.3"
+version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "686f825264d630750a544639377bae737628043f20d38bbc029e8f29ea968a7e"
+checksum = "3b0875f23caa03898994f6ddc501886a45c7d3d62d04d2d90788d47be1b1e4de"
 dependencies = [
  "idna_adapter",
  "smallvec",
@@ -10741,7 +10735,7 @@ dependencies = [
 [[package]]
 name = "secret-storage"
 version = "0.3.0"
-source = "git+https://github.com/iotaledger/secret-storage.git?tag=v0.3.0#7dc13ddae8a7f2c8a931d3155f3cb9e9a27902fb"
+source = "git+https://github.com/iotaledger/secret-storage?tag=v0.3.0#7dc13ddae8a7f2c8a931d3155f3cb9e9a27902fb"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -11184,7 +11178,6 @@ dependencies = [
 [[package]]
 name = "shared"
 version = "0.1.0"
-source = "git+https://github.com/impierce/did-manager?rev=00baa2a#00baa2a0f752c5c9f9d355faf6a1979eaab79c0c"
 dependencies = [
  "identity_iota",
  "identity_storage",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -206,7 +206,6 @@ dependencies = [
  "cqrs-es",
  "http-serde",
  "reqwest 0.12.20",
- "rustls 0.23.28",
  "serde",
  "serde_json",
  "serde_with 3.13.0",
@@ -2434,6 +2433,7 @@ checksum = "7c74b8349d32d297c9134b8c88677813a227df8f779daa29bfc29c183fe3dca6"
 [[package]]
 name = "consumer"
 version = "0.1.0"
+source = "git+https://github.com/impierce/did-manager?rev=b31deb3#b31deb3d0d075528dca5a0bddac0886ec11da91f"
 dependencies = [
  "did_iota",
  "did_jwk",
@@ -3192,6 +3192,7 @@ dependencies = [
 [[package]]
 name = "did_iota"
 version = "0.1.0"
+source = "git+https://github.com/impierce/did-manager?rev=b31deb3#b31deb3d0d075528dca5a0bddac0886ec11da91f"
 dependencies = [
  "anyhow",
  "identity_iota",
@@ -3206,6 +3207,7 @@ dependencies = [
 [[package]]
 name = "did_jwk"
 version = "0.1.0"
+source = "git+https://github.com/impierce/did-manager?rev=b31deb3#b31deb3d0d075528dca5a0bddac0886ec11da91f"
 dependencies = [
  "did-jwk",
  "identity_iota",
@@ -3222,6 +3224,7 @@ dependencies = [
 [[package]]
 name = "did_key"
 version = "0.1.0"
+source = "git+https://github.com/impierce/did-manager?rev=b31deb3#b31deb3d0d075528dca5a0bddac0886ec11da91f"
 dependencies = [
  "did-method-key",
  "identity_iota",
@@ -3268,6 +3271,7 @@ dependencies = [
 [[package]]
 name = "did_web"
 version = "0.1.0"
+source = "git+https://github.com/impierce/did-manager?rev=b31deb3#b31deb3d0d075528dca5a0bddac0886ec11da91f"
 dependencies = [
  "did-web",
  "identity_iota",
@@ -5277,6 +5281,7 @@ dependencies = [
 [[package]]
 name = "identity_stronghold_ext"
 version = "0.1.0"
+source = "git+https://github.com/impierce/did-manager?rev=b31deb3#b31deb3d0d075528dca5a0bddac0886ec11da91f"
 dependencies = [
  "async-trait",
  "elliptic-curve 0.13.8",
@@ -11179,6 +11184,7 @@ dependencies = [
 [[package]]
 name = "shared"
 version = "0.1.0"
+source = "git+https://github.com/impierce/did-manager?rev=b31deb3#b31deb3d0d075528dca5a0bddac0886ec11da91f"
 dependencies = [
  "identity_iota",
  "identity_storage",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -411,6 +411,7 @@ dependencies = [
  "async-trait",
  "base64 0.22.1",
  "consumer",
+ "did_iota",
  "futures",
  "identity_iota",
  "identity_stronghold_ext",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -424,6 +424,7 @@ dependencies = [
  "oid4vc-core",
  "p256 0.13.2",
  "ring",
+ "rustls 0.23.28",
  "serde",
  "tokio",
  "url",
@@ -2439,7 +2440,7 @@ checksum = "7c74b8349d32d297c9134b8c88677813a227df8f779daa29bfc29c183fe3dca6"
 [[package]]
 name = "consumer"
 version = "0.1.0"
-source = "git+https://github.com/impierce/did-manager?tag=v1.0.0-beta.6#e8f68b575a3ee354ac4b08663939917977974556"
+source = "git+https://github.com/impierce/did-manager?rev=00baa2a#00baa2a0f752c5c9f9d355faf6a1979eaab79c0c"
 dependencies = [
  "did_iota",
  "did_jwk",
@@ -3198,7 +3199,7 @@ dependencies = [
 [[package]]
 name = "did_iota"
 version = "0.1.0"
-source = "git+https://github.com/impierce/did-manager?tag=v1.0.0-beta.6#e8f68b575a3ee354ac4b08663939917977974556"
+source = "git+https://github.com/impierce/did-manager?rev=00baa2a#00baa2a0f752c5c9f9d355faf6a1979eaab79c0c"
 dependencies = [
  "anyhow",
  "identity_iota",
@@ -3213,7 +3214,7 @@ dependencies = [
 [[package]]
 name = "did_jwk"
 version = "0.1.0"
-source = "git+https://github.com/impierce/did-manager?tag=v1.0.0-beta.6#e8f68b575a3ee354ac4b08663939917977974556"
+source = "git+https://github.com/impierce/did-manager?rev=00baa2a#00baa2a0f752c5c9f9d355faf6a1979eaab79c0c"
 dependencies = [
  "did-jwk",
  "identity_iota",
@@ -3230,7 +3231,7 @@ dependencies = [
 [[package]]
 name = "did_key"
 version = "0.1.0"
-source = "git+https://github.com/impierce/did-manager?tag=v1.0.0-beta.6#e8f68b575a3ee354ac4b08663939917977974556"
+source = "git+https://github.com/impierce/did-manager?rev=00baa2a#00baa2a0f752c5c9f9d355faf6a1979eaab79c0c"
 dependencies = [
  "did-method-key",
  "identity_iota",
@@ -3277,7 +3278,7 @@ dependencies = [
 [[package]]
 name = "did_web"
 version = "0.1.0"
-source = "git+https://github.com/impierce/did-manager?tag=v1.0.0-beta.6#e8f68b575a3ee354ac4b08663939917977974556"
+source = "git+https://github.com/impierce/did-manager?rev=00baa2a#00baa2a0f752c5c9f9d355faf6a1979eaab79c0c"
 dependencies = [
  "did-web",
  "identity_iota",
@@ -5281,7 +5282,7 @@ dependencies = [
 [[package]]
 name = "identity_stronghold_ext"
 version = "0.1.0"
-source = "git+https://github.com/impierce/did-manager?tag=v1.0.0-beta.6#e8f68b575a3ee354ac4b08663939917977974556"
+source = "git+https://github.com/impierce/did-manager?rev=00baa2a#00baa2a0f752c5c9f9d355faf6a1979eaab79c0c"
 dependencies = [
  "async-trait",
  "elliptic-curve 0.13.8",
@@ -11171,7 +11172,7 @@ dependencies = [
 [[package]]
 name = "shared"
 version = "0.1.0"
-source = "git+https://github.com/impierce/did-manager?tag=v1.0.0-beta.6#e8f68b575a3ee354ac4b08663939917977974556"
+source = "git+https://github.com/impierce/did-manager?rev=00baa2a#00baa2a0f752c5c9f9d355faf6a1979eaab79c0c"
 dependencies = [
  "identity_iota",
  "identity_storage",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2433,7 +2433,7 @@ checksum = "7c74b8349d32d297c9134b8c88677813a227df8f779daa29bfc29c183fe3dca6"
 [[package]]
 name = "consumer"
 version = "0.1.0"
-source = "git+https://github.com/impierce/did-manager?rev=b31deb3#b31deb3d0d075528dca5a0bddac0886ec11da91f"
+source = "git+https://github.com/impierce/did-manager?rev=v1.0.0-beta.7#5ce0c7ddeebf0d3326a24717b470654c12d35e16"
 dependencies = [
  "did_iota",
  "did_jwk",
@@ -3192,7 +3192,7 @@ dependencies = [
 [[package]]
 name = "did_iota"
 version = "0.1.0"
-source = "git+https://github.com/impierce/did-manager?rev=b31deb3#b31deb3d0d075528dca5a0bddac0886ec11da91f"
+source = "git+https://github.com/impierce/did-manager?rev=v1.0.0-beta.7#5ce0c7ddeebf0d3326a24717b470654c12d35e16"
 dependencies = [
  "anyhow",
  "identity_iota",
@@ -3207,7 +3207,7 @@ dependencies = [
 [[package]]
 name = "did_jwk"
 version = "0.1.0"
-source = "git+https://github.com/impierce/did-manager?rev=b31deb3#b31deb3d0d075528dca5a0bddac0886ec11da91f"
+source = "git+https://github.com/impierce/did-manager?rev=v1.0.0-beta.7#5ce0c7ddeebf0d3326a24717b470654c12d35e16"
 dependencies = [
  "did-jwk",
  "identity_iota",
@@ -3224,7 +3224,7 @@ dependencies = [
 [[package]]
 name = "did_key"
 version = "0.1.0"
-source = "git+https://github.com/impierce/did-manager?rev=b31deb3#b31deb3d0d075528dca5a0bddac0886ec11da91f"
+source = "git+https://github.com/impierce/did-manager?rev=v1.0.0-beta.7#5ce0c7ddeebf0d3326a24717b470654c12d35e16"
 dependencies = [
  "did-method-key",
  "identity_iota",
@@ -3271,7 +3271,7 @@ dependencies = [
 [[package]]
 name = "did_web"
 version = "0.1.0"
-source = "git+https://github.com/impierce/did-manager?rev=b31deb3#b31deb3d0d075528dca5a0bddac0886ec11da91f"
+source = "git+https://github.com/impierce/did-manager?rev=v1.0.0-beta.7#5ce0c7ddeebf0d3326a24717b470654c12d35e16"
 dependencies = [
  "did-web",
  "identity_iota",
@@ -5281,7 +5281,7 @@ dependencies = [
 [[package]]
 name = "identity_stronghold_ext"
 version = "0.1.0"
-source = "git+https://github.com/impierce/did-manager?rev=b31deb3#b31deb3d0d075528dca5a0bddac0886ec11da91f"
+source = "git+https://github.com/impierce/did-manager?rev=v1.0.0-beta.7#5ce0c7ddeebf0d3326a24717b470654c12d35e16"
 dependencies = [
  "async-trait",
  "elliptic-curve 0.13.8",
@@ -11184,7 +11184,7 @@ dependencies = [
 [[package]]
 name = "shared"
 version = "0.1.0"
-source = "git+https://github.com/impierce/did-manager?rev=b31deb3#b31deb3d0d075528dca5a0bddac0886ec11da91f"
+source = "git+https://github.com/impierce/did-manager?rev=v1.0.0-beta.7#5ce0c7ddeebf0d3326a24717b470654c12d35e16"
 dependencies = [
  "identity_iota",
  "identity_storage",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -72,11 +72,6 @@ reqwest = { version = "0.12", default-features = false, features = [
     "rustls-tls",
 ] }
 rstest = "0.22"
-rustls = { version = "0.23", default-features = false, features = [
-    "logging",
-    "std",
-    "tls12",
-] }
 serde = { version = "1.0", default-features = false, features = ["derive"] }
 serde_json = { version = "1.0" }
 serde_json_path_to_error = { version = "0.1" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -69,6 +69,11 @@ reqwest = { version = "0.12", default-features = false, features = [
     "rustls-tls",
 ] }
 rstest = "0.22"
+rustls = { version = "0.23", default-features = false, features = [
+    "logging",
+    "std",
+    "tls12",
+] }
 serde = { version = "1.0", default-features = false, features = ["derive"] }
 serde_json = { version = "1.0" }
 serde_json_path_to_error = { version = "0.1" }

--- a/agent_event_publisher_http/Cargo.toml
+++ b/agent_event_publisher_http/Cargo.toml
@@ -18,7 +18,6 @@ anyhow.workspace = true
 async-trait.workspace = true
 cqrs-es.workspace = true
 http-serde = "2.1"
-rustls.workspace = true
 reqwest.workspace = true
 serde.workspace = true
 serde_with.workspace = true

--- a/agent_event_publisher_http/Cargo.toml
+++ b/agent_event_publisher_http/Cargo.toml
@@ -18,11 +18,7 @@ anyhow.workspace = true
 async-trait.workspace = true
 cqrs-es.workspace = true
 http-serde = "2.1"
-rustls = { version = "0.23", default-features = false, features = [
-    "logging",
-    "std",
-    "tls12",
-] }
+rustls.workspace = true
 reqwest.workspace = true
 serde.workspace = true
 serde_with.workspace = true

--- a/agent_secret_manager/Cargo.toml
+++ b/agent_secret_manager/Cargo.toml
@@ -13,9 +13,9 @@ agent_shared = { path = "../agent_shared" }
 # - All components of the `identity_stronghold_ext` module are still active.
 #
 # Future work: Migrate the remaining functionality into UniCore.
-did_manager_consumer = { git = "https://github.com/impierce/did-manager", rev = "v1.0.0-beta.7", package = "consumer" }
-did_manager_identity_stronghold_ext = { git = "https://github.com/impierce/did-manager", rev = "v1.0.0-beta.7", package = "identity_stronghold_ext" }
-did_manager_iota = { git = "https://github.com/impierce/did-manager", rev = "v1.0.0-beta.7", package = "did_iota" }
+did_manager_consumer = { git = "https://github.com/impierce/did-manager", tag = "v1.0.0-beta.7", package = "consumer" }
+did_manager_identity_stronghold_ext = { git = "https://github.com/impierce/did-manager", tag = "v1.0.0-beta.7", package = "identity_stronghold_ext" }
+did_manager_iota = { git = "https://github.com/impierce/did-manager", tag = "v1.0.0-beta.7", package = "did_iota" }
 
 anyhow.workspace = true
 async-trait.workspace = true

--- a/agent_secret_manager/Cargo.toml
+++ b/agent_secret_manager/Cargo.toml
@@ -14,8 +14,8 @@ agent_shared = { path = "../agent_shared" }
 #
 # Future work: Migrate the remaining functionality into UniCore.
 did_manager_consumer = { git = "https://github.com/impierce/did-manager", rev = "v1.0.0-beta.7", package = "consumer" }
-did_manager_iota = { git = "https://github.com/impierce/did-manager", rev = "v1.0.0-beta.7", package = "did_iota" }
 did_manager_identity_stronghold_ext = { git = "https://github.com/impierce/did-manager", rev = "v1.0.0-beta.7", package = "identity_stronghold_ext" }
+did_manager_iota = { git = "https://github.com/impierce/did-manager", rev = "v1.0.0-beta.7", package = "did_iota" }
 
 anyhow.workspace = true
 async-trait.workspace = true

--- a/agent_secret_manager/Cargo.toml
+++ b/agent_secret_manager/Cargo.toml
@@ -14,6 +14,7 @@ agent_shared = { path = "../agent_shared" }
 #
 # Future work: Migrate the remaining functionality into UniCore.
 did_manager_consumer = { path = "../../did-manager/consumer", package = "consumer" }
+did_manager_iota = { path = "../../did-manager/did_iota", package = "did_iota" }
 did_manager_identity_stronghold_ext = { path = "../../did-manager/identity_stronghold_ext", package = "identity_stronghold_ext" }
 
 anyhow.workspace = true

--- a/agent_secret_manager/Cargo.toml
+++ b/agent_secret_manager/Cargo.toml
@@ -13,9 +13,9 @@ agent_shared = { path = "../agent_shared" }
 # - All components of the `identity_stronghold_ext` module are still active.
 #
 # Future work: Migrate the remaining functionality into UniCore.
-did_manager_consumer = { git = "https://github.com/impierce/did-manager", rev = "b31deb3", package = "consumer" }
-did_manager_iota = { git = "https://github.com/impierce/did-manager", rev = "b31deb3", package = "did_iota" }
-did_manager_identity_stronghold_ext = { git = "https://github.com/impierce/did-manager", rev = "b31deb3", package = "identity_stronghold_ext" }
+did_manager_consumer = { git = "https://github.com/impierce/did-manager", rev = "v1.0.0-beta.7", package = "consumer" }
+did_manager_iota = { git = "https://github.com/impierce/did-manager", rev = "v1.0.0-beta.7", package = "did_iota" }
+did_manager_identity_stronghold_ext = { git = "https://github.com/impierce/did-manager", rev = "v1.0.0-beta.7", package = "identity_stronghold_ext" }
 
 anyhow.workspace = true
 async-trait.workspace = true

--- a/agent_secret_manager/Cargo.toml
+++ b/agent_secret_manager/Cargo.toml
@@ -13,8 +13,8 @@ agent_shared = { path = "../agent_shared" }
 # - All components of the `identity_stronghold_ext` module are still active.
 #
 # Future work: Migrate the remaining functionality into UniCore.
-did_manager_consumer = { git = "https://github.com/impierce/did-manager", tag = "v1.0.0-beta.6", package = "consumer" }
-did_manager_identity_stronghold_ext = { git = "https://github.com/impierce/did-manager", tag = "v1.0.0-beta.6", package = "identity_stronghold_ext" }
+did_manager_consumer = { git = "https://github.com/impierce/did-manager", rev = "00baa2a", package = "consumer" }
+did_manager_identity_stronghold_ext = { git = "https://github.com/impierce/did-manager", rev = "00baa2a", package = "identity_stronghold_ext" }
 
 anyhow.workspace = true
 async-trait.workspace = true
@@ -29,6 +29,7 @@ jsonwebtoken = "9.3"
 log = "0.4"
 oid4vc-core.workspace = true
 p256 = { version = "0.13", features = ["jwk"] }
+rustls.workspace = true
 serde.workspace = true
 tokio.workspace = true
 url.workspace = true

--- a/agent_secret_manager/Cargo.toml
+++ b/agent_secret_manager/Cargo.toml
@@ -13,9 +13,9 @@ agent_shared = { path = "../agent_shared" }
 # - All components of the `identity_stronghold_ext` module are still active.
 #
 # Future work: Migrate the remaining functionality into UniCore.
-did_manager_consumer = { path = "../../did-manager/consumer", package = "consumer" }
-did_manager_iota = { path = "../../did-manager/did_iota", package = "did_iota" }
-did_manager_identity_stronghold_ext = { path = "../../did-manager/identity_stronghold_ext", package = "identity_stronghold_ext" }
+did_manager_consumer = { git = "https://github.com/impierce/did-manager", rev = "b31deb3", package = "consumer" }
+did_manager_iota = { git = "https://github.com/impierce/did-manager", rev = "b31deb3", package = "did_iota" }
+did_manager_identity_stronghold_ext = { git = "https://github.com/impierce/did-manager", rev = "b31deb3", package = "identity_stronghold_ext" }
 
 anyhow.workspace = true
 async-trait.workspace = true
@@ -30,7 +30,11 @@ jsonwebtoken = "9.3"
 log = "0.4"
 oid4vc-core.workspace = true
 p256 = { version = "0.13", features = ["jwk"] }
-rustls.workspace = true
+rustls = { version = "0.23", default-features = false, features = [
+    "logging",
+    "std",
+    "tls12",
+] }
 serde.workspace = true
 tokio.workspace = true
 url.workspace = true

--- a/agent_secret_manager/Cargo.toml
+++ b/agent_secret_manager/Cargo.toml
@@ -13,8 +13,8 @@ agent_shared = { path = "../agent_shared" }
 # - All components of the `identity_stronghold_ext` module are still active.
 #
 # Future work: Migrate the remaining functionality into UniCore.
-did_manager_consumer = { git = "https://github.com/impierce/did-manager", rev = "00baa2a", package = "consumer" }
-did_manager_identity_stronghold_ext = { git = "https://github.com/impierce/did-manager", rev = "00baa2a", package = "identity_stronghold_ext" }
+did_manager_consumer = { path = "../../did-manager/consumer", package = "consumer" }
+did_manager_identity_stronghold_ext = { path = "../../did-manager/identity_stronghold_ext", package = "identity_stronghold_ext" }
 
 anyhow.workspace = true
 async-trait.workspace = true

--- a/agent_secret_manager/src/subject.rs
+++ b/agent_secret_manager/src/subject.rs
@@ -57,9 +57,9 @@ impl Subject {
         &mut self,
         tls_config: Option<rustls::ClientConfig>,
         node_url: Option<NodeUrls>,
-        set_user_password: Option<(&str, &str)>,
+        basic_auth: Option<(&str, &str)>,
     ) {
-        self.resolver = Resolver::new_with_options(tls_config, node_url, set_user_password).await;
+        self.resolver = Resolver::new_with_options(tls_config, node_url, basic_auth).await;
     }
 
     pub async fn get_public_key(&self, key_id: KeyId, algorithm: &Algorithm) -> anyhow::Result<Jwk> {

--- a/agent_secret_manager/src/subject.rs
+++ b/agent_secret_manager/src/subject.rs
@@ -21,6 +21,7 @@ use tokio::sync::Mutex;
 pub struct Subject {
     pub stronghold_storage: StrongholdExtStorage,
     pub verification_method_ids: Arc<Mutex<HashMap<StorageKey, DIDUrl>>>,
+    pub resolver: Resolver,
 }
 
 impl Subject {
@@ -31,6 +32,7 @@ impl Subject {
         Self {
             stronghold_storage,
             verification_method_ids: Arc::new(Mutex::new(HashMap::new())),
+            resolver: Resolver::new().await,
         }
     }
 
@@ -73,10 +75,8 @@ impl SubjectExt for Subject {
         let did_url =
             identity_iota::did::DIDUrl::parse(did_url).map_err(|err| anyhow!("Failed to parse DID URL: {err}"))?;
 
-        // TODO: Make sure the resolver only needs to be created once.
-        let resolver = Resolver::new().await;
-
-        let document = resolver
+        let document = self
+            .resolver
             .resolve(did_url.did().as_str())
             .await
             .map_err(|err| anyhow!("Failed to resolve DID Document for DID: `{did_url}`, error: {err}"))?;
@@ -139,6 +139,7 @@ mod default_subject {
                 Self {
                     stronghold_storage,
                     verification_method_ids,
+                    resolver: Resolver::new().await,
                 }
             })
         }
@@ -151,10 +152,8 @@ impl Verify for Subject {
         let did_url =
             identity_iota::did::DIDUrl::parse(did_url).map_err(|err| anyhow!("Failed to parse DID URL: {err}"))?;
 
-        // TODO: Make sure the resolver only needs to be created once.
-        let resolver = Resolver::new().await;
-
-        let document = resolver
+        let document = self
+            .resolver
             .resolve(did_url.did().as_str())
             .await
             .map_err(|err| anyhow!("Failed to resolve DID Document for DID: `{did_url}`, error: {err}"))?;

--- a/agent_secret_manager/src/subject.rs
+++ b/agent_secret_manager/src/subject.rs
@@ -352,7 +352,7 @@ mod tests {
             devnet: Some("https://indexer.devnet.iota.cafe".to_string()),
             testnet: Some("https://rpc.ankr.com/iota_testnet".to_string()),
         });
-        subject.configure_resolver(node_urls, None, None).await;
+        subject.configure_resolver(None, node_urls, None).await;
 
         subject
             .resolver

--- a/agent_secret_manager/src/subject.rs
+++ b/agent_secret_manager/src/subject.rs
@@ -335,7 +335,7 @@ mod tests {
             .unwrap();
         subject
             .resolver
-            .resolve("did:iota:testnet:0xe4edef97da1257e83cbeb49159cfdd2da6ac971ac447f233f8439cf29376ebfe")
+            .resolve("did:iota:testnet:0x04b26f82ba06c22a3ed57069cc349239bccd972fbb24ac5a7e0db6a0b9c42292")
             .await
             .unwrap();
     }

--- a/agent_secret_manager/src/subject.rs
+++ b/agent_secret_manager/src/subject.rs
@@ -30,6 +30,7 @@ impl Subject {
     pub async fn new() -> Self {
         let stronghold_storage = stronghold_storage().await;
 
+        // TODO: all networks are set to the same node URL ==> introduce per-network configuration?
         let node_urls = NodeUrls {
             mainnet: config().iota_node_url.clone(),
             testnet: config().iota_node_url.clone(),

--- a/agent_secret_manager/src/subject.rs
+++ b/agent_secret_manager/src/subject.rs
@@ -49,16 +49,6 @@ impl Subject {
         }
     }
 
-    /// If no node URLs are provided, the resolver will use the default IOTA node URLs.
-    pub async fn configure_resolver(
-        &mut self,
-        tls_config: Option<rustls::ClientConfig>,
-        node_url: Option<NodeUrls>,
-        basic_auth: Option<(&str, &str)>,
-    ) {
-        self.resolver = Resolver::new_with_options(tls_config, node_url, basic_auth).await;
-    }
-
     pub async fn get_public_key(&self, key_id: KeyId, algorithm: &Algorithm) -> anyhow::Result<Jwk> {
         match algorithm {
             Algorithm::EdDSA => self.stronghold_storage.get_ed25519_public_key(&key_id).await,
@@ -339,27 +329,5 @@ mod tests {
         // Verify the signature
         let public_key = UnparsedPublicKey::new(&ED25519, public_key_bytes);
         assert!(public_key.verify(message.as_bytes(), &signature_bytes).is_ok());
-    }
-
-    #[tokio::test]
-    async fn test_configure_resolver_node_urls() {
-        let mut subject = Subject::new().await;
-        let node_urls = Some(NodeUrls {
-            mainnet: Some("https://rpc.mainnet.iota.monochain.p2p.org/".to_string()),
-            devnet: Some("https://indexer.devnet.iota.cafe".to_string()),
-            testnet: Some("https://rpc.ankr.com/iota_testnet".to_string()),
-        });
-        subject.configure_resolver(None, node_urls, None).await;
-
-        subject
-            .resolver
-            .resolve("did:key:z6MkgE84NCMpMeAx9jK9cf5W4G8gcZ9xuwJvG1e7wNk8KCgt")
-            .await
-            .unwrap();
-        subject
-            .resolver
-            .resolve("did:iota:testnet:0x04b26f82ba06c22a3ed57069cc349239bccd972fbb24ac5a7e0db6a0b9c42292")
-            .await
-            .unwrap();
     }
 }

--- a/agent_secret_manager/src/subject.rs
+++ b/agent_secret_manager/src/subject.rs
@@ -32,8 +32,12 @@ impl Subject {
         Self {
             stronghold_storage,
             verification_method_ids: Arc::new(Mutex::new(HashMap::new())),
-            resolver: Resolver::new().await,
+            resolver: Resolver::new(None, None).await,
         }
+    }
+
+    pub async fn configure_resolver(&mut self, node_url: Option<&str>, tls_config: Option<rustls::ClientConfig>) {
+        self.resolver = Resolver::new(node_url, tls_config).await;
     }
 
     pub async fn get_public_key(&self, key_id: KeyId, algorithm: &Algorithm) -> anyhow::Result<Jwk> {
@@ -139,7 +143,7 @@ mod default_subject {
                 Self {
                     stronghold_storage,
                     verification_method_ids,
-                    resolver: Resolver::new().await,
+                    resolver: Resolver::new(None, None).await,
                 }
             })
         }

--- a/agent_secret_manager/src/subject.rs
+++ b/agent_secret_manager/src/subject.rs
@@ -48,18 +48,18 @@ impl Subject {
         Self {
             stronghold_storage,
             verification_method_ids: Arc::new(Mutex::new(HashMap::new())),
-            resolver: Resolver::new(Some(node_urls), None, username_password).await,
+            resolver: Resolver::new_with_options(None, Some(node_urls), username_password).await,
         }
     }
 
     /// If no node URLs are provided, the resolver will use the default IOTA node URLs.
     pub async fn configure_resolver(
         &mut self,
-        node_url: Option<NodeUrls>,
         tls_config: Option<rustls::ClientConfig>,
+        node_url: Option<NodeUrls>,
         set_user_password: Option<(&str, &str)>,
     ) {
-        self.resolver = Resolver::new(node_url, tls_config, set_user_password).await;
+        self.resolver = Resolver::new_with_options(tls_config, node_url, set_user_password).await;
     }
 
     pub async fn get_public_key(&self, key_id: KeyId, algorithm: &Algorithm) -> anyhow::Result<Jwk> {
@@ -165,7 +165,7 @@ mod default_subject {
                 Self {
                     stronghold_storage,
                     verification_method_ids,
-                    resolver: Resolver::new(None, None, None).await,
+                    resolver: Resolver::new().await,
                 }
             })
         }

--- a/agent_secret_manager/src/subject.rs
+++ b/agent_secret_manager/src/subject.rs
@@ -32,17 +32,14 @@ impl Subject {
 
         let node_urls = NodeUrls {
             mainnet: config().iota_node_url.clone(),
-            devnet: config().iota_node_url.clone(),
             testnet: config().iota_node_url.clone(),
+            devnet: config().iota_node_url.clone(),
         };
 
-        let config_username = config().iota_node_username.clone();
-        let config_password = config().iota_node_password.clone();
-
-        let username_password = match (config_username, config_password) {
-            (Some(username), Some(password)) => Some((username, password)),
-            _ => None,
-        };
+        let username_password = config()
+            .iota_node_username
+            .clone()
+            .zip(config().iota_node_password.clone());
         let username_password = username_password.as_ref().map(|(u, p)| (u.as_str(), p.as_str()));
 
         Self {

--- a/agent_secret_manager/src/subject.rs
+++ b/agent_secret_manager/src/subject.rs
@@ -5,6 +5,7 @@ use async_trait::async_trait;
 use base64::{engine::general_purpose::URL_SAFE_NO_PAD, Engine};
 use did_manager_consumer::resolver::Resolver;
 use did_manager_identity_stronghold_ext::StrongholdExtStorage;
+use did_manager_iota::consumer::NodeUrls;
 use identity_iota::did::DIDUrl;
 use identity_iota::storage::{JwkStorage, KeyId};
 use identity_iota::verification::jwk::Jwk;
@@ -29,15 +30,36 @@ impl Subject {
     pub async fn new() -> Self {
         let stronghold_storage = stronghold_storage().await;
 
+        let node_urls = NodeUrls {
+            mainnet: config().iota_node_url.clone(),
+            devnet: config().iota_node_url.clone(),
+            testnet: config().iota_node_url.clone(),
+        };
+
+        let config_username = config().iota_node_username.clone();
+        let config_password = config().iota_node_password.clone();
+
+        let username_password = match (config_username, config_password) {
+            (Some(username), Some(password)) => Some((username, password)),
+            _ => None,
+        };
+        let username_password = username_password.as_ref().map(|(u, p)| (u.as_str(), p.as_str()));
+
         Self {
             stronghold_storage,
             verification_method_ids: Arc::new(Mutex::new(HashMap::new())),
-            resolver: Resolver::new(None, None).await,
+            resolver: Resolver::new(Some(node_urls), None, username_password).await,
         }
     }
 
-    pub async fn configure_resolver(&mut self, node_url: Option<&str>, tls_config: Option<rustls::ClientConfig>) {
-        self.resolver = Resolver::new(node_url, tls_config).await;
+    /// If no node URLs are provided, the resolver will use the default IOTA node URLs.
+    pub async fn configure_resolver(
+        &mut self,
+        node_url: Option<NodeUrls>,
+        tls_config: Option<rustls::ClientConfig>,
+        set_user_password: Option<(&str, &str)>,
+    ) {
+        self.resolver = Resolver::new(node_url, tls_config, set_user_password).await;
     }
 
     pub async fn get_public_key(&self, key_id: KeyId, algorithm: &Algorithm) -> anyhow::Result<Jwk> {
@@ -143,7 +165,7 @@ mod default_subject {
                 Self {
                     stronghold_storage,
                     verification_method_ids,
-                    resolver: Resolver::new(None, None).await,
+                    resolver: Resolver::new(None, None, None).await,
                 }
             })
         }
@@ -323,9 +345,14 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn test_configure_resolver() {
+    async fn test_configure_resolver_node_urls() {
         let mut subject = Subject::new().await;
-        subject.configure_resolver(Some("https://api.iota.mainnet.dlt.green/"), None).await;
+        let node_urls = Some(NodeUrls {
+            mainnet: Some("https://rpc.mainnet.iota.monochain.p2p.org/".to_string()),
+            devnet: Some("https://indexer.devnet.iota.cafe".to_string()),
+            testnet: Some("https://rpc.ankr.com/iota_testnet".to_string()),
+        });
+        subject.configure_resolver(node_urls, None, None).await;
 
         subject
             .resolver

--- a/agent_secret_manager/src/subject.rs
+++ b/agent_secret_manager/src/subject.rs
@@ -321,4 +321,22 @@ mod tests {
         let public_key = UnparsedPublicKey::new(&ED25519, public_key_bytes);
         assert!(public_key.verify(message.as_bytes(), &signature_bytes).is_ok());
     }
+
+    #[tokio::test]
+    async fn test_configure_resolver() {
+        let mut subject = Subject::new().await;
+        // TODO: find a node_url for testing
+        subject.configure_resolver(None, None).await;
+
+        subject
+            .resolver
+            .resolve("did:key:z6MkgE84NCMpMeAx9jK9cf5W4G8gcZ9xuwJvG1e7wNk8KCgt")
+            .await
+            .unwrap();
+        subject
+            .resolver
+            .resolve("did:iota:testnet:0xe4edef97da1257e83cbeb49159cfdd2da6ac971ac447f233f8439cf29376ebfe")
+            .await
+            .unwrap();
+    }
 }

--- a/agent_secret_manager/src/subject.rs
+++ b/agent_secret_manager/src/subject.rs
@@ -325,8 +325,7 @@ mod tests {
     #[tokio::test]
     async fn test_configure_resolver() {
         let mut subject = Subject::new().await;
-        // TODO: find a node_url for testing
-        subject.configure_resolver(None, None).await;
+        subject.configure_resolver(Some("https://api.iota.mainnet.dlt.green/"), None).await;
 
         subject
             .resolver


### PR DESCRIPTION
# Description of change
Since did-manager repo has also been updated to allow for configuring the IOTA node url used by the Resolver, this repo also needed a few small updates to allow for the updates in did-manager to be used in this repo.

Blocked by:
- https://github.com/impierce/did-manager/pull/41

After the blocking PR is merged also the Cargo.toml refs need to be updated in this PR

## Links to any relevant issues

## How the change has been tested
A new unit test has been added.
Old tests still pass.

## Definition of Done checklist
Add an `x` to the boxes that are relevant to your changes.

- [x] I have followed the contribution guidelines for this project
- [ ] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] I have successfully tested this change in a docker environment 
