### PR TITLE
feat: attach all possible Verification Method Relationships to Documents

### DIFF
--- a/agent_identity/src/document/aggregate.rs
+++ b/agent_identity/src/document/aggregate.rs
@@ -13,6 +13,7 @@ use identity_iota::iota::rebased::client::{
 use identity_iota::iota::rebased::migration::{ControllerToken, Identity, OnChainIdentity};
 use identity_iota::iota::{rebased, IotaDID};
 use identity_iota::storage::{Storage, StorageSigner};
+use identity_iota::verification::MethodRelationship;
 use identity_iota::{
     iota::IotaDocument,
     verification::{MethodScope, MethodType, VerificationMethod},
@@ -363,8 +364,30 @@ impl Aggregate for Document {
                         .map_err(|err| VerificationMethodInsertionError(err.to_string()))?;
 
                     document
-                        .insert_method(verification_method, MethodScope::VerificationMethod) // TODO: add relationships, also TODO: adjust KID insertion elsewhere
+                        .insert_method(verification_method.clone(), MethodScope::VerificationMethod) // TODO: adjust KID insertion elsewhere
                         .map_err(|err| VerificationMethodInsertionError(err.to_string()))?;
+
+                    // Attach all possible relationships to the verification method.
+                    document.attach_method_relationship(
+                        verification_method.id().clone(),
+                        MethodRelationship::Authentication,
+                    )?;
+                    document.attach_method_relationship(
+                        verification_method.id().clone(),
+                        MethodRelationship::AssertionMethod,
+                    )?;
+                    document.attach_method_relationship(
+                        verification_method.id().clone(),
+                        MethodRelationship::KeyAgreement,
+                    )?;
+                    document.attach_method_relationship(
+                        verification_method.id().clone(),
+                        MethodRelationship::CapabilityDelegation,
+                    )?;
+                    document.attach_method_relationship(
+                        verification_method.id().clone(),
+                        MethodRelationship::CapabilityInvocation,
+                    )?;
 
                     events.push(PublicKeyUpdated {
                         document_id: self.document_id.clone(),
@@ -980,7 +1003,7 @@ pub mod test_utils {
         document::CoreDocument,
         service::{Service, ServiceEndpoint},
     };
-    use identity_iota::verification::jwk::Jwk;
+    use identity_iota::verification::{jwk::Jwk, MethodRelationship};
     use identity_iota::verification::{MethodData, MethodScope, MethodType, VerificationMethod};
     use rstest::*;
     use serde_json::json;
@@ -1067,8 +1090,27 @@ pub mod test_utils {
         mut document: CoreDocument,
         es256_verification_method: VerificationMethod,
     ) -> CoreDocument {
+        let verification_method_id = es256_verification_method.id().clone();
+
         document
             .insert_method(es256_verification_method, MethodScope::VerificationMethod)
+            .unwrap();
+
+        // Attach all possible relationships to the verification method.
+        document
+            .attach_method_relationship(verification_method_id.clone(), MethodRelationship::Authentication)
+            .unwrap();
+        document
+            .attach_method_relationship(verification_method_id.clone(), MethodRelationship::AssertionMethod)
+            .unwrap();
+        document
+            .attach_method_relationship(verification_method_id.clone(), MethodRelationship::KeyAgreement)
+            .unwrap();
+        document
+            .attach_method_relationship(verification_method_id.clone(), MethodRelationship::CapabilityDelegation)
+            .unwrap();
+        document
+            .attach_method_relationship(verification_method_id, MethodRelationship::CapabilityInvocation)
             .unwrap();
 
         document
@@ -1080,8 +1122,26 @@ pub mod test_utils {
         both_verification_methods: Vec<VerificationMethod>,
     ) -> CoreDocument {
         for verification_method in both_verification_methods {
+            let verification_method_id = verification_method.id().clone();
+
             document
                 .insert_method(verification_method, MethodScope::VerificationMethod)
+                .unwrap();
+
+            document
+                .attach_method_relationship(verification_method_id.clone(), MethodRelationship::Authentication)
+                .unwrap();
+            document
+                .attach_method_relationship(verification_method_id.clone(), MethodRelationship::AssertionMethod)
+                .unwrap();
+            document
+                .attach_method_relationship(verification_method_id.clone(), MethodRelationship::KeyAgreement)
+                .unwrap();
+            document
+                .attach_method_relationship(verification_method_id.clone(), MethodRelationship::CapabilityDelegation)
+                .unwrap();
+            document
+                .attach_method_relationship(verification_method_id, MethodRelationship::CapabilityInvocation)
                 .unwrap();
         }
 


### PR DESCRIPTION
# Description of change
Makes sure that all Verification Methods (keys) in the DID Documents have all Verification Method Relationships attached to them, indicating that the keys can be used for multiple purposes. In the future we should implement more fine-grained logic for public key purpose/permissions.

This change fixes the following two requirements in the DIIPv5 spec (see bottom of [this](https://fidescommunity.github.io/DIIP/#oid4vci) section):
> Requirement: DIIP-compliant implementations MUST support the jwt proof type with a [did:jwk](https://fidescommunity.github.io/DIIP/#term:did:jwk) or [did:web](https://fidescommunity.github.io/DIIP/#term:did:web) as the iss value and use a kid from the assertionMethod Verification Method relationship of the respective [Issuer](https://fidescommunity.github.io/DIIP/#term:issuer)'s [DID](https://fidescommunity.github.io/DIIP/#term:did) document.

> Requirement: DIIP-compliant implementations MUST support a cnf holder binding claim in the [Issuer](https://fidescommunity.github.io/DIIP/#term:issuer)'s jwt and it MUST include a kid value from the authentication Verification Method relationship of the respective [Holder](https://fidescommunity.github.io/DIIP/#term:holder)'s [DID](https://fidescommunity.github.io/DIIP/#term:did) document.

## Links to any relevant issues
n/a

## How the change has been tested
Existing test (fixtures) have been updated)

## Definition of Done checklist
Add an `x` to the boxes that are relevant to your changes.

- [x] I have followed the contribution guidelines for this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] I have successfully tested this change in a docker environment 
