### PR TITLE
fix: update issuer URL handling in server metadata loading

### DIFF
--- a/agent_issuance/src/server_config/aggregate.rs
+++ b/agent_issuance/src/server_config/aggregate.rs
@@ -1,4 +1,5 @@
 use agent_shared::config::{config, Authorization};
+use agent_shared::UrlAppendHelpers as _;
 use async_trait::async_trait;
 use base64::{engine::general_purpose::URL_SAFE_NO_PAD, Engine};
 use cqrs_es::Aggregate;
@@ -106,9 +107,15 @@ impl Aggregate for ServerConfig {
             UpdateIssuerUrl { url } => {
                 let mut authorization_server_metadata = self.authorization_server_metadata.clone();
                 authorization_server_metadata.issuer = url.clone();
+                authorization_server_metadata.authorization_endpoint = Some(url.append_path_segment("auth/authorize"));
+                authorization_server_metadata.token_endpoint = Some(url.append_path_segment("auth/token"));
+                authorization_server_metadata.pushed_authorization_request_endpoint =
+                    Some(url.append_path_segment("auth/par"));
 
                 let mut credential_issuer_metadata = self.credential_issuer_metadata.clone();
-                credential_issuer_metadata.credential_issuer = url;
+                credential_issuer_metadata.credential_issuer = url.clone();
+                credential_issuer_metadata.credential_endpoint = url.append_path_segment("openid4vci/credential");
+                credential_issuer_metadata.nonce_endpoint = Some(url.append_path_segment("openid4vci/nonce"));
 
                 Ok(vec![IssuerUrlUpdated {
                     authorization_server_metadata: Box::new(authorization_server_metadata),

--- a/agent_issuance/src/state.rs
+++ b/agent_issuance/src/state.rs
@@ -116,14 +116,14 @@ pub async fn load_server_metadata(state: &IssuanceState) -> anyhow::Result<()> {
 
     match query_handler(SERVER_CONFIG_ID, &state.query.server_config).await? {
         Some(server_config_view) => {
-            if public_url != server_config_view.authorization_server_metadata.issuer {
-                debug!("The server metadata issuer URL does not match the configured URL.");
+            // if public_url != server_config_view.authorization_server_metadata.issuer {
+            //     debug!("The server metadata issuer URL does not match the configured URL.");
 
-                let command = ServerConfigCommand::UpdateIssuerUrl {
-                    url: public_url.clone(),
-                };
-                command_handler(SERVER_CONFIG_ID, &state.command.server_config, command).await?;
-            }
+            let command = ServerConfigCommand::UpdateIssuerUrl {
+                url: public_url.clone(),
+            };
+            command_handler(SERVER_CONFIG_ID, &state.command.server_config, command).await?;
+            // }
 
             if display != server_config_view.credential_issuer_metadata.display {
                 debug!("The server metadata display does not match the configured display.");

--- a/agent_issuance/src/state.rs
+++ b/agent_issuance/src/state.rs
@@ -116,14 +116,12 @@ pub async fn load_server_metadata(state: &IssuanceState) -> anyhow::Result<()> {
 
     match query_handler(SERVER_CONFIG_ID, &state.query.server_config).await? {
         Some(server_config_view) => {
-            // if public_url != server_config_view.authorization_server_metadata.issuer {
-            //     debug!("The server metadata issuer URL does not match the configured URL.");
+            info!("Update Issuer URL in server metadata");
 
             let command = ServerConfigCommand::UpdateIssuerUrl {
                 url: public_url.clone(),
             };
             command_handler(SERVER_CONFIG_ID, &state.command.server_config, command).await?;
-            // }
 
             if display != server_config_view.credential_issuer_metadata.display {
                 debug!("The server metadata display does not match the configured display.");


### PR DESCRIPTION
# Description of change
Different endpoints in Credential Issuer, and Authorization Server Metadata were not updated when the Public URL is updated. This PR fixes that and ensures that this always happens during initialization.

## Links to any relevant issues
- https://github.com/impierce/ssi-agent/issues/336#issuecomment-4379989004

## How the change has been tested
n/a

## Definition of Done checklist
Add an `x` to the boxes that are relevant to your changes.

- [x] I have followed the contribution guidelines for this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have successfully tested this change in a docker environment 
