### PR TITLE
fix: skip serializing `delete` field in `Connection` view

### DIFF
--- a/agent_api_http/openapi-generated.yaml
+++ b/agent_api_http/openapi-generated.yaml
@@ -298,11 +298,15 @@ components:
   schemas:
     AcceptConnectionChangesRequest:
       type: object
+      required:
+      - id
       properties:
         id:
           type: string
     AddConnectionEndpointRequest:
       type: object
+      required:
+      - url
       properties:
         url:
           type: string
@@ -310,6 +314,7 @@ components:
       type: object
       required:
       - id
+      - url
       - dids
       - validations
       properties:
@@ -338,9 +343,7 @@ components:
           - type: 'null'
           - $ref: '#/components/schemas/PendingChanges'
         url:
-          type:
-          - string
-          - 'null'
+          type: string
           format: uri
         validations:
           type: array
@@ -652,11 +655,15 @@ components:
           - $ref: '#/components/schemas/ConnectionDisplayProperties'
     RemoveConnectionRequest:
       type: object
+      required:
+      - id
       properties:
         id:
           type: string
     SyncConnectionRequest:
       type: object
+      required:
+      - id
       properties:
         id:
           type: string

--- a/agent_api_http/openapi-generated.yaml
+++ b/agent_api_http/openapi-generated.yaml
@@ -312,10 +312,7 @@ components:
       - id
       - dids
       - validations
-      - deleted
       properties:
-        deleted:
-          type: boolean
         dids:
           type: array
           items:

--- a/agent_api_http/src/v0/identity/connections/mod.rs
+++ b/agent_api_http/src/v0/identity/connections/mod.rs
@@ -111,9 +111,7 @@ pub(crate) async fn get_connections(
                     display
                         .as_ref()
                         .map_or(true, |display| connection.display.as_ref() == Some(display))
-                        && url
-                            .as_ref()
-                            .map_or(true, |url| connection.url.to_string() == url.to_string())
+                        && url.as_ref().map_or(true, |url| connection.url == url)
                         && did.as_ref().map_or(true, |did| connection.dids.contains(did))
                 })
                 .collect();

--- a/agent_api_http/src/v0/identity/connections/mod.rs
+++ b/agent_api_http/src/v0/identity/connections/mod.rs
@@ -111,7 +111,7 @@ pub(crate) async fn get_connections(
                     display
                         .as_ref()
                         .map_or(true, |display| connection.display.as_ref() == Some(display))
-                        && url.as_ref().map_or(true, |url| connection.url == url)
+                        && url.as_ref().map_or(true, |url| connection.url == url.to_string())
                         && did.as_ref().map_or(true, |did| connection.dids.contains(did))
                 })
                 .collect();

--- a/agent_api_http/src/v0/identity/connections/mod.rs
+++ b/agent_api_http/src/v0/identity/connections/mod.rs
@@ -111,7 +111,7 @@ pub(crate) async fn get_connections(
                     display
                         .as_ref()
                         .map_or(true, |display| connection.display.as_ref() == Some(display))
-                        && url.as_ref().map_or(true, |url| connection.url == url.to_string())
+                        && url.as_ref().map_or(true, |url| *url == connection.url)
                         && did.as_ref().map_or(true, |did| connection.dids.contains(did))
                 })
                 .collect();

--- a/agent_api_http/src/v0/identity/connections/mod.rs
+++ b/agent_api_http/src/v0/identity/connections/mod.rs
@@ -22,7 +22,6 @@ pub mod openapi;
 #[derive(Deserialize, Serialize, utoipa::ToSchema)]
 #[serde(rename_all = "camelCase")]
 pub struct AddConnectionEndpointRequest {
-    #[serde(default)]
     pub url: String,
 }
 
@@ -112,7 +111,9 @@ pub(crate) async fn get_connections(
                     display
                         .as_ref()
                         .map_or(true, |display| connection.display.as_ref() == Some(display))
-                        && url.as_ref().map_or(true, |url| connection.url.as_ref() == Some(url))
+                        && url
+                            .as_ref()
+                            .map_or(true, |url| connection.url.to_string() == url.to_string())
                         && did.as_ref().map_or(true, |did| connection.dids.contains(did))
                 })
                 .collect();
@@ -151,7 +152,6 @@ pub(crate) async fn get_connection(
 #[derive(Deserialize, Serialize, utoipa::ToSchema)]
 #[serde(rename_all = "camelCase")]
 pub struct SyncConnectionRequest {
-    #[serde(default)]
     id: String,
 }
 
@@ -182,7 +182,6 @@ pub(crate) async fn sync_connection(
 #[derive(Deserialize, Serialize, utoipa::ToSchema)]
 #[serde(rename_all = "camelCase")]
 pub struct AcceptConnectionChangesRequest {
-    #[serde(default)]
     id: String,
 }
 
@@ -212,7 +211,6 @@ pub(crate) async fn accept_connection_changes(
 #[derive(Deserialize, Serialize, utoipa::ToSchema)]
 #[serde(rename_all = "camelCase")]
 pub struct RemoveConnectionRequest {
-    #[serde(default)]
     id: String,
 }
 

--- a/agent_identity/src/connection/views/mod.rs
+++ b/agent_identity/src/connection/views/mod.rs
@@ -4,16 +4,17 @@ use super::event::ConnectionEvent;
 use crate::connection::aggregate::{Connection, ConnectionDisplayProperties, PendingChanges, Validation};
 use chrono::{DateTime, Utc};
 use cqrs_es::{EventEnvelope, View};
-use identity_core::common::Url;
 use identity_did::DIDUrl;
 use serde::{Deserialize, Serialize};
 
-#[derive(Debug, Clone, Serialize, Deserialize, utoipa::ToSchema)]
+#[derive(Debug, Clone, Serialize, Default, Deserialize, utoipa::ToSchema)]
 #[schema(as = Connection)]
 pub struct ConnectionView {
     #[serde(rename = "id")]
     pub connection_id: String,
-    pub url: Url,
+    // `identity_core::common::url::Url` doesn't implement a `Default`, which is why we use `String`.
+    #[schema(value_type = url::Url)]
+    pub url: String,
     #[schema(value_type = Vec<String>)]
     pub dids: Vec<DIDUrl>,
     pub validations: Vec<Validation>,
@@ -41,7 +42,7 @@ impl View<Connection> for ConnectionView {
             } => {
                 self.connection_id.clone_from(connection_id);
                 self.display.clone_from(display);
-                self.url = url.clone();
+                self.url = url.to_string();
                 self.dids.clone_from(dids);
                 self.validations.clone_from(validations);
                 self.first_interacted_at = *first_interacted_at;
@@ -74,24 +75,6 @@ impl View<Connection> for ConnectionView {
             ConnectionRemoved { connection_id: _ } => {
                 self.deleted = true;
             }
-        }
-    }
-}
-
-// `View` requires a `Default` which `identity_core::common::url::Url` doesn't provide.
-// The `ConnectionView` default is never called in practice.
-impl std::default::Default for ConnectionView {
-    fn default() -> Self {
-        ConnectionView {
-            connection_id: String::new(),
-            url: Url::parse("http://localhost").unwrap(),
-            dids: Vec::new(),
-            validations: Vec::new(),
-            display: None,
-            pending_changes: None,
-            first_interacted_at: None,
-            last_interacted_at: None,
-            deleted: false,
         }
     }
 }

--- a/agent_identity/src/connection/views/mod.rs
+++ b/agent_identity/src/connection/views/mod.rs
@@ -8,12 +8,12 @@ use identity_core::common::Url;
 use identity_did::DIDUrl;
 use serde::{Deserialize, Serialize};
 
-#[derive(Debug, Clone, Serialize, Deserialize, Default, utoipa::ToSchema)]
+#[derive(Debug, Clone, Serialize, Deserialize, utoipa::ToSchema)]
 #[schema(as = Connection)]
 pub struct ConnectionView {
     #[serde(rename = "id")]
     pub connection_id: String,
-    pub url: Option<Url>,
+    pub url: Url,
     #[schema(value_type = Vec<String>)]
     pub dids: Vec<DIDUrl>,
     pub validations: Vec<Validation>,
@@ -41,7 +41,7 @@ impl View<Connection> for ConnectionView {
             } => {
                 self.connection_id.clone_from(connection_id);
                 self.display.clone_from(display);
-                self.url = Some(url.clone());
+                self.url = url.clone();
                 self.dids.clone_from(dids);
                 self.validations.clone_from(validations);
                 self.first_interacted_at = *first_interacted_at;
@@ -74,6 +74,24 @@ impl View<Connection> for ConnectionView {
             ConnectionRemoved { connection_id: _ } => {
                 self.deleted = true;
             }
+        }
+    }
+}
+
+// `View` requires a `Default` which `identity_core::common::url::Url` doesn't provide.
+// The `ConnectionView` default is never called in practice.
+impl std::default::Default for ConnectionView {
+    fn default() -> Self {
+        ConnectionView {
+            connection_id: String::new(),
+            url: Url::parse("http://localhost").unwrap(),
+            dids: Vec::new(),
+            validations: Vec::new(),
+            display: None,
+            pending_changes: None,
+            first_interacted_at: None,
+            last_interacted_at: None,
+            deleted: false,
         }
     }
 }

--- a/agent_identity/src/connection/views/mod.rs
+++ b/agent_identity/src/connection/views/mod.rs
@@ -7,7 +7,7 @@ use cqrs_es::{EventEnvelope, View};
 use identity_did::DIDUrl;
 use serde::{Deserialize, Serialize};
 
-#[derive(Debug, Clone, Serialize, Default, Deserialize, utoipa::ToSchema)]
+#[derive(Debug, Clone, Serialize, Deserialize, Default, utoipa::ToSchema)]
 #[schema(as = Connection)]
 pub struct ConnectionView {
     #[serde(rename = "id")]

--- a/agent_identity/src/connection/views/mod.rs
+++ b/agent_identity/src/connection/views/mod.rs
@@ -21,6 +21,7 @@ pub struct ConnectionView {
     pub pending_changes: Option<PendingChanges>,
     pub first_interacted_at: Option<DateTime<Utc>>,
     pub last_interacted_at: Option<DateTime<Utc>>,
+    #[serde(skip)]
     pub deleted: bool,
 }
 


### PR DESCRIPTION
# Description of change

Internal `deleted` flag should not be present in Connection response.

## Links to any relevant issues
- n/a

## How the change has been tested
Describe the tests that you ran to verify your changes.
Make sure to provide instructions for the maintainer as well as any relevant configurations.

## Definition of Done checklist
Add an `x` to the boxes that are relevant to your changes.

- [x] I have followed the contribution guidelines for this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] I have successfully tested this change in a docker environment 
