### PR TITLE
feat: toggle nonce validation checks

### DIFF
--- a/agent_api_http/src/v0/issuance/credential_issuer/credential.rs
+++ b/agent_api_http/src/v0/issuance/credential_issuer/credential.rs
@@ -26,7 +26,7 @@ use oid4vci::errors::CredentialErrorResponse;
 use oid4vci::Proof;
 use std::sync::Arc;
 use tokio::time::sleep;
-use tracing::error;
+use tracing::{error, info};
 
 const POLLING_INTERVAL_MS: u64 = 100;
 
@@ -59,31 +59,35 @@ pub(crate) async fn credential(
         .and_then(|claims| claims.issuer_state)
         .ok_or_else(|| PublicError::from(CredentialErrorResponse::InvalidToken))?;
 
-    if let Some(proof) = &credential_request.proof {
-        if let Some(nonce) = extract_nonce_from_proof(proof) {
-            // Query nonce state
-            let nonce_status = query_handler(&nonce, &state.query.nonce)
-                .await
-                .map_err(|_| PublicError::from(CredentialErrorResponse::InvalidProof))?;
+    if !config().skip_nonce_validation {
+        if let Some(proof) = &credential_request.proof {
+            if let Some(nonce) = extract_nonce_from_proof(proof) {
+                // Query nonce state
+                let nonce_status = query_handler(&nonce, &state.query.nonce)
+                    .await
+                    .map_err(|_| PublicError::from(CredentialErrorResponse::InvalidProof))?;
 
-            match nonce_status {
-                Some(n) if n.is_redeemed => {
-                    // Nonce has already been redeemed
-                    return Err(PublicError::from(CredentialErrorResponse::InvalidNonce));
-                }
-                Some(_) => {
-                    // Nonce is valid, redeem it
-                    let command = NonceCommand::RedeemNonce { c_nonce: nonce.clone() };
-                    command_handler(&nonce, &state.command.nonce, command)
-                        .await
-                        .map_err(|_| PublicError::from(CredentialErrorResponse::InvalidProof))?;
-                }
-                None => {
-                    // Nonce doesn't exist
-                    return Err(PublicError::from(CredentialErrorResponse::InvalidNonce));
+                match nonce_status {
+                    Some(n) if n.is_redeemed => {
+                        // Nonce has already been redeemed
+                        return Err(PublicError::from(CredentialErrorResponse::InvalidNonce));
+                    }
+                    Some(_) => {
+                        // Nonce is valid, redeem it
+                        let command = NonceCommand::RedeemNonce { c_nonce: nonce.clone() };
+                        command_handler(&nonce, &state.command.nonce, command)
+                            .await
+                            .map_err(|_| PublicError::from(CredentialErrorResponse::InvalidProof))?;
+                    }
+                    None => {
+                        // Nonce doesn't exist
+                        return Err(PublicError::from(CredentialErrorResponse::InvalidNonce));
+                    }
                 }
             }
         }
+    } else {
+        info!("Skipping nonce validation for credential requests");
     }
 
     // Get the `credential_issuer_metadata` and `authorization_server_metadata` from the `ServerConfigView`.

--- a/agent_shared/src/config/mod.rs
+++ b/agent_shared/src/config/mod.rs
@@ -320,6 +320,8 @@ pub struct ApplicationConfiguration {
     #[config(default)]
     #[serde(serialize_with = "redact")]
     pub iota_sponsoring_service_auth: Option<String>,
+    #[config(default)]
+    pub skip_nonce_validation: bool,
 }
 
 impl ApplicationConfiguration {
@@ -1106,6 +1108,7 @@ mod tests {
                   "kb-jwt_alg_values": ["ES256"]
                 }
               },
+              "skip_nonce_validation": false,
             })
         );
 


### PR DESCRIPTION
# Description of change
In some instances, such as when issuing batch credentials, we may want to disable the need to validate the nonces during credential requests as producing a fresh c_nonce for multiple credentials in quick succession can be cumbersome. In such situations, it may be beneficial to bypass nonce validation entirely. This PR introduces a `skip_nonce_validation` toggle to the config file which defaults, as it should, to false. 

## Links to any relevant issues
Be sure to reference any related issues by adding `fixes issue #`.

## How the change has been tested
Describe the tests that you ran to verify your changes.
Make sure to provide instructions for the maintainer as well as any relevant configurations.

## Definition of Done checklist
Add an `x` to the boxes that are relevant to your changes.

- [x] I have followed the contribution guidelines for this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have successfully tested this change in a docker environment 
