### PR TITLE
test: replace blocking `Subject::default()` with async initialization

### DIFF
--- a/.github/workflows/format-lint-test.yaml
+++ b/.github/workflows/format-lint-test.yaml
@@ -26,4 +26,6 @@ jobs:
         run: cargo clippy --all-targets --all-features -- -D warnings
 
       - name: Test
+        # TODO: We set `RUST_MIN_STACK` to 16 MiB to prevent stack overflow in `test_verify_credential_response`.
+        # Investigate if this is still needed after our testing refactor.
         run: RUST_MIN_STACK=16777216 cargo test --workspace

--- a/.github/workflows/format-lint-test.yaml
+++ b/.github/workflows/format-lint-test.yaml
@@ -26,4 +26,4 @@ jobs:
         run: cargo clippy --all-targets --all-features -- -D warnings
 
       - name: Test
-        run: cargo test --workspace
+        run: RUST_MIN_STACK=16777216 cargo test --workspace

--- a/agent_api_http/src/v0/authorization/authorization_server/authorize.rs
+++ b/agent_api_http/src/v0/authorization/authorization_server/authorize.rs
@@ -39,7 +39,9 @@ pub mod tests {
     use crate::v0::issuance::credentials::tests::credentials;
     use crate::v0::issuance::offers::tests::offers;
     use crate::v0::{authorization, issuance};
+    use agent_authorization::services::AuthorizationServices;
     use agent_authorization::state::UNIME_CLIENT_ID;
+    use agent_issuance::services::IssuanceServices;
     use agent_secret_manager::service::Service;
     use agent_store::in_memory::InMemory;
     use agent_store::{authorization_state, issuance_state};
@@ -110,7 +112,8 @@ pub mod tests {
     #[serial_test::serial]
     #[tokio::test]
     async fn test_authorization_endpoint() {
-        let issuance_state = Arc::new(issuance_state(&InMemory, Service::default(), Default::default()).await);
+        let issuance_state =
+            Arc::new(issuance_state(&InMemory, IssuanceServices::default().await, Default::default()).await);
 
         agent_issuance::state::initialize(&issuance_state).await.unwrap();
 
@@ -122,7 +125,7 @@ pub mod tests {
         let issuer_state = issuer_state.unwrap();
 
         let authorization_state =
-            Arc::new(authorization_state(&InMemory, Service::default(), Default::default()).await);
+            Arc::new(authorization_state(&InMemory, AuthorizationServices::default().await, Default::default()).await);
         agent_authorization::state::initialize(&authorization_state)
             .await
             .unwrap();

--- a/agent_api_http/src/v0/authorization/authorization_server/par.rs
+++ b/agent_api_http/src/v0/authorization/authorization_server/par.rs
@@ -30,10 +30,11 @@ pub mod tests {
         authorization,
         issuance::{self, credentials::tests::credentials, offers::tests::offers},
     };
-    use agent_authorization::state::UNIME_CLIENT_ID;
     use agent_authorization::{
         domain::oauth2_authorization_request::aggregate::test_utils::code_challenge, state::UNIME_REDIRECT_URI,
     };
+    use agent_authorization::{services::AuthorizationServices, state::UNIME_CLIENT_ID};
+    use agent_issuance::services::IssuanceServices;
     use agent_secret_manager::service::Service;
     use agent_store::{authorization_state, in_memory::InMemory, issuance_state};
     use axum::{
@@ -104,7 +105,8 @@ pub mod tests {
     #[serial_test::serial]
     #[tokio::test]
     async fn test_pushed_authorization_request_endpoint() {
-        let issuance_state = Arc::new(issuance_state(&InMemory, Service::default(), Default::default()).await);
+        let issuance_state =
+            Arc::new(issuance_state(&InMemory, IssuanceServices::default().await, Default::default()).await);
 
         agent_issuance::state::initialize(&issuance_state).await.unwrap();
 
@@ -116,7 +118,7 @@ pub mod tests {
         let issuer_state = issuer_state.unwrap();
 
         let authorization_state =
-            Arc::new(authorization_state(&InMemory, Service::default(), Default::default()).await);
+            Arc::new(authorization_state(&InMemory, AuthorizationServices::default().await, Default::default()).await);
         agent_authorization::state::initialize(&authorization_state)
             .await
             .unwrap();

--- a/agent_api_http/src/v0/authorization/authorization_server/token.rs
+++ b/agent_api_http/src/v0/authorization/authorization_server/token.rs
@@ -36,10 +36,12 @@ pub mod tests {
         },
         issuance::{self, credentials::tests::credentials, offers::tests::offers},
     };
+    use agent_authorization::services::AuthorizationServices;
     use agent_authorization::state::UNIME_CLIENT_ID;
     use agent_authorization::{
         domain::oauth2_authorization_request::aggregate::test_utils::code_verifier, state::UNIME_REDIRECT_URI,
     };
+    use agent_issuance::services::IssuanceServices;
     use agent_secret_manager::service::Service;
     use agent_store::{authorization_state, in_memory::InMemory, issuance_state};
     use axum::{
@@ -139,7 +141,8 @@ pub mod tests {
     #[serial_test::serial]
     #[tokio::test]
     async fn test_token_endpoint(#[case] is_pre_authorized: bool) {
-        let issuance_state = Arc::new(issuance_state(&InMemory, Service::default(), Default::default()).await);
+        let issuance_state =
+            Arc::new(issuance_state(&InMemory, IssuanceServices::default().await, Default::default()).await);
 
         agent_issuance::state::initialize(&issuance_state).await.unwrap();
 
@@ -155,7 +158,7 @@ pub mod tests {
         let grants = offers(&mut app, &credential_configuration_id).await.unwrap();
 
         let authorization_state =
-            Arc::new(authorization_state(&InMemory, Service::default(), Default::default()).await);
+            Arc::new(authorization_state(&InMemory, AuthorizationServices::default().await, Default::default()).await);
 
         agent_authorization::state::initialize(&authorization_state)
             .await

--- a/agent_api_http/src/v0/identity/services/linked_vp.rs
+++ b/agent_api_http/src/v0/identity/services/linked_vp.rs
@@ -71,7 +71,7 @@ pub(crate) async fn linked_vp(
             service: Box::new(linked_verifiable_presentation_service.clone()),
         };
 
-        command_handler(&document_id, &state.command.document, command).await?;
+        command_handler(document_id, &state.command.document, command).await?;
     }
 
     publish_decentrally_hosted_documents(&state)

--- a/agent_api_http/src/v0/issuance/credential_issuer/credential.rs
+++ b/agent_api_http/src/v0/issuance/credential_issuer/credential.rs
@@ -147,9 +147,11 @@ pub mod tests {
         v0::issuance::{credentials::CredentialsEndpointRequest, offers::tests::offers},
     };
 
+    use agent_authorization::services::AuthorizationServices;
     use agent_event_publisher_http::EventPublisherHttp;
     use agent_issuance::credential::aggregate::CredentialExpiry;
     use agent_issuance::offer::event::OfferEvent;
+    use agent_issuance::services::IssuanceServices;
     use agent_secret_manager::service::Service;
     use agent_shared::config::{set_config, Events};
     use agent_store::authorization_state;
@@ -352,7 +354,8 @@ pub mod tests {
             (None, Default::default())
         };
 
-        let issuance_state = Arc::new(issuance_state(&InMemory, Service::default(), issuance_event_publishers).await);
+        let issuance_state =
+            Arc::new(issuance_state(&InMemory, IssuanceServices::default().await, issuance_event_publishers).await);
         agent_issuance::state::initialize(&issuance_state).await.unwrap();
 
         let mut issuance_app = router(issuance_state.clone());
@@ -383,7 +386,7 @@ pub mod tests {
         let grants = offers(&mut issuance_app, &credential_configuration_id).await.unwrap();
 
         let authorization_state =
-            Arc::new(authorization_state(&InMemory, Service::default(), Default::default()).await);
+            Arc::new(authorization_state(&InMemory, AuthorizationServices::default().await, Default::default()).await);
         agent_authorization::state::initialize(&authorization_state)
             .await
             .unwrap();

--- a/agent_api_http/src/v0/issuance/credential_issuer/notification.rs
+++ b/agent_api_http/src/v0/issuance/credential_issuer/notification.rs
@@ -68,6 +68,8 @@ mod tests {
     use crate::v0::issuance::credentials::tests::credentials;
     use crate::v0::issuance::offers::tests::offers;
     use crate::v0::{authorization, issuance};
+    use agent_authorization::services::AuthorizationServices;
+    use agent_issuance::services::IssuanceServices;
     use agent_secret_manager::service::Service;
     use agent_store::in_memory::InMemory;
     use agent_store::{authorization_state, issuance_state};
@@ -80,7 +82,8 @@ mod tests {
     #[serial_test::serial]
     #[tokio::test]
     async fn test_valid_notification_request() {
-        let issuance_state = Arc::new(issuance_state(&InMemory, Service::default(), Default::default()).await);
+        let issuance_state =
+            Arc::new(issuance_state(&InMemory, IssuanceServices::default().await, Default::default()).await);
         agent_issuance::state::initialize(&issuance_state).await.unwrap();
         let mut issuance_app = issuance::router(issuance_state.clone());
 
@@ -88,7 +91,7 @@ mod tests {
         let grants = offers(&mut issuance_app, "001").await.unwrap();
 
         let authorization_state =
-            Arc::new(authorization_state(&InMemory, Service::default(), Default::default()).await);
+            Arc::new(authorization_state(&InMemory, AuthorizationServices::default().await, Default::default()).await);
         agent_authorization::state::initialize(&authorization_state)
             .await
             .unwrap();
@@ -119,7 +122,8 @@ mod tests {
 
     #[tokio::test]
     async fn test_invalid_notification_request() {
-        let issuance_state = Arc::new(issuance_state(&InMemory, Service::default(), Default::default()).await);
+        let issuance_state =
+            Arc::new(issuance_state(&InMemory, IssuanceServices::default().await, Default::default()).await);
         agent_issuance::state::initialize(&issuance_state).await.unwrap();
         let mut issuance_app = issuance::router(issuance_state.clone());
 
@@ -127,7 +131,7 @@ mod tests {
         let grants = offers(&mut issuance_app, "001").await.unwrap();
 
         let authorization_state =
-            Arc::new(authorization_state(&InMemory, Service::default(), Default::default()).await);
+            Arc::new(authorization_state(&InMemory, AuthorizationServices::default().await, Default::default()).await);
         agent_authorization::state::initialize(&authorization_state)
             .await
             .unwrap();

--- a/agent_api_http/src/v0/issuance/credential_issuer/token_status_list.rs
+++ b/agent_api_http/src/v0/issuance/credential_issuer/token_status_list.rs
@@ -41,7 +41,7 @@ pub async fn token_status_list(
 pub mod tests {
     use std::sync::Arc;
 
-    use agent_issuance::state::initialize;
+    use agent_issuance::{services::IssuanceServices, state::initialize};
     use agent_secret_manager::{service::Service, subject::Subject};
     use agent_shared::config::{config, BITS_PER_STATUS, STATUS_LIST_BYTES_AMOUNT};
     use agent_store::{in_memory::InMemory, issuance_state};
@@ -61,10 +61,10 @@ pub mod tests {
     /// The remainder of the test breaks down the Token Status List response in various steps and checks these steps one by one.
     #[tokio::test]
     pub async fn test_token_status_list() {
-        let issuance_state = Arc::new(issuance_state(&InMemory, Service::default(), Default::default()).await);
+        let issuance_state = Arc::new(issuance_state(&InMemory, IssuanceServices::default().await, vec![]).await);
         initialize(&issuance_state).await.unwrap();
 
-        let relying_party_state = Subject::default();
+        let relying_party_state = Subject::test_subject().await;
 
         let mut app = router(issuance_state);
 

--- a/agent_api_http/src/v0/issuance/credential_issuer/well_known/oauth_authorization_server.rs
+++ b/agent_api_http/src/v0/issuance/credential_issuer/well_known/oauth_authorization_server.rs
@@ -27,7 +27,7 @@ pub(crate) async fn oauth_authorization_server(State(state): State<Arc<IssuanceS
 mod tests {
     use super::*;
     use crate::v0::issuance::router;
-    use agent_issuance::state::initialize;
+    use agent_issuance::{services::IssuanceServices, state::initialize};
     use agent_secret_manager::service::Service;
     use agent_store::{in_memory::InMemory, issuance_state};
     use axum::{
@@ -74,7 +74,8 @@ mod tests {
 
     #[tokio::test]
     async fn test_oauth_authorization_server_endpoint() {
-        let issuance_state = Arc::new(issuance_state(&InMemory, Service::default(), Default::default()).await);
+        let issuance_state =
+            Arc::new(issuance_state(&InMemory, IssuanceServices::default().await, Default::default()).await);
         initialize(&issuance_state).await.unwrap();
 
         let mut app = router(issuance_state);

--- a/agent_api_http/src/v0/issuance/credential_issuer/well_known/openid_credential_issuer.rs
+++ b/agent_api_http/src/v0/issuance/credential_issuer/well_known/openid_credential_issuer.rs
@@ -34,7 +34,7 @@ pub(crate) async fn openid_credential_issuer(State(state): State<Arc<IssuanceSta
 mod tests {
     use super::*;
     use crate::{tests::CREDENTIAL_ISSUER_METADATA, v0::issuance::router};
-    use agent_issuance::state::initialize;
+    use agent_issuance::{services::IssuanceServices, state::initialize};
     use agent_secret_manager::service::Service;
     use agent_store::{in_memory::InMemory, issuance_state};
     use axum::{
@@ -71,7 +71,8 @@ mod tests {
 
     #[tokio::test]
     async fn test_openid_credential_issuer_endpoint() {
-        let issuance_state = Arc::new(issuance_state(&InMemory, Service::default(), Default::default()).await);
+        let issuance_state =
+            Arc::new(issuance_state(&InMemory, IssuanceServices::default().await, Default::default()).await);
         initialize(&issuance_state).await.unwrap();
 
         let mut app = router(issuance_state);

--- a/agent_api_http/src/v0/issuance/credentials.rs
+++ b/agent_api_http/src/v0/issuance/credentials.rs
@@ -247,7 +247,7 @@ pub mod tests {
     use crate::tests::OFFER_ID;
     use crate::v0::issuance::router;
     use crate::API_VERSION;
-    use agent_issuance::state::initialize;
+    use agent_issuance::{services::IssuanceServices, state::initialize};
     use agent_secret_manager::service::Service;
     use agent_secret_manager::subject::Subject;
     use agent_store::in_memory::InMemory;
@@ -355,7 +355,7 @@ pub mod tests {
     pub async fn patch_credential(app: &mut Router) {
         let credential_endpoint = credentials(app, "001").await;
 
-        let relying_party_state = Subject::default();
+        let relying_party_state = Subject::test_subject().await;
 
         let patch_response = app
             .call(
@@ -412,7 +412,8 @@ pub mod tests {
 
     #[tokio::test]
     async fn test_patch_credential() {
-        let issuance_state = Arc::new(issuance_state(&InMemory, Service::default(), Default::default()).await);
+        let issuance_state =
+            Arc::new(issuance_state(&InMemory, IssuanceServices::default().await, Default::default()).await);
         initialize(&issuance_state).await.unwrap();
 
         let mut app = router(issuance_state);
@@ -423,7 +424,8 @@ pub mod tests {
     #[tokio::test]
     #[tracing_test::traced_test]
     async fn test_credentials_endpoint() {
-        let issuance_state = Arc::new(issuance_state(&InMemory, Service::default(), Default::default()).await);
+        let issuance_state =
+            Arc::new(issuance_state(&InMemory, IssuanceServices::default().await, Default::default()).await);
         initialize(&issuance_state).await.unwrap();
 
         let mut app = router(issuance_state);

--- a/agent_api_http/src/v0/issuance/offers/mod.rs
+++ b/agent_api_http/src/v0/issuance/offers/mod.rs
@@ -136,6 +136,7 @@ pub mod tests {
         tests::OFFER_ID,
         v0::issuance::{credentials::tests::credentials, router},
     };
+    use agent_issuance::services::IssuanceServices;
     use agent_issuance::state::initialize;
     use agent_secret_manager::service::Service;
     use agent_shared::config::set_config;
@@ -223,7 +224,8 @@ pub mod tests {
     #[tokio::test]
     #[tracing_test::traced_test]
     async fn test_offers_endpoint() {
-        let issuance_state = Arc::new(issuance_state(&InMemory, Service::default(), Default::default()).await);
+        let issuance_state =
+            Arc::new(issuance_state(&InMemory, IssuanceServices::default().await, Default::default()).await);
         initialize(&issuance_state).await.unwrap();
 
         let mut app = router(issuance_state);
@@ -237,7 +239,8 @@ pub mod tests {
     #[tracing_test::traced_test]
     async fn test_offers_endpoint_by_reference() {
         set_config().credential_offer_by_value_enabled = false;
-        let issuance_state = Arc::new(issuance_state(&InMemory, Service::default(), Default::default()).await);
+        let issuance_state =
+            Arc::new(issuance_state(&InMemory, IssuanceServices::default().await, Default::default()).await);
         initialize(&issuance_state).await.unwrap();
 
         let mut app = router(issuance_state);

--- a/agent_api_http/src/v0/verification/authorization_requests.rs
+++ b/agent_api_http/src/v0/verification/authorization_requests.rs
@@ -108,6 +108,7 @@ pub mod tests {
     use agent_secret_manager::service::Service;
     use agent_store::in_memory::InMemory;
     use agent_store::verification_state;
+    use agent_verification::services::VerificationServices;
     use axum::{
         body::Body,
         http::{self, Request},
@@ -196,7 +197,8 @@ pub mod tests {
     #[tracing_test::traced_test]
     #[tokio::test]
     async fn test_authorization_requests_endpoint() {
-        let verification_state = Arc::new(verification_state(&InMemory, Service::default(), Default::default()).await);
+        let verification_state =
+            Arc::new(verification_state(&InMemory, VerificationServices::default().await, Default::default()).await);
         let mut app = router(verification_state);
 
         let result = authorization_requests(&mut app).await;

--- a/agent_api_http/src/v0/verification/relying_party/redirect.rs
+++ b/agent_api_http/src/v0/verification/relying_party/redirect.rs
@@ -67,6 +67,7 @@ pub mod tests {
     use agent_secret_manager::{service::Service, subject::Subject};
     use agent_shared::config::{set_config, Events};
     use agent_store::{in_memory::InMemory, verification_state, EventPublisher};
+    use agent_verification::services::VerificationServices;
     use axum::{
         body::Body,
         http::{self, Request},
@@ -109,8 +110,12 @@ pub mod tests {
             .build()
             .unwrap();
 
-        let provider_manager =
-            ProviderManager::new(Arc::new(Subject::default()), vec!["did:key"], vec![Algorithm::EdDSA]).unwrap();
+        let provider_manager = ProviderManager::new(
+            Arc::new(Subject::test_subject().await),
+            vec!["did:key"],
+            vec![Algorithm::EdDSA],
+        )
+        .unwrap();
         let authorization_response = provider_manager
             .generate_response(&authorization_request, Default::default())
             .await
@@ -158,7 +163,8 @@ pub mod tests {
 
         let event_publishers = vec![Box::new(EventPublisherHttp::load().unwrap()) as Box<dyn EventPublisher>];
 
-        let verification_state = Arc::new(verification_state(&InMemory, Service::default(), event_publishers).await);
+        let verification_state =
+            Arc::new(verification_state(&InMemory, VerificationServices::default().await, event_publishers).await);
 
         let mut app = router(verification_state);
 

--- a/agent_api_http/src/v0/verification/relying_party/request.rs
+++ b/agent_api_http/src/v0/verification/relying_party/request.rs
@@ -38,6 +38,7 @@ pub mod tests {
     use crate::v0::verification::router;
     use agent_secret_manager::service::Service;
     use agent_store::{in_memory::InMemory, verification_state};
+    use agent_verification::services::VerificationServices;
     use axum::{
         body::Body,
         http::{self, Request},
@@ -74,7 +75,8 @@ pub mod tests {
     #[tokio::test]
     #[tracing_test::traced_test]
     async fn test_request_endpoint() {
-        let verification_state = Arc::new(verification_state(&InMemory, Service::default(), Default::default()).await);
+        let verification_state =
+            Arc::new(verification_state(&InMemory, VerificationServices::default().await, Default::default()).await);
 
         let mut app = router(verification_state);
 

--- a/agent_holder/src/credential/aggregate.rs
+++ b/agent_holder/src/credential/aggregate.rs
@@ -119,7 +119,7 @@ pub mod credential_tests {
     #[rstest]
     #[serial_test::serial]
     async fn test_add_credential(holder_credential_id: String, received_offer_id: String) {
-        CredentialTestFramework::with(Service::default())
+        CredentialTestFramework::with(HolderServices::default().await)
             .given_no_previous_events()
             .when(CredentialCommand::AddCredential {
                 holder_credential_id: holder_credential_id.clone(),

--- a/agent_holder/src/offer/aggregate.rs
+++ b/agent_holder/src/offer/aggregate.rs
@@ -316,7 +316,9 @@ pub mod tests {
     use super::*;
     use agent_api_http::v0::{authorization, issuance};
     use agent_api_http::API_VERSION;
+    use agent_authorization::services::AuthorizationServices;
     use agent_issuance::server_config::aggregate::test_utils::credential_configurations_supported;
+    use agent_issuance::services::IssuanceServices;
     use agent_secret_manager::service::Service;
     use agent_shared::config::config;
     use agent_shared::config::config_mut;
@@ -349,12 +351,13 @@ pub mod tests {
         config_mut().credential_endpoint = application_url.join("openid4vci/credential").unwrap();
         config_mut().credential_offer_uri = application_url.join("openid4vci/credential-offer/").unwrap();
 
-        let issuance_state = Arc::new(issuance_state(&InMemory, Service::default(), Default::default()).await);
+        let issuance_state =
+            Arc::new(issuance_state(&InMemory, IssuanceServices::default().await, Default::default()).await);
         agent_issuance::state::initialize(&issuance_state).await.unwrap();
         let mut credential_isser = issuance::router(issuance_state.clone());
 
         let authorization_state =
-            Arc::new(authorization_state(&InMemory, Service::default(), Default::default()).await);
+            Arc::new(authorization_state(&InMemory, AuthorizationServices::default().await, Default::default()).await);
         agent_authorization::state::initialize(&authorization_state)
             .await
             .unwrap();
@@ -438,7 +441,7 @@ pub mod tests {
         #[future(awt)] credential_offer_parameters: Box<CredentialOfferParameters>,
         credential_configurations_supported: HashMap<String, CredentialConfigurationsSupportedObject>,
     ) {
-        OfferTestFramework::with(Service::default())
+        OfferTestFramework::with(HolderServices::default().await)
             .given_no_previous_events()
             .when_async(OfferCommand::ReceiveCredentialOffer {
                 received_offer_id: received_offer_id.clone(),
@@ -468,7 +471,7 @@ pub mod tests {
         #[future(awt)] credential_offer_parameters: Box<CredentialOfferParameters>,
         credential_configurations_supported: HashMap<String, CredentialConfigurationsSupportedObject>,
     ) {
-        OfferTestFramework::with(Service::default())
+        OfferTestFramework::with(HolderServices::default().await)
             .given(vec![OfferEvent::CredentialOfferReceived {
                 received_offer_id: received_offer_id.clone(),
                 credential_offer: credential_offer_parameters,
@@ -512,7 +515,7 @@ pub mod tests {
         credential_configurations_supported: HashMap<String, CredentialConfigurationsSupportedObject>,
         signed_credentials: Vec<OfferCredential>,
     ) {
-        OfferTestFramework::with(Service::default())
+        OfferTestFramework::with(HolderServices::default().await)
             .given(vec![
                 OfferEvent::CredentialOfferReceived {
                     received_offer_id: received_offer_id.clone(),
@@ -554,7 +557,7 @@ pub mod tests {
         #[future(awt)] credential_offer_parameters: Box<CredentialOfferParameters>,
         credential_configurations_supported: HashMap<String, CredentialConfigurationsSupportedObject>,
     ) {
-        OfferTestFramework::with(Service::default())
+        OfferTestFramework::with(HolderServices::default().await)
             .given(vec![OfferEvent::CredentialOfferReceived {
                 received_offer_id: received_offer_id.clone(),
                 credential_offer: credential_offer_parameters,

--- a/agent_holder/src/presentation/aggregate.rs
+++ b/agent_holder/src/presentation/aggregate.rs
@@ -151,7 +151,7 @@ pub mod presentation_tests {
         signed_credentials: Vec<OfferCredential>,
         signed_presentation: Jwt,
     ) {
-        PresentationTestFramework::with(Service::default())
+        PresentationTestFramework::with(HolderServices::default().await)
             .given_no_previous_events()
             .when(PresentationCommand::CreatePresentation {
                 presentation_id: presentation_id.clone(),

--- a/agent_issuance/src/credential/aggregate.rs
+++ b/agent_issuance/src/credential/aggregate.rs
@@ -595,7 +595,7 @@ pub mod credential_tests {
         credential_id: String,
         notification_id: String,
     ) {
-        CredentialTestFramework::with(Service::default())
+        CredentialTestFramework::with(IssuanceServices::default().await)
             .given_no_previous_events()
             .when(CredentialCommand::CreateUnsignedCredential {
                 credential_id: credential_id.clone(),
@@ -639,7 +639,7 @@ pub mod credential_tests {
         #[case] verifiable_credential_jwt: String,
         credential_id: String,
     ) {
-        CredentialTestFramework::with(Service::default())
+        CredentialTestFramework::with(IssuanceServices::default().await)
             .given(vec![CredentialEvent::UnsignedCredentialCreated {
                 credential_id: credential_id.clone(),
                 data: Data {

--- a/agent_issuance/src/offer/aggregate.rs
+++ b/agent_issuance/src/offer/aggregate.rs
@@ -406,7 +406,7 @@ pub mod tests {
         #[future(awt)] credential_offer_uri: CredentialOffer,
         #[future(awt)] form_url_encoded_credential_offer: String,
     ) {
-        OfferTestFramework::with(Service::default())
+        OfferTestFramework::with(IssuanceServices::default().await)
             .given_no_previous_events()
             .when(OfferCommand::CreateCredentialOffer {
                 offer_id: offer_id.clone(),
@@ -446,7 +446,7 @@ pub mod tests {
         #[future(awt)] form_url_encoded_credential_offer: String,
         delivery_options: DeliveryOptions,
     ) {
-        OfferTestFramework::with(Service::default())
+        OfferTestFramework::with(IssuanceServices::default().await)
             .given_no_previous_events()
             .when(OfferCommand::CreateCredentialOffer {
                 offer_id: offer_id.clone(),
@@ -487,7 +487,7 @@ pub mod tests {
         #[future(awt)] credential_offer_with_credential_configuration_ids: CredentialOffer,
         #[future(awt)] form_url_encoded_credential_offer_with_credential_configuration_ids: String,
     ) {
-        OfferTestFramework::with(Service::default())
+        OfferTestFramework::with(IssuanceServices::default().await)
             .given(vec![OfferEvent::CredentialOfferCreated {
                 offer_id: offer_id.clone(),
                 grant_types,
@@ -534,7 +534,7 @@ pub mod tests {
         credential_issuer_metadata: Box<CredentialIssuerMetadata>,
         authorization_server_metadata: Box<AuthorizationServerMetadata>,
     ) {
-        OfferTestFramework::with(Service::default())
+        OfferTestFramework::with(IssuanceServices::default().await)
             .given(vec![
                 OfferEvent::CredentialOfferCreated {
                     offer_id: offer_id.clone(),
@@ -585,7 +585,7 @@ pub mod tests {
         credential_response: CredentialResponse,
         notification_id: String,
     ) {
-        OfferTestFramework::with(Service::default())
+        OfferTestFramework::with(IssuanceServices::default().await)
             .given(vec![
                 OfferEvent::CredentialOfferCreated {
                     offer_id: offer_id.clone(),
@@ -642,7 +642,7 @@ pub mod tests {
         credential_response: CredentialResponse,
         notification_id: String,
     ) {
-        OfferTestFramework::with(Service::default())
+        OfferTestFramework::with(IssuanceServices::default().await)
             .given(vec![
                 OfferEvent::CredentialOfferCreated {
                     offer_id: offer_id.clone(),
@@ -724,7 +724,7 @@ pub mod test_utils {
 
     #[fixture]
     pub async fn holder() -> Arc<dyn oid4vc_core::Subject> {
-        Arc::new(agent_secret_manager::subject::Subject::default())
+        Arc::new(agent_secret_manager::subject::Subject::test_subject().await)
     }
 
     #[fixture]

--- a/agent_issuance/src/server_config/aggregate.rs
+++ b/agent_issuance/src/server_config/aggregate.rs
@@ -326,13 +326,13 @@ pub mod server_config_tests {
     type ServerConfigTestFramework = TestFramework<ServerConfig>;
 
     #[rstest]
-    fn test_load_server_metadata(
+    async fn test_load_server_metadata(
         authorization_server_metadata: Box<AuthorizationServerMetadata>,
         credential_issuer_metadata: Box<CredentialIssuerMetadata>,
         cryptographic_binding_methods_supported: Vec<String>,
         signing_algorithms_supported: Vec<Algorithm>,
     ) {
-        ServerConfigTestFramework::with(Service::default())
+        ServerConfigTestFramework::with(IssuanceServices::default().await)
             .given_no_previous_events()
             .when(ServerConfigCommand::InitializeServerMetadata {
                 authorization_server_metadata: authorization_server_metadata.clone(),
@@ -349,7 +349,7 @@ pub mod server_config_tests {
     }
 
     #[rstest]
-    fn test_add_credential_configuration(
+    async fn test_add_credential_configuration(
         authorization_server_metadata: Box<AuthorizationServerMetadata>,
         credential_issuer_metadata: Box<CredentialIssuerMetadata>,
         cryptographic_binding_methods_supported: Vec<String>,
@@ -358,7 +358,7 @@ pub mod server_config_tests {
         credential_configurations: HashMap<String, (bool, CredentialConfigurationsSupportedObject, Authorization)>,
         credential_issuer_metadata_with_credential_configuration: Box<CredentialIssuerMetadata>,
     ) {
-        ServerConfigTestFramework::with(Service::default())
+        ServerConfigTestFramework::with(IssuanceServices::default().await)
             .given(vec![ServerConfigEvent::ServerMetadataInitialized {
                 authorization_server_metadata,
                 credential_issuer_metadata,

--- a/agent_secret_manager/src/service.rs
+++ b/agent_secret_manager/src/service.rs
@@ -1,15 +1,17 @@
 use crate::subject::SubjectExt;
+use async_trait::async_trait;
 use std::sync::Arc;
 
 /// Convenience trait for Services like `IssuanceServices`, `HolderServices`, and `VerifierServices`.
+#[async_trait]
 pub trait Service {
     fn new(subject: Arc<dyn SubjectExt>) -> Self;
 
     #[cfg(feature = "test_utils")]
-    fn default() -> Arc<Self>
+    async fn default() -> Arc<Self>
     where
         Self: Sized,
     {
-        Arc::new(Self::new(Arc::new(crate::subject::Subject::default())))
+        Arc::new(Self::new(Arc::new(crate::subject::Subject::test_subject().await)))
     }
 }

--- a/agent_secret_manager/src/subject.rs
+++ b/agent_secret_manager/src/subject.rs
@@ -126,36 +126,34 @@ mod default_subject {
     }
 
     // This `Default` implementation for `Subject` returns a new `Subject` with the Verification Method IDs already preloaded.
-    impl Default for Subject {
-        fn default() -> Self {
-            futures::executor::block_on(async {
-                let stronghold_storage = stronghold_storage().await;
+    impl Subject {
+        pub async fn test_subject() -> Self {
+            let stronghold_storage = stronghold_storage().await;
 
-                let verification_method_ids = Arc::new(Mutex::new(HashMap::from_iter(vec![
-                    (
-                        StorageKey::new(SupportedDidMethod::Key, Algorithm::ES256),
-                        Self::DID_KEY_ES256_VERIFICATION_METHOD_ID.parse().unwrap(),
-                    ),
-                    (
-                        StorageKey::new(SupportedDidMethod::Key, Algorithm::EdDSA),
-                        Self::DID_KEY_EDDSA_VERIFICATION_METHOD_ID.parse().unwrap(),
-                    ),
-                    (
-                        StorageKey::new(SupportedDidMethod::Jwk, Algorithm::ES256),
-                        Self::DID_JWK_ES256_VERIFICATION_METHOD_ID.parse().unwrap(),
-                    ),
-                    (
-                        StorageKey::new(SupportedDidMethod::Jwk, Algorithm::EdDSA),
-                        Self::DID_JWK_EDDSA_VERIFICATION_METHOD_ID.parse().unwrap(),
-                    ),
-                ])));
+            let verification_method_ids = Arc::new(Mutex::new(HashMap::from_iter(vec![
+                (
+                    StorageKey::new(SupportedDidMethod::Key, Algorithm::ES256),
+                    Self::DID_KEY_ES256_VERIFICATION_METHOD_ID.parse().unwrap(),
+                ),
+                (
+                    StorageKey::new(SupportedDidMethod::Key, Algorithm::EdDSA),
+                    Self::DID_KEY_EDDSA_VERIFICATION_METHOD_ID.parse().unwrap(),
+                ),
+                (
+                    StorageKey::new(SupportedDidMethod::Jwk, Algorithm::ES256),
+                    Self::DID_JWK_ES256_VERIFICATION_METHOD_ID.parse().unwrap(),
+                ),
+                (
+                    StorageKey::new(SupportedDidMethod::Jwk, Algorithm::EdDSA),
+                    Self::DID_JWK_EDDSA_VERIFICATION_METHOD_ID.parse().unwrap(),
+                ),
+            ])));
 
-                Self {
-                    stronghold_storage,
-                    verification_method_ids,
-                    resolver: Resolver::new().await,
-                }
-            })
+            Self {
+                stronghold_storage,
+                verification_method_ids,
+                resolver: Resolver::new().await,
+            }
         }
     }
 }
@@ -296,7 +294,7 @@ mod tests {
     async fn es256_signed_jwt_successfully_verified() {
         set_config().set_secret_manager_config(SECRET_MANAGER_CONFIG.clone());
 
-        let subject = Arc::new(Subject::default());
+        let subject = Arc::new(Subject::test_subject().await);
 
         let mut split = ES256_SIGNED_JWT.rsplitn(2, '.');
         let (signature, message) = (split.next().unwrap(), split.next().unwrap());
@@ -316,7 +314,7 @@ mod tests {
     async fn eddsa_signed_jwt_successfully_verified() {
         set_config().set_secret_manager_config(SECRET_MANAGER_CONFIG.clone());
 
-        let subject = Arc::new(Subject::default());
+        let subject = Arc::new(Subject::test_subject().await);
 
         let mut split = EDDSA_SIGNED_JWT.rsplitn(2, '.');
         let (signature, message) = (split.next().unwrap(), split.next().unwrap());

--- a/agent_verification/src/authorization_request/aggregate.rs
+++ b/agent_verification/src/authorization_request/aggregate.rs
@@ -311,7 +311,7 @@ pub mod tests {
     ) {
         set_config().set_preferred_did_method(verifier_did_method);
 
-        let verification_services = VerificationServices::default();
+        let verification_services = VerificationServices::default().await;
         let siopv2_client_metadata = verification_services.siopv2_client_metadata.clone();
         let oid4vp_client_metadata = verification_services.oid4vp_client_metadata.clone();
 
@@ -350,7 +350,7 @@ pub mod tests {
     ) {
         set_config().set_preferred_did_method(verifier_did_method);
 
-        let verification_services = VerificationServices::default();
+        let verification_services = VerificationServices::default().await;
         let siopv2_client_metadata = verification_services.siopv2_client_metadata.clone();
         let oid4vp_client_metadata = verification_services.oid4vp_client_metadata.clone();
 
@@ -391,7 +391,7 @@ pub mod tests {
     ) {
         set_config().set_preferred_did_method(verifier_did_method);
 
-        let verification_services = VerificationServices::default();
+        let verification_services = VerificationServices::default().await;
         let siopv2_client_metadata = verification_services.siopv2_client_metadata.clone();
         let oid4vp_client_metadata = verification_services.oid4vp_client_metadata.clone();
 
@@ -432,7 +432,7 @@ pub mod tests {
     ) {
         set_config().set_preferred_did_method(verifier_did_method);
 
-        let verification_services = VerificationServices::default();
+        let verification_services = VerificationServices::default().await;
         let oid4vp_client_metadata = verification_services.oid4vp_client_metadata.clone();
         let siopv2_client_metadata = verification_services.siopv2_client_metadata.clone();
 
@@ -473,7 +473,7 @@ pub mod tests {
         authorization_request: &GenericAuthorizationRequest,
     ) -> GenericAuthorizationResponse {
         let provider_manager = ProviderManager::new(
-            Arc::new(Subject::default()),
+            Arc::new(Subject::test_subject().await),
             vec![provider_did_method],
             vec![Algorithm::ES256],
         )
@@ -500,7 +500,11 @@ pub mod tests {
     }
 
     pub async fn verifier_did(did_method: &str) -> String {
-        VERIFIER.identifier(did_method, Algorithm::EdDSA).await.unwrap()
+        Subject::test_subject()
+            .await
+            .identifier(did_method, Algorithm::EdDSA)
+            .await
+            .unwrap()
     }
 
     pub async fn authorization_request(
@@ -644,7 +648,6 @@ pub mod tests {
     }
 
     lazy_static! {
-        pub static ref VERIFIER: Subject = Subject::default();
         pub static ref REDIRECT_URI: url::Url = "https://my-domain.example.org/redirect".parse::<url::Url>().unwrap();
         pub static ref RESPONSE_URI: url::Url = "https://my-domain.example.org/redirect".parse::<url::Url>().unwrap();
         pub static ref DCQL_QUERY: DcqlQuery = DcqlQuery {


### PR DESCRIPTION
# Description of change
Since the addition of `pub resolver: Resolver,` to `Subject` in [this commit](https://github.com/impierce/ssi-agent/commit/d42a8f9a7336bb7eec8f45e0eb969c12e34e7f0e#diff-49ea6b0853e5c54834add274451694740b725f16d35cdecd6b5d3fdfee4e3377) we're initializing `Resolver` once and then reuse it (which is a good thing). Somehow this causes many tests to timeout due to a `block_on` in `impl Default for Subject` that would cause an upstream `jsonrpsee` crate to get 'stuck'.

This PR fixes that by replacing the Default impl for a custom async `test_subject` method. 

This change caused one of the tests to overflow:
```bash
thread 'offer::aggregate::tests::test_verify_credential_response' (718784) has overflowed its stack
fatal runtime error: stack overflow, aborting
error: test failed, to rerun pass `-p agent_issuance --lib`

Caused by:
  process didn't exit successfully: `/home/nander/Impierce/ssi-agent/target/debug/deps/agent_issuance-3f00251efa88b62a test_verify_credential_response --nocapture` (signal: 6, SIGABRT: process abort signal)
```

To fix that I changed `cargo test --workspace` to `RUST_MIN_STACK=16777216 cargo test --workspace` in `format-lint-test.yaml`

## Links to any relevant issues
n/a

## How the change has been tested
All tests run successfully now. 

## Definition of Done checklist
Add an `x` to the boxes that are relevant to your changes.

- [x] I have followed the contribution guidelines for this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] I have successfully tested this change in a docker environment 
