### PR TITLE
fix: update `did_manager` to prevent panic on `Resolver` initialization

### DIFF
--- a/.github/workflows/coverage.yaml
+++ b/.github/workflows/coverage.yaml
@@ -30,9 +30,9 @@ jobs:
         uses: taiki-e/install-action@cargo-llvm-cov
 
       - name: Generate code coverage
-        # TODO: We set `RUST_MIN_STACK` to 16 MiB to prevent stack overflow in `test_verify_credential_response`.
+        # TODO: We set `RUST_MIN_STACK` to 32 MiB to prevent stack overflow in `test_verify_credential_response`.
         # Investigate if this is still needed after our testing refactor.
-        run: RUST_MIN_STACK=16777216 cargo llvm-cov --all-features --workspace --lcov --output-path lcov.info
+        run: RUST_MIN_STACK=33554432 cargo llvm-cov --all-features --workspace --lcov --output-path lcov.info
 
       - name: Upload coverage to Codecov
         uses: codecov/codecov-action@v5

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2323,7 +2323,7 @@ checksum = "3d52eff69cd5e647efe296129160853a42795992097e8af39800e1060caeea9b"
 [[package]]
 name = "consumer"
 version = "0.1.0"
-source = "git+https://github.com/impierce/did-manager?rev=9d17d57#9d17d5795f06b7e6f5de6015287e9f50fed7e4c3"
+source = "git+https://github.com/impierce/did-manager?tag=v1.0.0-beta.8#7763b585447877c3a02fcd3e2fc2f3f0f20bf037"
 dependencies = [
  "did_iota",
  "did_jwk",
@@ -3082,7 +3082,7 @@ dependencies = [
 [[package]]
 name = "did_iota"
 version = "0.1.0"
-source = "git+https://github.com/impierce/did-manager?rev=9d17d57#9d17d5795f06b7e6f5de6015287e9f50fed7e4c3"
+source = "git+https://github.com/impierce/did-manager?tag=v1.0.0-beta.8#7763b585447877c3a02fcd3e2fc2f3f0f20bf037"
 dependencies = [
  "anyhow",
  "identity_iota",
@@ -3097,7 +3097,7 @@ dependencies = [
 [[package]]
 name = "did_jwk"
 version = "0.1.0"
-source = "git+https://github.com/impierce/did-manager?rev=9d17d57#9d17d5795f06b7e6f5de6015287e9f50fed7e4c3"
+source = "git+https://github.com/impierce/did-manager?tag=v1.0.0-beta.8#7763b585447877c3a02fcd3e2fc2f3f0f20bf037"
 dependencies = [
  "did-jwk",
  "identity_iota",
@@ -3114,7 +3114,7 @@ dependencies = [
 [[package]]
 name = "did_key"
 version = "0.1.0"
-source = "git+https://github.com/impierce/did-manager?rev=9d17d57#9d17d5795f06b7e6f5de6015287e9f50fed7e4c3"
+source = "git+https://github.com/impierce/did-manager?tag=v1.0.0-beta.8#7763b585447877c3a02fcd3e2fc2f3f0f20bf037"
 dependencies = [
  "did-method-key",
  "identity_iota",
@@ -3161,7 +3161,7 @@ dependencies = [
 [[package]]
 name = "did_web"
 version = "0.1.0"
-source = "git+https://github.com/impierce/did-manager?rev=9d17d57#9d17d5795f06b7e6f5de6015287e9f50fed7e4c3"
+source = "git+https://github.com/impierce/did-manager?tag=v1.0.0-beta.8#7763b585447877c3a02fcd3e2fc2f3f0f20bf037"
 dependencies = [
  "did-web",
  "identity_iota",
@@ -5120,7 +5120,7 @@ dependencies = [
 [[package]]
 name = "identity_stronghold_ext"
 version = "0.1.0"
-source = "git+https://github.com/impierce/did-manager?rev=9d17d57#9d17d5795f06b7e6f5de6015287e9f50fed7e4c3"
+source = "git+https://github.com/impierce/did-manager?tag=v1.0.0-beta.8#7763b585447877c3a02fcd3e2fc2f3f0f20bf037"
 dependencies = [
  "async-trait",
  "elliptic-curve 0.13.8",
@@ -11077,7 +11077,7 @@ dependencies = [
 [[package]]
 name = "shared"
 version = "0.1.0"
-source = "git+https://github.com/impierce/did-manager?rev=9d17d57#9d17d5795f06b7e6f5de6015287e9f50fed7e4c3"
+source = "git+https://github.com/impierce/did-manager?tag=v1.0.0-beta.8#7763b585447877c3a02fcd3e2fc2f3f0f20bf037"
 dependencies = [
  "identity_iota",
  "identity_storage",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2323,7 +2323,7 @@ checksum = "3d52eff69cd5e647efe296129160853a42795992097e8af39800e1060caeea9b"
 [[package]]
 name = "consumer"
 version = "0.1.0"
-source = "git+https://github.com/impierce/did-manager?rev=b9b53e8#b9b53e84f6e45ecf29446f4446f033a0aa5aee80"
+source = "git+https://github.com/impierce/did-manager?rev=9d17d57#9d17d5795f06b7e6f5de6015287e9f50fed7e4c3"
 dependencies = [
  "did_iota",
  "did_jwk",
@@ -3082,7 +3082,7 @@ dependencies = [
 [[package]]
 name = "did_iota"
 version = "0.1.0"
-source = "git+https://github.com/impierce/did-manager?rev=b9b53e8#b9b53e84f6e45ecf29446f4446f033a0aa5aee80"
+source = "git+https://github.com/impierce/did-manager?rev=9d17d57#9d17d5795f06b7e6f5de6015287e9f50fed7e4c3"
 dependencies = [
  "anyhow",
  "identity_iota",
@@ -3097,7 +3097,7 @@ dependencies = [
 [[package]]
 name = "did_jwk"
 version = "0.1.0"
-source = "git+https://github.com/impierce/did-manager?rev=b9b53e8#b9b53e84f6e45ecf29446f4446f033a0aa5aee80"
+source = "git+https://github.com/impierce/did-manager?rev=9d17d57#9d17d5795f06b7e6f5de6015287e9f50fed7e4c3"
 dependencies = [
  "did-jwk",
  "identity_iota",
@@ -3114,7 +3114,7 @@ dependencies = [
 [[package]]
 name = "did_key"
 version = "0.1.0"
-source = "git+https://github.com/impierce/did-manager?rev=b9b53e8#b9b53e84f6e45ecf29446f4446f033a0aa5aee80"
+source = "git+https://github.com/impierce/did-manager?rev=9d17d57#9d17d5795f06b7e6f5de6015287e9f50fed7e4c3"
 dependencies = [
  "did-method-key",
  "identity_iota",
@@ -3161,7 +3161,7 @@ dependencies = [
 [[package]]
 name = "did_web"
 version = "0.1.0"
-source = "git+https://github.com/impierce/did-manager?rev=b9b53e8#b9b53e84f6e45ecf29446f4446f033a0aa5aee80"
+source = "git+https://github.com/impierce/did-manager?rev=9d17d57#9d17d5795f06b7e6f5de6015287e9f50fed7e4c3"
 dependencies = [
  "did-web",
  "identity_iota",
@@ -5120,7 +5120,7 @@ dependencies = [
 [[package]]
 name = "identity_stronghold_ext"
 version = "0.1.0"
-source = "git+https://github.com/impierce/did-manager?rev=b9b53e8#b9b53e84f6e45ecf29446f4446f033a0aa5aee80"
+source = "git+https://github.com/impierce/did-manager?rev=9d17d57#9d17d5795f06b7e6f5de6015287e9f50fed7e4c3"
 dependencies = [
  "async-trait",
  "elliptic-curve 0.13.8",
@@ -11077,7 +11077,7 @@ dependencies = [
 [[package]]
 name = "shared"
 version = "0.1.0"
-source = "git+https://github.com/impierce/did-manager?rev=b9b53e8#b9b53e84f6e45ecf29446f4446f033a0aa5aee80"
+source = "git+https://github.com/impierce/did-manager?rev=9d17d57#9d17d5795f06b7e6f5de6015287e9f50fed7e4c3"
 dependencies = [
  "identity_iota",
  "identity_storage",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2323,7 +2323,7 @@ checksum = "3d52eff69cd5e647efe296129160853a42795992097e8af39800e1060caeea9b"
 [[package]]
 name = "consumer"
 version = "0.1.0"
-source = "git+https://github.com/impierce/did-manager?rev=a2863a3#a2863a328ece653d9a8f61528bb1cbf96d263858"
+source = "git+https://github.com/impierce/did-manager?rev=b9b53e8#b9b53e84f6e45ecf29446f4446f033a0aa5aee80"
 dependencies = [
  "did_iota",
  "did_jwk",
@@ -3082,7 +3082,7 @@ dependencies = [
 [[package]]
 name = "did_iota"
 version = "0.1.0"
-source = "git+https://github.com/impierce/did-manager?rev=a2863a3#a2863a328ece653d9a8f61528bb1cbf96d263858"
+source = "git+https://github.com/impierce/did-manager?rev=b9b53e8#b9b53e84f6e45ecf29446f4446f033a0aa5aee80"
 dependencies = [
  "anyhow",
  "identity_iota",
@@ -3097,7 +3097,7 @@ dependencies = [
 [[package]]
 name = "did_jwk"
 version = "0.1.0"
-source = "git+https://github.com/impierce/did-manager?rev=a2863a3#a2863a328ece653d9a8f61528bb1cbf96d263858"
+source = "git+https://github.com/impierce/did-manager?rev=b9b53e8#b9b53e84f6e45ecf29446f4446f033a0aa5aee80"
 dependencies = [
  "did-jwk",
  "identity_iota",
@@ -3114,7 +3114,7 @@ dependencies = [
 [[package]]
 name = "did_key"
 version = "0.1.0"
-source = "git+https://github.com/impierce/did-manager?rev=a2863a3#a2863a328ece653d9a8f61528bb1cbf96d263858"
+source = "git+https://github.com/impierce/did-manager?rev=b9b53e8#b9b53e84f6e45ecf29446f4446f033a0aa5aee80"
 dependencies = [
  "did-method-key",
  "identity_iota",
@@ -3161,7 +3161,7 @@ dependencies = [
 [[package]]
 name = "did_web"
 version = "0.1.0"
-source = "git+https://github.com/impierce/did-manager?rev=a2863a3#a2863a328ece653d9a8f61528bb1cbf96d263858"
+source = "git+https://github.com/impierce/did-manager?rev=b9b53e8#b9b53e84f6e45ecf29446f4446f033a0aa5aee80"
 dependencies = [
  "did-web",
  "identity_iota",
@@ -5120,7 +5120,7 @@ dependencies = [
 [[package]]
 name = "identity_stronghold_ext"
 version = "0.1.0"
-source = "git+https://github.com/impierce/did-manager?rev=a2863a3#a2863a328ece653d9a8f61528bb1cbf96d263858"
+source = "git+https://github.com/impierce/did-manager?rev=b9b53e8#b9b53e84f6e45ecf29446f4446f033a0aa5aee80"
 dependencies = [
  "async-trait",
  "elliptic-curve 0.13.8",
@@ -11077,7 +11077,7 @@ dependencies = [
 [[package]]
 name = "shared"
 version = "0.1.0"
-source = "git+https://github.com/impierce/did-manager?rev=a2863a3#a2863a328ece653d9a8f61528bb1cbf96d263858"
+source = "git+https://github.com/impierce/did-manager?rev=b9b53e8#b9b53e84f6e45ecf29446f4446f033a0aa5aee80"
 dependencies = [
  "identity_iota",
  "identity_storage",

--- a/agent_secret_manager/Cargo.toml
+++ b/agent_secret_manager/Cargo.toml
@@ -13,9 +13,9 @@ agent_shared = { path = "../agent_shared" }
 # - All components of the `identity_stronghold_ext` module are still active.
 #
 # Future work: Migrate the remaining functionality into UniCore.
-did_manager_consumer = { git = "https://github.com/impierce/did-manager", rev = "b9b53e8", package = "consumer" }
-did_manager_identity_stronghold_ext = { git = "https://github.com/impierce/did-manager", rev = "b9b53e8", package = "identity_stronghold_ext" }
-did_manager_iota = { git = "https://github.com/impierce/did-manager", rev = "b9b53e8", package = "did_iota" }
+did_manager_consumer = { git = "https://github.com/impierce/did-manager", rev = "9d17d57", package = "consumer" }
+did_manager_identity_stronghold_ext = { git = "https://github.com/impierce/did-manager", rev = "9d17d57", package = "identity_stronghold_ext" }
+did_manager_iota = { git = "https://github.com/impierce/did-manager", rev = "9d17d57", package = "did_iota" }
 
 anyhow.workspace = true
 async-trait.workspace = true

--- a/agent_secret_manager/Cargo.toml
+++ b/agent_secret_manager/Cargo.toml
@@ -13,9 +13,9 @@ agent_shared = { path = "../agent_shared" }
 # - All components of the `identity_stronghold_ext` module are still active.
 #
 # Future work: Migrate the remaining functionality into UniCore.
-did_manager_consumer = { git = "https://github.com/impierce/did-manager", rev = "9d17d57", package = "consumer" }
-did_manager_identity_stronghold_ext = { git = "https://github.com/impierce/did-manager", rev = "9d17d57", package = "identity_stronghold_ext" }
-did_manager_iota = { git = "https://github.com/impierce/did-manager", rev = "9d17d57", package = "did_iota" }
+did_manager_consumer = { git = "https://github.com/impierce/did-manager", tag = "v1.0.0-beta.8", package = "consumer" }
+did_manager_identity_stronghold_ext = { git = "https://github.com/impierce/did-manager", tag = "v1.0.0-beta.8", package = "identity_stronghold_ext" }
+did_manager_iota = { git = "https://github.com/impierce/did-manager", tag = "v1.0.0-beta.8", package = "did_iota" }
 
 anyhow.workspace = true
 async-trait.workspace = true

--- a/agent_secret_manager/Cargo.toml
+++ b/agent_secret_manager/Cargo.toml
@@ -13,9 +13,9 @@ agent_shared = { path = "../agent_shared" }
 # - All components of the `identity_stronghold_ext` module are still active.
 #
 # Future work: Migrate the remaining functionality into UniCore.
-did_manager_consumer = { git = "https://github.com/impierce/did-manager", rev = "a2863a3", package = "consumer" }
-did_manager_identity_stronghold_ext = { git = "https://github.com/impierce/did-manager", rev = "a2863a3", package = "identity_stronghold_ext" }
-did_manager_iota = { git = "https://github.com/impierce/did-manager", rev = "a2863a3", package = "did_iota" }
+did_manager_consumer = { git = "https://github.com/impierce/did-manager", rev = "b9b53e8", package = "consumer" }
+did_manager_identity_stronghold_ext = { git = "https://github.com/impierce/did-manager", rev = "b9b53e8", package = "identity_stronghold_ext" }
+did_manager_iota = { git = "https://github.com/impierce/did-manager", rev = "b9b53e8", package = "did_iota" }
 
 anyhow.workspace = true
 async-trait.workspace = true

--- a/agent_secret_manager/src/subject.rs
+++ b/agent_secret_manager/src/subject.rs
@@ -47,7 +47,7 @@ impl Subject {
         Self {
             stronghold_storage,
             verification_method_ids: Arc::new(Mutex::new(HashMap::new())),
-            resolver: Resolver::new_with_options(None, Some(node_urls), username_password).await,
+            resolver: Resolver::new_with_options(None, Some(node_urls), username_password),
         }
     }
 
@@ -178,7 +178,7 @@ mod default_subject {
             Self {
                 stronghold_storage,
                 verification_method_ids,
-                resolver: Resolver::new().await,
+                resolver: Resolver::new(),
             }
         }
     }


### PR DESCRIPTION
# Description of change
Fixes the panic in `did_manager::Resolver::new` by updating the `did_manager` version to [v1.0.0-beta.8](https://github.com/impierce/did-manager/releases/tag/v1.0.0-beta.8)

This change also increases the `RUST_MIN_STACK` to `33554432` which is required to run the `test_verify_credential_response` test

## Links to any relevant issues
- https://github.com/impierce/did-manager/releases/tag/v1.0.0-beta.8
- https://github.com/impierce/did-manager/pull/44

## How the change has been tested
ssi-agent does not crash on startup anymore.

## Definition of Done checklist
Add an `x` to the boxes that are relevant to your changes.

- [x] I have followed the contribution guidelines for this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
