### PR TITLE
feat: add ELM to Template `DataModel` options

### DIFF
--- a/agent_api_http/openapi-generated.yaml
+++ b/agent_api_http/openapi-generated.yaml
@@ -445,7 +445,7 @@ components:
       - w3c_vc_data_model_v1-1
       - w3c_vc_data_model_v2-0
       - open_badges_3-0
-      - europen_digital_credential_3-3
+      - european_learning_model_v3-3
     DeleteTemplateEndpointRequest:
       type: object
       required:

--- a/agent_api_http/openapi-generated.yaml
+++ b/agent_api_http/openapi-generated.yaml
@@ -1,18 +1,18 @@
 openapi: 3.1.0
 info:
   title: UniCore HTTP API
-  description: ""
+  description: ''
   license:
     name: Apache 2.0
   version: 0.0.0-semantically-released
 servers:
-  - url: http://localhost:3033
-    description: Local development
+- url: http://localhost:3033
+  description: Local development
 paths:
   /v0/connections:
     get:
       tags:
-        - Connections
+      - Connections
       summary: List all connections
       description: List all available connections.
       operationId: get_all_connections
@@ -20,78 +20,78 @@ paths:
         content:
           application/x-www-form-urlencoded:
             schema:
-              $ref: "#/components/schemas/GetConnectionsEndpointRequest"
+              $ref: '#/components/schemas/GetConnectionsEndpointRequest'
         required: true
       responses:
-        "200":
+        '200':
           description: All connections retrieved successfully
           content:
             application/json:
               schema:
                 type: array
                 items:
-                  $ref: "#/components/schemas/Connection"
+                  $ref: '#/components/schemas/Connection'
   /v0/connections/{connection_id}:
     get:
       tags:
-        - Connections
+      - Connections
       summary: Get connection by ID
       description: Retrieve a specific connection by its unique identifier.
       operationId: get_connection_by_id
       parameters:
-        - name: connection_id
-          in: path
-          required: true
-          schema:
-            type: string
+      - name: connection_id
+        in: path
+        required: true
+        schema:
+          type: string
       responses:
-        "200":
+        '200':
           description: Connection retrieved successfully
           content:
             application/json:
               schema:
-                $ref: "#/components/schemas/Connection"
+                $ref: '#/components/schemas/Connection'
   /v0/credentials:
     get:
       tags:
-        - Issuance
+      - Issuance
       summary: List all credentials
       description: Lists all credentials including their current status and metadata.
       operationId: get_all_credentials
       responses:
-        "200":
+        '200':
           description: List of all credentials
           content:
             application/json:
               schema:
                 type: array
                 items:
-                  $ref: "#/components/schemas/Credential"
+                  $ref: '#/components/schemas/Credential'
   /v0/credentials/{credential_id}:
     get:
       tags:
-        - Issuance
+      - Issuance
       summary: Get credential by ID
       description: Retrieves a credential by its ID.
       operationId: get_credential_by_id
       parameters:
-        - name: credential_id
-          in: path
-          required: true
-          schema:
-            type: string
+      - name: credential_id
+        in: path
+        required: true
+        schema:
+          type: string
       responses:
-        "200":
+        '200':
           description: Successfully retrieved credential
           content:
             application/json:
               schema:
-                $ref: "#/components/schemas/Credential"
+                $ref: '#/components/schemas/Credential'
   /v0/templates/create-template:
     post:
       tags:
-        - Library
-        - Templates
+      - Library
+      - Templates
       summary: Create a new template
       description: Creates a new template which can be used to issue credentials.
       operationId: create_template
@@ -99,7 +99,7 @@ paths:
         content:
           application/json:
             schema:
-              $ref: "#/components/schemas/CreateTemplateEndpointRequest"
+              $ref: '#/components/schemas/CreateTemplateEndpointRequest'
             examples:
               Standard template:
                 description: A simple example that will issue credentials in the W3C Verifiable Credentials Data Model v1.1 format.
@@ -109,7 +109,7 @@ paths:
                   holderType: individual
         required: true
       responses:
-        "201":
+        '201':
           description: New template created successfully
           headers:
             Location:
@@ -119,12 +119,12 @@ paths:
           content:
             application/json:
               schema:
-                $ref: "#/components/schemas/Template"
+                $ref: '#/components/schemas/Template'
   /v0/templates/delete-template:
     post:
       tags:
-        - Library
-        - Templates
+      - Library
+      - Templates
       summary: Delete a template
       description: Deletes a template by marking its status as `Deleted`. Deleted templates will no longer appear in any views.
       operationId: delete_template_by_id
@@ -132,16 +132,16 @@ paths:
         content:
           application/json:
             schema:
-              $ref: "#/components/schemas/DeleteTemplateEndpointRequest"
+              $ref: '#/components/schemas/DeleteTemplateEndpointRequest'
         required: true
       responses:
-        "204":
+        '204':
           description: Template deleted successfully
   /v0/templates/duplicate-template:
     post:
       tags:
-        - Library
-        - Templates
+      - Library
+      - Templates
       summary: Duplicate existing template
       description: Creates a duplicate of an existing template.
       operationId: duplicate_template
@@ -149,12 +149,12 @@ paths:
         content:
           application/json:
             schema:
-              $ref: "#/components/schemas/DuplicateTemplateEndpointRequest"
+              $ref: '#/components/schemas/DuplicateTemplateEndpointRequest'
             example:
               sourceTemplateId: 91fc790f-d876-4827-9a9d-0fb0f6766dca
         required: true
       responses:
-        "201":
+        '201':
           description: Duplicate created successfully
           headers:
             Location:
@@ -164,31 +164,31 @@ paths:
           content:
             application/json:
               schema:
-                $ref: "#/components/schemas/Template"
-        "422":
+                $ref: '#/components/schemas/Template'
+        '422':
           description: Source Template Not Found
   /v0/templates/get-all-templates:
     get:
       tags:
-        - Library
-        - Templates
+      - Library
+      - Templates
       summary: List all templates
       description: List all available templates.
       operationId: get_all_templates
       responses:
-        "200":
+        '200':
           description: All templates retrieved successfully
           content:
             application/json:
               schema:
                 type: array
                 items:
-                  $ref: "#/components/schemas/Template"
+                  $ref: '#/components/schemas/Template'
   /v0/templates/update-template:
     post:
       tags:
-        - Library
-        - Templates
+      - Library
+      - Templates
       summary: Update a template
       description: Updates an existing template with the provided content.
       operationId: update_template
@@ -196,98 +196,98 @@ paths:
         content:
           application/json:
             schema:
-              $ref: "#/components/schemas/UpdateTemplateEndpointRequest"
+              $ref: '#/components/schemas/UpdateTemplateEndpointRequest'
         required: true
       responses:
-        "204":
+        '204':
           description: Template updated successfully
   /v0/templates/{template_id}:
     get:
       tags:
-        - Library
-        - Templates
+      - Library
+      - Templates
       summary: Get template by ID
       description: Retrieve a specific template by its ID.
       operationId: get_template_by_id
       parameters:
-        - name: template_id
-          in: path
-          required: true
-          schema:
-            type: string
+      - name: template_id
+        in: path
+        required: true
+        schema:
+          type: string
       responses:
-        "200":
+        '200':
           description: Template retrieved successfully
           content:
             application/json:
               schema:
-                $ref: "#/components/schemas/Template"
+                $ref: '#/components/schemas/Template'
 components:
   schemas:
     Connection:
       type: object
       required:
-        - id
-        - dids
+      - id
+      - dids
       properties:
         alias:
           type:
-            - string
-            - "null"
+          - string
+          - 'null'
         credential_offer_endpoint:
           type:
-            - string
-            - "null"
+          - string
+          - 'null'
         dids:
           type: array
           items:
             type: string
         domain:
           type:
-            - string
-            - "null"
+          - string
+          - 'null'
         first_interacted:
           type:
-            - string
-            - "null"
+          - string
+          - 'null'
         id:
           type: string
         last_interacted:
           type:
-            - string
-            - "null"
+          - string
+          - 'null'
     CreateTemplateEndpointRequest:
       type: object
       properties:
         creator:
           type:
-            - string
-            - "null"
+          - string
+          - 'null'
           default: null
         dataModel:
           oneOf:
-            - type: "null"
-            - $ref: "#/components/schemas/CredentialFormat"
+          - type: 'null'
+          - $ref: '#/components/schemas/DataModel'
           default: null
         description:
           type:
-            - string
-            - "null"
+          - string
+          - 'null'
           default: null
         display:
           oneOf:
-            - type: "null"
-            - $ref: "#/components/schemas/Display"
+          - type: 'null'
+          - $ref: '#/components/schemas/Display'
           default: null
         holderType:
           oneOf:
-            - type: "null"
-            - $ref: "#/components/schemas/HolderType"
+          - type: 'null'
+          - $ref: '#/components/schemas/HolderType'
           default: null
         schema: {}
         status:
           oneOf:
-            - $ref: "#/components/schemas/TemplateStatus"
+          - $ref: '#/components/schemas/TemplateStatus'
           default: draft
         tags:
           type: array
@@ -296,8 +296,8 @@ components:
           default: []
         title:
           type:
-            - string
-            - "null"
+          - string
+          - 'null'
           default: null
         type:
           type: array
@@ -306,32 +306,32 @@ components:
           default: []
         visibility:
           oneOf:
-            - $ref: "#/components/schemas/Visibility"
+          - $ref: '#/components/schemas/Visibility'
           default: private
     Credential:
       type: object
       required:
-        - id
-        - credential_configuration
-        - status
-        - holder_notifications
-        - credential_status
+      - id
+      - credential_configuration
+      - status
+      - holder_notifications
+      - credential_status
       properties:
         created_at:
           type:
-            - string
-            - "null"
+          - string
+          - 'null'
         credential_configuration:
           type: object
           required:
-            - credential_format
+          - credential_format
           properties:
             credential_format:
               type: object
               enum:
-                - jwt_vc_json
-                - dc+sd-jwt
-                - vc+sd-jwt
+              - jwt_vc_json
+              - dc+sd-jwt
+              - vc+sd-jwt
             credential_metadata:
               type: object
               properties:
@@ -343,7 +343,7 @@ components:
                   items:
                     type: object
                     required:
-                      - name
+                    - name
                     properties:
                       background_color:
                         type: string
@@ -356,7 +356,7 @@ components:
                       logo:
                         type: object
                         required:
-                          - uri
+                        - uri
                         properties:
                           alt_text:
                             type: string
@@ -380,29 +380,29 @@ components:
             scope:
               type: object
         credential_status:
-          $ref: "#/components/schemas/CredentialStatus"
+          $ref: '#/components/schemas/CredentialStatus'
         data:
           oneOf:
-            - type: "null"
-            - $ref: "#/components/schemas/Data"
+          - type: 'null'
+          - $ref: '#/components/schemas/Data'
         expires_at:
           type:
-            - string
-            - "null"
+          - string
+          - 'null'
         holder_notifications:
           type: array
           items:
             type: object
             required:
-              - notification_id
-              - event
+            - notification_id
+            - event
             properties:
               event:
                 type: string
                 enum:
-                  - credential_accepted
-                  - credential_failure
-                  - credential_deleted
+                - credential_accepted
+                - credential_failure
+                - credential_deleted
               event_description:
                 type: string
               notification_id:
@@ -412,22 +412,16 @@ components:
           type: string
         notification_id:
           type:
-            - string
-            - "null"
+          - string
+          - 'null'
         signed: {}
         status:
-          $ref: "#/components/schemas/IssuanceStatus"
-    dataModel:
-      type: string
-      enum:
-        - w3c_vc_data_model_v1-1
-        - w3c_vc_data_model_v2-0
-        - open_badges_3-0
+          $ref: '#/components/schemas/IssuanceStatus'
     CredentialStatus:
       type: object
       required:
-        - index
-        - status
+      - index
+      - status
       properties:
         index:
           type: integer
@@ -435,38 +429,45 @@ components:
         status:
           type: string
           enum:
-            - VALID
-            - INVALID
-            - SUSPENDED
-            - UNDEFINED
+          - VALID
+          - INVALID
+          - SUSPENDED
+          - UNDEFINED
     Data:
       type: object
       required:
-        - raw
+      - raw
       properties:
         raw: {}
+    DataModel:
+      type: string
+      enum:
+      - w3c_vc_data_model_v1-1
+      - w3c_vc_data_model_v2-0
+      - open_badges_3-0
+      - europen_digital_credential_3-3
     DeleteTemplateEndpointRequest:
       type: object
       required:
-        - id
+      - id
       properties:
         id:
           type: string
     Display:
       type: object
       required:
-        - name
+      - name
       properties:
         logo:
           oneOf:
-            - type: "null"
-            - $ref: "#/components/schemas/Logo"
+          - type: 'null'
+          - $ref: '#/components/schemas/Logo'
         name:
           type: string
     DuplicateTemplateEndpointRequest:
       type: object
       required:
-        - sourceTemplateId
+      - sourceTemplateId
       properties:
         sourceTemplateId:
           type: string
@@ -475,137 +476,137 @@ components:
       properties:
         alias:
           type:
-            - string
-            - "null"
+          - string
+          - 'null'
         did:
           type:
-            - string
-            - "null"
+          - string
+          - 'null'
         domain:
           type:
-            - string
-            - "null"
+          - string
+          - 'null'
     HolderType:
       type: string
       enum:
-        - individual
-        - organization
+      - individual
+      - organization
     IssuanceStatus:
       type: string
       enum:
-        - Pending
-        - Issued
+      - Pending
+      - Issued
     Logo:
       type: object
       required:
-        - uri
+      - uri
       properties:
         alt_text:
           type:
-            - string
-            - "null"
+          - string
+          - 'null'
         uri:
           type: string
     Template:
       type: object
       description: Data transfer object for Templates.
       required:
-        - id
-        - tags
-        - status
-        - visibility
-        - type
+      - id
+      - tags
+      - status
+      - visibility
+      - type
       properties:
         creator:
           type:
-            - string
-            - "null"
+          - string
+          - 'null'
         dataModel:
           oneOf:
-            - type: "null"
-            - $ref: "#/components/schemas/CredentialFormat"
+          - type: 'null'
+          - $ref: '#/components/schemas/DataModel'
         description:
           type:
-            - string
-            - "null"
+          - string
+          - 'null'
         display:
           oneOf:
-            - type: "null"
-            - $ref: "#/components/schemas/Display"
+          - type: 'null'
+          - $ref: '#/components/schemas/Display'
         holderType:
           oneOf:
-            - type: "null"
-            - $ref: "#/components/schemas/HolderType"
+          - type: 'null'
+          - $ref: '#/components/schemas/HolderType'
         id:
           type: string
         modifiedAt:
           type:
-            - string
-            - "null"
+          - string
+          - 'null'
         schema: {}
         sourceTemplateId:
           type:
-            - string
-            - "null"
+          - string
+          - 'null'
         status:
-          $ref: "#/components/schemas/TemplateStatus"
+          $ref: '#/components/schemas/TemplateStatus'
         tags:
           type: array
           items:
             type: string
         title:
           type:
-            - string
-            - "null"
+          - string
+          - 'null'
         type:
           type: array
           items:
             type: string
         visibility:
-          $ref: "#/components/schemas/Visibility"
+          $ref: '#/components/schemas/Visibility'
     TemplateStatus:
       type: string
       enum:
-        - draft
-        - published
-        - archived
-        - deleted
+      - draft
+      - published
+      - archived
+      - deleted
     UpdateTemplateEndpointRequest:
       type: object
       properties:
         creator:
           type:
-            - string
-            - "null"
+          - string
+          - 'null'
           default: null
         dataModel:
           oneOf:
-            - type: "null"
-            - $ref: "#/components/schemas/CredentialFormat"
+          - type: 'null'
+          - $ref: '#/components/schemas/DataModel'
           default: null
         description:
           type:
-            - string
-            - "null"
+          - string
+          - 'null'
           default: null
         display:
           oneOf:
-            - type: "null"
-            - $ref: "#/components/schemas/Display"
+          - type: 'null'
+          - $ref: '#/components/schemas/Display'
           default: null
         holderType:
           oneOf:
-            - type: "null"
-            - $ref: "#/components/schemas/HolderType"
+          - type: 'null'
+          - $ref: '#/components/schemas/HolderType'
           default: null
         id:
           type: string
-          default: ""
+          default: ''
         schema: {}
         status:
           oneOf:
-            - type: "null"
-            - $ref: "#/components/schemas/TemplateStatus"
+          - type: 'null'
+          - $ref: '#/components/schemas/TemplateStatus'
           default: null
         tags:
           type: array
@@ -614,8 +615,8 @@ components:
           default: []
         title:
           type:
-            - string
-            - "null"
+          - string
+          - 'null'
           default: null
         type:
           type: array
@@ -624,23 +625,23 @@ components:
           default: []
         visibility:
           oneOf:
-            - type: "null"
-            - $ref: "#/components/schemas/Visibility"
+          - type: 'null'
+          - $ref: '#/components/schemas/Visibility'
           default: null
     Visibility:
       type: string
       enum:
-        - private
-        - public
+      - private
+      - public
 tags:
-  - name: Connections
-    description: Manage trusted connections.
-  - name: Issuance
-    description: Issue credentials to individuals and organizations, manage credential offers and track their status.
-  - name: Library
-    description: Manage your own templates, browse and import external templates.
-  - name: Templates
-    description: Create and manage templates which provide the structure for credentials to be issued.
+- name: Connections
+  description: Manage trusted connections.
+- name: Issuance
+  description: Issue credentials to individuals and organizations, manage credential offers and track their status.
+- name: Library
+  description: Manage your own templates, browse and import external templates.
+- name: Templates
+  description: Create and manage templates which provide the structure for credentials to be issued.
 externalDocs:
   url: https://docs.impierce.com/unicore
   description: Official UniCore documentation

--- a/agent_api_http/openapi-generated.yaml
+++ b/agent_api_http/openapi-generated.yaml
@@ -1,18 +1,18 @@
 openapi: 3.1.0
 info:
   title: UniCore HTTP API
-  description: ''
+  description: ""
   license:
     name: Apache 2.0
   version: 0.0.0-semantically-released
 servers:
-- url: http://localhost:3033
-  description: Local development
+  - url: http://localhost:3033
+    description: Local development
 paths:
   /v0/connections:
     get:
       tags:
-      - Connections
+        - Connections
       summary: List all connections
       description: List all available connections.
       operationId: get_all_connections
@@ -20,78 +20,78 @@ paths:
         content:
           application/x-www-form-urlencoded:
             schema:
-              $ref: '#/components/schemas/GetConnectionsEndpointRequest'
+              $ref: "#/components/schemas/GetConnectionsEndpointRequest"
         required: true
       responses:
-        '200':
+        "200":
           description: All connections retrieved successfully
           content:
             application/json:
               schema:
                 type: array
                 items:
-                  $ref: '#/components/schemas/Connection'
+                  $ref: "#/components/schemas/Connection"
   /v0/connections/{connection_id}:
     get:
       tags:
-      - Connections
+        - Connections
       summary: Get connection by ID
       description: Retrieve a specific connection by its unique identifier.
       operationId: get_connection_by_id
       parameters:
-      - name: connection_id
-        in: path
-        required: true
-        schema:
-          type: string
+        - name: connection_id
+          in: path
+          required: true
+          schema:
+            type: string
       responses:
-        '200':
+        "200":
           description: Connection retrieved successfully
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/Connection'
+                $ref: "#/components/schemas/Connection"
   /v0/credentials:
     get:
       tags:
-      - Issuance
+        - Issuance
       summary: List all credentials
       description: Lists all credentials including their current status and metadata.
       operationId: get_all_credentials
       responses:
-        '200':
+        "200":
           description: List of all credentials
           content:
             application/json:
               schema:
                 type: array
                 items:
-                  $ref: '#/components/schemas/Credential'
+                  $ref: "#/components/schemas/Credential"
   /v0/credentials/{credential_id}:
     get:
       tags:
-      - Issuance
+        - Issuance
       summary: Get credential by ID
       description: Retrieves a credential by its ID.
       operationId: get_credential_by_id
       parameters:
-      - name: credential_id
-        in: path
-        required: true
-        schema:
-          type: string
+        - name: credential_id
+          in: path
+          required: true
+          schema:
+            type: string
       responses:
-        '200':
+        "200":
           description: Successfully retrieved credential
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/Credential'
+                $ref: "#/components/schemas/Credential"
   /v0/templates/create-template:
     post:
       tags:
-      - Library
-      - Templates
+        - Library
+        - Templates
       summary: Create a new template
       description: Creates a new template which can be used to issue credentials.
       operationId: create_template
@@ -99,17 +99,17 @@ paths:
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/CreateTemplateEndpointRequest'
+              $ref: "#/components/schemas/CreateTemplateEndpointRequest"
             examples:
               Standard template:
                 description: A simple example that will issue credentials in the W3C Verifiable Credentials Data Model v1.1 format.
                 value:
                   title: Standard template
-                  credentialFormat: w3c_vc_data_model_v1-1
+                  dataModel: w3c_vc_data_model_v1-1
                   holderType: individual
         required: true
       responses:
-        '201':
+        "201":
           description: New template created successfully
           headers:
             Location:
@@ -119,12 +119,12 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/Template'
+                $ref: "#/components/schemas/Template"
   /v0/templates/delete-template:
     post:
       tags:
-      - Library
-      - Templates
+        - Library
+        - Templates
       summary: Delete a template
       description: Deletes a template by marking its status as `Deleted`. Deleted templates will no longer appear in any views.
       operationId: delete_template_by_id
@@ -132,16 +132,16 @@ paths:
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/DeleteTemplateEndpointRequest'
+              $ref: "#/components/schemas/DeleteTemplateEndpointRequest"
         required: true
       responses:
-        '204':
+        "204":
           description: Template deleted successfully
   /v0/templates/duplicate-template:
     post:
       tags:
-      - Library
-      - Templates
+        - Library
+        - Templates
       summary: Duplicate existing template
       description: Creates a duplicate of an existing template.
       operationId: duplicate_template
@@ -149,12 +149,12 @@ paths:
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/DuplicateTemplateEndpointRequest'
+              $ref: "#/components/schemas/DuplicateTemplateEndpointRequest"
             example:
               sourceTemplateId: 91fc790f-d876-4827-9a9d-0fb0f6766dca
         required: true
       responses:
-        '201':
+        "201":
           description: Duplicate created successfully
           headers:
             Location:
@@ -164,31 +164,31 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/Template'
-        '422':
+                $ref: "#/components/schemas/Template"
+        "422":
           description: Source Template Not Found
   /v0/templates/get-all-templates:
     get:
       tags:
-      - Library
-      - Templates
+        - Library
+        - Templates
       summary: List all templates
       description: List all available templates.
       operationId: get_all_templates
       responses:
-        '200':
+        "200":
           description: All templates retrieved successfully
           content:
             application/json:
               schema:
                 type: array
                 items:
-                  $ref: '#/components/schemas/Template'
+                  $ref: "#/components/schemas/Template"
   /v0/templates/update-template:
     post:
       tags:
-      - Library
-      - Templates
+        - Library
+        - Templates
       summary: Update a template
       description: Updates an existing template with the provided content.
       operationId: update_template
@@ -196,98 +196,98 @@ paths:
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/UpdateTemplateEndpointRequest'
+              $ref: "#/components/schemas/UpdateTemplateEndpointRequest"
         required: true
       responses:
-        '204':
+        "204":
           description: Template updated successfully
   /v0/templates/{template_id}:
     get:
       tags:
-      - Library
-      - Templates
+        - Library
+        - Templates
       summary: Get template by ID
       description: Retrieve a specific template by its ID.
       operationId: get_template_by_id
       parameters:
-      - name: template_id
-        in: path
-        required: true
-        schema:
-          type: string
+        - name: template_id
+          in: path
+          required: true
+          schema:
+            type: string
       responses:
-        '200':
+        "200":
           description: Template retrieved successfully
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/Template'
+                $ref: "#/components/schemas/Template"
 components:
   schemas:
     Connection:
       type: object
       required:
-      - id
-      - dids
+        - id
+        - dids
       properties:
         alias:
           type:
-          - string
-          - 'null'
+            - string
+            - "null"
         credential_offer_endpoint:
           type:
-          - string
-          - 'null'
+            - string
+            - "null"
         dids:
           type: array
           items:
             type: string
         domain:
           type:
-          - string
-          - 'null'
+            - string
+            - "null"
         first_interacted:
           type:
-          - string
-          - 'null'
+            - string
+            - "null"
         id:
           type: string
         last_interacted:
           type:
-          - string
-          - 'null'
+            - string
+            - "null"
     CreateTemplateEndpointRequest:
       type: object
       properties:
         creator:
           type:
-          - string
-          - 'null'
+            - string
+            - "null"
           default: null
-        credentialFormat:
+        dataModel:
           oneOf:
-          - type: 'null'
-          - $ref: '#/components/schemas/CredentialFormat'
+            - type: "null"
+            - $ref: "#/components/schemas/CredentialFormat"
           default: null
         description:
           type:
-          - string
-          - 'null'
+            - string
+            - "null"
           default: null
         display:
           oneOf:
-          - type: 'null'
-          - $ref: '#/components/schemas/Display'
+            - type: "null"
+            - $ref: "#/components/schemas/Display"
           default: null
         holderType:
           oneOf:
-          - type: 'null'
-          - $ref: '#/components/schemas/HolderType'
+            - type: "null"
+            - $ref: "#/components/schemas/HolderType"
           default: null
         schema: {}
         status:
           oneOf:
-          - $ref: '#/components/schemas/TemplateStatus'
+            - $ref: "#/components/schemas/TemplateStatus"
           default: draft
         tags:
           type: array
@@ -296,8 +296,8 @@ components:
           default: []
         title:
           type:
-          - string
-          - 'null'
+            - string
+            - "null"
           default: null
         type:
           type: array
@@ -306,32 +306,32 @@ components:
           default: []
         visibility:
           oneOf:
-          - $ref: '#/components/schemas/Visibility'
+            - $ref: "#/components/schemas/Visibility"
           default: private
     Credential:
       type: object
       required:
-      - id
-      - credential_configuration
-      - status
-      - holder_notifications
-      - credential_status
+        - id
+        - credential_configuration
+        - status
+        - holder_notifications
+        - credential_status
       properties:
         created_at:
           type:
-          - string
-          - 'null'
+            - string
+            - "null"
         credential_configuration:
           type: object
           required:
-          - credential_format
+            - credential_format
           properties:
             credential_format:
               type: object
               enum:
-              - jwt_vc_json
-              - dc+sd-jwt
-              - vc+sd-jwt
+                - jwt_vc_json
+                - dc+sd-jwt
+                - vc+sd-jwt
             credential_metadata:
               type: object
               properties:
@@ -343,7 +343,7 @@ components:
                   items:
                     type: object
                     required:
-                    - name
+                      - name
                     properties:
                       background_color:
                         type: string
@@ -356,7 +356,7 @@ components:
                       logo:
                         type: object
                         required:
-                        - uri
+                          - uri
                         properties:
                           alt_text:
                             type: string
@@ -380,29 +380,29 @@ components:
             scope:
               type: object
         credential_status:
-          $ref: '#/components/schemas/CredentialStatus'
+          $ref: "#/components/schemas/CredentialStatus"
         data:
           oneOf:
-          - type: 'null'
-          - $ref: '#/components/schemas/Data'
+            - type: "null"
+            - $ref: "#/components/schemas/Data"
         expires_at:
           type:
-          - string
-          - 'null'
+            - string
+            - "null"
         holder_notifications:
           type: array
           items:
             type: object
             required:
-            - notification_id
-            - event
+              - notification_id
+              - event
             properties:
               event:
                 type: string
                 enum:
-                - credential_accepted
-                - credential_failure
-                - credential_deleted
+                  - credential_accepted
+                  - credential_failure
+                  - credential_deleted
               event_description:
                 type: string
               notification_id:
@@ -412,22 +412,22 @@ components:
           type: string
         notification_id:
           type:
-          - string
-          - 'null'
+            - string
+            - "null"
         signed: {}
         status:
-          $ref: '#/components/schemas/IssuanceStatus'
-    CredentialFormat:
+          $ref: "#/components/schemas/IssuanceStatus"
+    dataModel:
       type: string
       enum:
-      - w3c_vc_data_model_v1-1
-      - w3c_vc_data_model_v2-0
-      - open_badges_3-0
+        - w3c_vc_data_model_v1-1
+        - w3c_vc_data_model_v2-0
+        - open_badges_3-0
     CredentialStatus:
       type: object
       required:
-      - index
-      - status
+        - index
+        - status
       properties:
         index:
           type: integer
@@ -435,38 +435,38 @@ components:
         status:
           type: string
           enum:
-          - VALID
-          - INVALID
-          - SUSPENDED
-          - UNDEFINED
+            - VALID
+            - INVALID
+            - SUSPENDED
+            - UNDEFINED
     Data:
       type: object
       required:
-      - raw
+        - raw
       properties:
         raw: {}
     DeleteTemplateEndpointRequest:
       type: object
       required:
-      - id
+        - id
       properties:
         id:
           type: string
     Display:
       type: object
       required:
-      - name
+        - name
       properties:
         logo:
           oneOf:
-          - type: 'null'
-          - $ref: '#/components/schemas/Logo'
+            - type: "null"
+            - $ref: "#/components/schemas/Logo"
         name:
           type: string
     DuplicateTemplateEndpointRequest:
       type: object
       required:
-      - sourceTemplateId
+        - sourceTemplateId
       properties:
         sourceTemplateId:
           type: string
@@ -475,137 +475,137 @@ components:
       properties:
         alias:
           type:
-          - string
-          - 'null'
+            - string
+            - "null"
         did:
           type:
-          - string
-          - 'null'
+            - string
+            - "null"
         domain:
           type:
-          - string
-          - 'null'
+            - string
+            - "null"
     HolderType:
       type: string
       enum:
-      - individual
-      - organization
+        - individual
+        - organization
     IssuanceStatus:
       type: string
       enum:
-      - Pending
-      - Issued
+        - Pending
+        - Issued
     Logo:
       type: object
       required:
-      - uri
+        - uri
       properties:
         alt_text:
           type:
-          - string
-          - 'null'
+            - string
+            - "null"
         uri:
           type: string
     Template:
       type: object
       description: Data transfer object for Templates.
       required:
-      - id
-      - tags
-      - status
-      - visibility
-      - type
+        - id
+        - tags
+        - status
+        - visibility
+        - type
       properties:
         creator:
           type:
-          - string
-          - 'null'
-        credentialFormat:
+            - string
+            - "null"
+        dataModel:
           oneOf:
-          - type: 'null'
-          - $ref: '#/components/schemas/CredentialFormat'
+            - type: "null"
+            - $ref: "#/components/schemas/CredentialFormat"
         description:
           type:
-          - string
-          - 'null'
+            - string
+            - "null"
         display:
           oneOf:
-          - type: 'null'
-          - $ref: '#/components/schemas/Display'
+            - type: "null"
+            - $ref: "#/components/schemas/Display"
         holderType:
           oneOf:
-          - type: 'null'
-          - $ref: '#/components/schemas/HolderType'
+            - type: "null"
+            - $ref: "#/components/schemas/HolderType"
         id:
           type: string
         modifiedAt:
           type:
-          - string
-          - 'null'
+            - string
+            - "null"
         schema: {}
         sourceTemplateId:
           type:
-          - string
-          - 'null'
+            - string
+            - "null"
         status:
-          $ref: '#/components/schemas/TemplateStatus'
+          $ref: "#/components/schemas/TemplateStatus"
         tags:
           type: array
           items:
             type: string
         title:
           type:
-          - string
-          - 'null'
+            - string
+            - "null"
         type:
           type: array
           items:
             type: string
         visibility:
-          $ref: '#/components/schemas/Visibility'
+          $ref: "#/components/schemas/Visibility"
     TemplateStatus:
       type: string
       enum:
-      - draft
-      - published
-      - archived
-      - deleted
+        - draft
+        - published
+        - archived
+        - deleted
     UpdateTemplateEndpointRequest:
       type: object
       properties:
         creator:
           type:
-          - string
-          - 'null'
+            - string
+            - "null"
           default: null
-        credentialFormat:
+        dataModel:
           oneOf:
-          - type: 'null'
-          - $ref: '#/components/schemas/CredentialFormat'
+            - type: "null"
+            - $ref: "#/components/schemas/CredentialFormat"
           default: null
         description:
           type:
-          - string
-          - 'null'
+            - string
+            - "null"
           default: null
         display:
           oneOf:
-          - type: 'null'
-          - $ref: '#/components/schemas/Display'
+            - type: "null"
+            - $ref: "#/components/schemas/Display"
           default: null
         holderType:
           oneOf:
-          - type: 'null'
-          - $ref: '#/components/schemas/HolderType'
+            - type: "null"
+            - $ref: "#/components/schemas/HolderType"
           default: null
         id:
           type: string
-          default: ''
+          default: ""
         schema: {}
         status:
           oneOf:
-          - type: 'null'
-          - $ref: '#/components/schemas/TemplateStatus'
+            - type: "null"
+            - $ref: "#/components/schemas/TemplateStatus"
           default: null
         tags:
           type: array
@@ -614,8 +614,8 @@ components:
           default: []
         title:
           type:
-          - string
-          - 'null'
+            - string
+            - "null"
           default: null
         type:
           type: array
@@ -624,23 +624,23 @@ components:
           default: []
         visibility:
           oneOf:
-          - type: 'null'
-          - $ref: '#/components/schemas/Visibility'
+            - type: "null"
+            - $ref: "#/components/schemas/Visibility"
           default: null
     Visibility:
       type: string
       enum:
-      - private
-      - public
+        - private
+        - public
 tags:
-- name: Connections
-  description: Manage trusted connections.
-- name: Issuance
-  description: Issue credentials to individuals and organizations, manage credential offers and track their status.
-- name: Library
-  description: Manage your own templates, browse and import external templates.
-- name: Templates
-  description: Create and manage templates which provide the structure for credentials to be issued.
+  - name: Connections
+    description: Manage trusted connections.
+  - name: Issuance
+    description: Issue credentials to individuals and organizations, manage credential offers and track their status.
+  - name: Library
+    description: Manage your own templates, browse and import external templates.
+  - name: Templates
+    description: Create and manage templates which provide the structure for credentials to be issued.
 externalDocs:
   url: https://docs.impierce.com/unicore
   description: Official UniCore documentation

--- a/agent_api_http/openapi.yaml
+++ b/agent_api_http/openapi.yaml
@@ -1054,7 +1054,7 @@ paths:
                   value:
                     - id: "550e8400-e29b-41d4-a716-446655440000"
                       title: "Employee ID Credential"
-                      credentialFormat: "w3c_vc_data_model_v1-1"
+                      dataModel: "w3c_vc_data_model_v1-1"
                       status: "published"
                       visibility: "public"
                       type:
@@ -1105,8 +1105,8 @@ paths:
                   example: "Employee ID Credential"
                 display:
                   $ref: "#/components/schemas/Display"
-                credentialFormat:
-                  $ref: "#/components/schemas/CredentialFormat"
+                dataModel:
+                  $ref: "#/components/schemas/DataModel"
                 creator:
                   type: string
                 holderType:
@@ -1168,8 +1168,8 @@ paths:
                   type: string
                 display:
                   $ref: "#/components/schemas/Display"
-                credentialFormat:
-                  $ref: "#/components/schemas/CredentialFormat"
+                dataModel:
+                  $ref: "#/components/schemas/DataModel"
                 creator:
                   type: string
                 holderType:
@@ -2044,7 +2044,7 @@ components:
         logo:
           $ref: "#/components/schemas/Logo"
 
-    CredentialFormat:
+    DataModel:
       type: string
       enum:
         - "w3c_vc_data_model_v1-1"
@@ -2099,9 +2099,9 @@ components:
         display:
           allOf:
             - $ref: "#/components/schemas/Display"
-        credentialFormat:
+        dataModel:
           allOf:
-            - $ref: "#/components/schemas/CredentialFormat"
+            - $ref: "#/components/schemas/DataModel"
         creator:
           type: string
           description: Identifier of the template creator

--- a/agent_api_http/openapi.yaml
+++ b/agent_api_http/openapi.yaml
@@ -517,7 +517,7 @@ paths:
                       name: Identity Credential
                   format: vc+sd-jwt
               elm_sd_jwt_credential_configurations:
-                summary: Europen Digital Credential V3.3 SD-JWT
+                summary: European Digital Credential V3.3 SD-JWT
                 value:
                   credential_configuration_id: elm_vc+sd-jwt
                   type:

--- a/agent_api_http/postman/ssi-agent.postman_collection.json
+++ b/agent_api_http/postman/ssi-agent.postman_collection.json
@@ -2451,7 +2451,7 @@
                 "header": [],
                 "body": {
                   "mode": "raw",
-                  "raw": "{\n    \"title\": \"My Example Template\",\n    \"credentialFormat\": \"w3c_vc_data_model_v1-1\",\n    \"holderType\": \"organization\"\n}",
+                  "raw": "{\n    \"title\": \"My Example Template\",\n    \"dataModel\": \"w3c_vc_data_model_v1-1\",\n    \"holderType\": \"organization\"\n}",
                   "options": {
                     "raw": {
                       "language": "json"

--- a/agent_api_http/src/v0/templates/mod.rs
+++ b/agent_api_http/src/v0/templates/mod.rs
@@ -2,7 +2,7 @@ use crate::error::type_url;
 use crate::handlers::{command_handler, query_handler};
 use crate::API_VERSION;
 use agent_library::state::LibraryState;
-use agent_library::template::aggregate::{CredentialFormat, Display, HolderType, Status, Template, Visibility};
+use agent_library::template::aggregate::{DataModel, Display, HolderType, Status, Template, Visibility};
 use agent_library::template::command::TemplateCommand;
 use axum::{
     extract::{Path, State},
@@ -27,7 +27,7 @@ pub struct TemplateDto {
     pub source_template_id: Option<String>,
     pub title: Option<String>,
     pub display: Option<Display>,
-    pub credential_format: Option<CredentialFormat>,
+    pub data_model: Option<DataModel>,
     pub creator: Option<String>,
     pub holder_type: Option<HolderType>,
     pub modified_at: Option<String>,
@@ -46,7 +46,7 @@ impl From<Template> for TemplateDto {
             source_template_id: value.source_template_id,
             title: value.title,
             display: value.display,
-            credential_format: value.credential_format,
+            data_model: value.data_model,
             creator: value.creator,
             holder_type: value.holder_type,
             modified_at: value.modified_at,
@@ -65,7 +65,7 @@ impl From<Template> for TemplateDto {
 pub struct CreateTemplateEndpointRequest {
     pub title: Option<String>,
     pub display: Option<Display>,
-    pub credential_format: Option<CredentialFormat>,
+    pub data_model: Option<DataModel>,
     pub creator: Option<String>,
     pub holder_type: Option<HolderType>,
     pub tags: Vec<String>,
@@ -88,7 +88,7 @@ pub struct CreateTemplateEndpointRequest {
         examples(
             ("Standard template" = (
                 description = "A simple example that will issue credentials in the W3C Verifiable Credentials Data Model v1.1 format.",
-                value = json!({ "title": "Standard template", "credentialFormat": "w3c_vc_data_model_v1-1", "holderType": "individual" })
+                value = json!({ "title": "Standard template", "dataModel": "w3c_vc_data_model_v1-1", "holderType": "individual" })
             ))
         )
     ),
@@ -102,7 +102,7 @@ pub(crate) async fn create_template(
     Json(CreateTemplateEndpointRequest {
         title,
         display,
-        credential_format,
+        data_model,
         creator,
         holder_type,
         tags,
@@ -120,7 +120,7 @@ pub(crate) async fn create_template(
         source_template_id: None,
         title,
         display,
-        credential_format,
+        data_model,
         creator,
         holder_type,
         tags,
@@ -192,7 +192,7 @@ pub(crate) async fn duplicate_template(
         source_template_id: Some(source_template_id),
         title: original_template.title.map(|t| format!("{} Copy", t)),
         display: original_template.display,
-        credential_format: original_template.credential_format,
+        data_model: original_template.data_model,
         creator: original_template.creator,
         holder_type: original_template.holder_type,
         tags: original_template.tags,
@@ -225,7 +225,7 @@ pub struct UpdateTemplateEndpointRequest {
     pub template_id: String,
     pub title: Option<String>,
     pub display: Option<Display>,
-    pub credential_format: Option<CredentialFormat>,
+    pub data_model: Option<DataModel>,
     pub creator: Option<String>,
     pub holder_type: Option<HolderType>,
     pub tags: Vec<String>,
@@ -255,7 +255,7 @@ pub(crate) async fn update_template(
         template_id,
         title,
         display,
-        credential_format,
+        data_model,
         creator,
         holder_type,
         tags,
@@ -300,10 +300,10 @@ pub(crate) async fn update_template(
         command_handler(&template_id, &state.command.template, command).await?;
     }
 
-    if let Some(credential_format) = credential_format {
-        let command = TemplateCommand::UpdateCredentialFormat {
+    if let Some(data_model) = data_model {
+        let command = TemplateCommand::UpdateDataModel {
             template_id: template_id.clone(),
-            credential_format,
+            data_model,
         };
         command_handler(&template_id, &state.command.template, command).await?;
     }

--- a/agent_event_publisher_http/README.md
+++ b/agent_event_publisher_http/README.md
@@ -110,7 +110,7 @@ LinkedVerifiablePresentationServiceCreated
 TemplateCreated
 TitleUpdated
 DisplayUpdated
-CredentialFormatUpdated
+DataModelUpdated
 CreatorUpdated
 HolderTypeUpdated
 TagsUpdated

--- a/agent_library/src/template/aggregate.rs
+++ b/agent_library/src/template/aggregate.rs
@@ -20,6 +20,7 @@ pub struct Display {
     pub logo: Option<Logo>,
 }
 
+// TODO: rename to CredentialDataFormat since elsewhere we use `format` to indicate credential format identifiers.
 #[derive(Debug, Clone, Serialize, Deserialize, Eq, PartialEq, utoipa::ToSchema)]
 pub enum CredentialFormat {
     // See https://www.w3.org/TR/vc-data-model-1.1/
@@ -31,6 +32,9 @@ pub enum CredentialFormat {
     // See https://www.imsglobal.org/spec/ob/v3p0/
     #[serde(rename = "open_badges_3-0")]
     OpenBadges30,
+    // See https://op.europa.eu/en/web/eu-vocabularies/dataset/-/resource?uri=http://publications.europa.eu/resource/dataset/snb-model
+    #[serde(rename = "europen_digital_credential_3-3")]
+    EuropenDigitalCredential33,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, Eq, PartialEq, utoipa::ToSchema)]

--- a/agent_library/src/template/aggregate.rs
+++ b/agent_library/src/template/aggregate.rs
@@ -32,8 +32,8 @@ pub enum DataModel {
     #[serde(rename = "open_badges_3-0")]
     OpenBadges30,
     // See https://op.europa.eu/en/web/eu-vocabularies/dataset/-/resource?uri=http://publications.europa.eu/resource/dataset/snb-model
-    #[serde(rename = "europen_digital_credential_3-3")]
-    EuropenDigitalCredential33,
+    #[serde(rename = "european_learning_model_v3-3")]
+    EuropeanLearningModelV33,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, Eq, PartialEq, utoipa::ToSchema)]

--- a/agent_library/src/template/aggregate.rs
+++ b/agent_library/src/template/aggregate.rs
@@ -24,16 +24,16 @@ pub struct Display {
 pub enum DataModel {
     // See https://www.w3.org/TR/vc-data-model-1.1/
     #[serde(rename = "w3c_vc_data_model_v1-1")]
-    W3CVcDataModelV11,
+    W3CVcDataModelV1_1,
     // See https://www.w3.org/TR/vc-data-model-2.0/
     #[serde(rename = "w3c_vc_data_model_v2-0")]
-    W3CVcDataModelV20,
+    W3CVcDataModelV2_0,
     // See https://www.imsglobal.org/spec/ob/v3p0/
     #[serde(rename = "open_badges_3-0")]
-    OpenBadges30,
+    OpenBadges3_0,
     // See https://op.europa.eu/en/web/eu-vocabularies/dataset/-/resource?uri=http://publications.europa.eu/resource/dataset/snb-model
     #[serde(rename = "european_learning_model_v3-3")]
-    EuropeanLearningModelV33,
+    EuropeanLearningModelV3_3,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, Eq, PartialEq, utoipa::ToSchema)]
@@ -511,7 +511,7 @@ pub mod test_utils {
 
     #[fixture]
     pub fn data_model() -> Option<DataModel> {
-        Some(DataModel::W3CVcDataModelV11)
+        Some(DataModel::W3CVcDataModelV1_1)
     }
 
     #[fixture]

--- a/agent_library/src/template/aggregate.rs
+++ b/agent_library/src/template/aggregate.rs
@@ -20,9 +20,8 @@ pub struct Display {
     pub logo: Option<Logo>,
 }
 
-// TODO: rename to CredentialDataFormat since elsewhere we use `format` to indicate credential format identifiers.
 #[derive(Debug, Clone, Serialize, Deserialize, Eq, PartialEq, utoipa::ToSchema)]
-pub enum CredentialFormat {
+pub enum DataModel {
     // See https://www.w3.org/TR/vc-data-model-1.1/
     #[serde(rename = "w3c_vc_data_model_v1-1")]
     W3CVcDataModelV11,
@@ -71,7 +70,7 @@ pub struct Template {
     pub source_template_id: Option<String>,
     pub title: Option<String>,
     pub display: Option<Display>,
-    pub credential_format: Option<CredentialFormat>,
+    pub data_model: Option<DataModel>,
     pub creator: Option<String>,
     pub holder_type: Option<HolderType>,
     pub modified_at: Option<String>,
@@ -110,7 +109,7 @@ impl Aggregate for Template {
                 source_template_id,
                 title,
                 display,
-                credential_format,
+                data_model,
                 creator,
                 holder_type,
                 tags,
@@ -130,7 +129,7 @@ impl Aggregate for Template {
                     source_template_id,
                     title,
                     display,
-                    credential_format,
+                    data_model,
                     creator,
                     holder_type,
                     modified_at,
@@ -166,18 +165,18 @@ impl Aggregate for Template {
                     modified_at,
                 }])
             }
-            UpdateCredentialFormat {
+            UpdateDataModel {
                 template_id,
-                credential_format,
+                data_model,
             } => {
                 #[cfg(not(test))]
                 let modified_at = chrono::Utc::now().to_rfc3339();
                 #[cfg(test)]
                 let modified_at = test_utils::modified_at();
 
-                Ok(vec![CredentialFormatUpdated {
+                Ok(vec![DataModelUpdated {
                     template_id,
-                    credential_format,
+                    data_model,
                     modified_at,
                 }])
             }
@@ -301,7 +300,7 @@ impl Aggregate for Template {
                 source_template_id,
                 title,
                 display,
-                credential_format,
+                data_model,
                 creator,
                 holder_type,
                 modified_at,
@@ -316,7 +315,7 @@ impl Aggregate for Template {
                 self.source_template_id = source_template_id;
                 self.title = title;
                 self.display = display;
-                self.credential_format = credential_format;
+                self.data_model = data_model;
                 self.creator = creator;
                 self.holder_type = holder_type;
                 self.modified_at.replace(modified_at);
@@ -343,12 +342,12 @@ impl Aggregate for Template {
                 self.display = Some(display);
                 self.modified_at.replace(modified_at);
             }
-            CredentialFormatUpdated {
+            DataModelUpdated {
                 template_id: _,
-                credential_format,
+                data_model,
                 modified_at,
             } => {
-                self.credential_format = Some(credential_format);
+                self.data_model = Some(data_model);
                 self.modified_at.replace(modified_at);
             }
             CreatorUpdated {
@@ -440,7 +439,7 @@ pub mod document_tests {
         template_id: String,
         title: Option<String>,
         display: Option<Display>,
-        credential_format: Option<CredentialFormat>,
+        data_model: Option<DataModel>,
         creator: Option<String>,
         holder_type: Option<HolderType>,
         modified_at: String,
@@ -458,7 +457,7 @@ pub mod document_tests {
                 source_template_id: None,
                 title: title.clone(),
                 display: display.clone(),
-                credential_format: credential_format.clone(),
+                data_model: data_model.clone(),
                 creator: creator.clone(),
                 holder_type: holder_type.clone(),
                 tags: tags.clone(),
@@ -473,7 +472,7 @@ pub mod document_tests {
                 source_template_id: None,
                 title,
                 display,
-                credential_format,
+                data_model,
                 creator,
                 holder_type,
                 modified_at,
@@ -511,8 +510,8 @@ pub mod test_utils {
     }
 
     #[fixture]
-    pub fn credential_format() -> Option<CredentialFormat> {
-        Some(CredentialFormat::W3CVcDataModelV11)
+    pub fn data_model() -> Option<DataModel> {
+        Some(DataModel::W3CVcDataModelV11)
     }
 
     #[fixture]

--- a/agent_library/src/template/command.rs
+++ b/agent_library/src/template/command.rs
@@ -1,4 +1,4 @@
-pub use super::aggregate::{CredentialFormat, Display, HolderType, Status, Visibility};
+pub use super::aggregate::{DataModel, Display, HolderType, Status, Visibility};
 use serde::Deserialize;
 
 #[derive(Debug, Deserialize)]
@@ -9,7 +9,7 @@ pub enum TemplateCommand {
         source_template_id: Option<String>,
         title: Option<String>,
         display: Option<Display>,
-        credential_format: Option<CredentialFormat>,
+        data_model: Option<DataModel>,
         creator: Option<String>,
         holder_type: Option<HolderType>,
         tags: Vec<String>,
@@ -27,9 +27,9 @@ pub enum TemplateCommand {
         template_id: String,
         display: Display,
     },
-    UpdateCredentialFormat {
+    UpdateDataModel {
         template_id: String,
-        credential_format: CredentialFormat,
+        data_model: DataModel,
     },
     UpdateCreator {
         template_id: String,

--- a/agent_library/src/template/event.rs
+++ b/agent_library/src/template/event.rs
@@ -1,4 +1,4 @@
-pub use super::aggregate::{CredentialFormat, Display, HolderType, Status, Visibility};
+pub use super::aggregate::{DataModel, Display, HolderType, Status, Visibility};
 use cqrs_es::DomainEvent;
 use serde::{Deserialize, Serialize};
 use strum::Display;
@@ -12,7 +12,7 @@ pub enum TemplateEvent {
         // TODO: Make this a required field.
         title: Option<String>,
         display: Option<Display>,
-        credential_format: Option<CredentialFormat>,
+        data_model: Option<DataModel>,
         creator: Option<String>,
         holder_type: Option<HolderType>,
         modified_at: String,
@@ -33,9 +33,9 @@ pub enum TemplateEvent {
         display: Display,
         modified_at: String,
     },
-    CredentialFormatUpdated {
+    DataModelUpdated {
         template_id: String,
-        credential_format: CredentialFormat,
+        data_model: DataModel,
         modified_at: String,
     },
     CreatorUpdated {

--- a/agent_library/src/template/views/mod.rs
+++ b/agent_library/src/template/views/mod.rs
@@ -16,7 +16,7 @@ impl View<Template> for Template {
                 source_template_id,
                 title,
                 display,
-                credential_format,
+                data_model,
                 creator,
                 holder_type,
                 modified_at,
@@ -31,7 +31,7 @@ impl View<Template> for Template {
                 self.source_template_id.clone_from(source_template_id);
                 self.title.clone_from(title);
                 self.display.clone_from(display);
-                self.credential_format.clone_from(credential_format);
+                self.data_model.clone_from(data_model);
                 self.creator.clone_from(creator);
                 self.holder_type.clone_from(holder_type);
                 self.modified_at.replace(modified_at.clone());
@@ -58,12 +58,12 @@ impl View<Template> for Template {
                 self.display.replace(display.clone());
                 self.modified_at.replace(modified_at.clone());
             }
-            CredentialFormatUpdated {
+            DataModelUpdated {
                 template_id: _,
-                credential_format,
+                data_model,
                 modified_at,
             } => {
-                self.credential_format.replace(credential_format.clone());
+                self.data_model.replace(data_model.clone());
                 self.modified_at.replace(modified_at.clone());
             }
             CreatorUpdated {

--- a/agent_shared/src/config/mod.rs
+++ b/agent_shared/src/config/mod.rs
@@ -685,7 +685,7 @@ pub enum TemplateEvent {
     TemplateCreated,
     TitleUpdated,
     DisplayUpdated,
-    CredentialFormatUpdated,
+    DataModelUpdated,
     CreatorUpdated,
     HolderTypeUpdated,
     TagsUpdated,


### PR DESCRIPTION
# Description of change
I've added the `EuropeanDigitalCredential` variant to the `DataModel` enum for Templates.
This enables creating Templates for the ELM Data Model.

Furthermore, i've renamed the `credentialFormat` name to `dataModel` which is more consistent with naming throughout our codebase.

## BREAKING CHANGE
Rename `credentialFormat` to `dataModel` in the Template data model.

## Links to any relevant issues
-

## How the change has been tested
Old tests pass, since the chance is so small no new tests are needed.

## Definition of Done checklist
Add an `x` to the boxes that are relevant to your changes.

- [x] I have followed the contribution guidelines for this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] I have successfully tested this change in a docker environment 
