### PR TITLE
fix: check for sponsoring service config during DID update

### DIFF
--- a/agent_identity/src/state.rs
+++ b/agent_identity/src/state.rs
@@ -423,7 +423,7 @@ pub async fn initialize_domain_linkage(state: &IdentityState) -> anyhow::Result<
             && document
                 .iota_metadata
                 .as_ref()
-                .map(|iota_metadata| iota_metadata.is_funded)
+                .map(|iota_metadata| iota_metadata.is_funded || config().iota_sponsoring_service_url.is_some())
                 .unwrap_or(true)
     })
     .await?;


### PR DESCRIPTION
# Description of change

During a DID update, not only the current funding of the address is checked, but also if a sponsoring service is configured that could fund the transaction.

## Links to any relevant issues
n/a

## How the change has been tested
Describe the tests that you ran to verify your changes.
Make sure to provide instructions for the maintainer as well as any relevant configurations.

## Definition of Done checklist
Add an `x` to the boxes that are relevant to your changes.

- [x] I have followed the contribution guidelines for this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] I have successfully tested this change in a docker environment 
