### PR TITLE
feat(api-http): add pluggable authorization checker

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -86,6 +86,7 @@ dependencies = [
  "agent_verification",
  "anyhow",
  "askama",
+ "async-trait",
  "axum 0.8.3",
  "axum-auth 0.8.1",
  "axum-macros",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -156,6 +156,7 @@ dependencies = [
  "serde_json",
  "serde_with 3.13.0",
  "tokio",
+ "tower 0.4.13",
  "tower-http 0.6.8",
  "tracing",
 ]

--- a/agent_api_http/Cargo.toml
+++ b/agent_api_http/Cargo.toml
@@ -16,6 +16,7 @@ agent_verification = { path = "../agent_verification" }
 
 anyhow.workspace = true
 askama = "0.14"
+async-trait.workspace = true
 axum.workspace = true
 axum-auth = "0.8"
 axum-macros = "0.5"

--- a/agent_api_http/src/authorization.rs
+++ b/agent_api_http/src/authorization.rs
@@ -1,0 +1,90 @@
+use std::sync::Arc;
+
+use async_trait::async_trait;
+use axum::{
+    extract::{Request, State},
+    middleware::Next,
+    response::Response,
+};
+use http::StatusCode;
+
+pub type SharedAuthorizationChecker = Arc<dyn AuthorizationChecker>;
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct AuthorizationRequest {
+    pub method: String,
+    pub path: String,
+}
+
+impl AuthorizationRequest {
+    pub fn from_request(request: &Request) -> Self {
+        Self {
+            method: request.method().to_string(),
+            path: request.uri().path().to_string(),
+        }
+    }
+}
+
+#[async_trait]
+pub trait AuthorizationChecker: Send + Sync {
+    async fn is_authorized(&self, request: &AuthorizationRequest) -> bool;
+}
+
+pub struct AllowAllAuthorizationChecker;
+
+#[async_trait]
+impl AuthorizationChecker for AllowAllAuthorizationChecker {
+    async fn is_authorized(&self, _request: &AuthorizationRequest) -> bool {
+        true
+    }
+}
+
+pub async fn authorize_request(
+    State(checker): State<SharedAuthorizationChecker>,
+    request: Request,
+    next: Next,
+) -> Result<Response, StatusCode> {
+    let authorization_request = AuthorizationRequest::from_request(&request);
+
+    if checker.is_authorized(&authorization_request).await {
+        Ok(next.run(request).await)
+    } else {
+        Err(StatusCode::FORBIDDEN)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use axum::body::Body;
+
+    #[tokio::test]
+    async fn allow_all_checker_authorizes_requests() {
+        let checker = AllowAllAuthorizationChecker;
+        let request = AuthorizationRequest {
+            method: "GET".to_string(),
+            path: "/v0/credentials".to_string(),
+        };
+
+        assert!(checker.is_authorized(&request).await);
+    }
+
+    #[test]
+    fn authorization_request_captures_method_and_path() {
+        let request = Request::builder()
+            .method("POST")
+            .uri("/v0/credentials?ignored=true")
+            .body(Body::empty())
+            .unwrap();
+
+        let authorization_request = AuthorizationRequest::from_request(&request);
+
+        assert_eq!(
+            authorization_request,
+            AuthorizationRequest {
+                method: "POST".to_string(),
+                path: "/v0/credentials".to_string(),
+            }
+        );
+    }
+}

--- a/agent_api_http/src/authorization.rs
+++ b/agent_api_http/src/authorization.rs
@@ -56,7 +56,24 @@ pub async fn authorize_request(
 #[cfg(test)]
 mod tests {
     use super::*;
-    use axum::body::Body;
+    use axum::{body::Body, middleware, routing::get, Router};
+    use std::sync::Mutex;
+    use tower::ServiceExt;
+
+    #[derive(Default)]
+    struct TestAuthorizationChecker {
+        authorized: bool,
+        requests: Mutex<Vec<AuthorizationRequest>>,
+    }
+
+    #[async_trait]
+    impl AuthorizationChecker for TestAuthorizationChecker {
+        async fn is_authorized(&self, request: &AuthorizationRequest) -> bool {
+            self.requests.lock().unwrap().push(request.clone());
+
+            self.authorized
+        }
+    }
 
     #[tokio::test]
     async fn allow_all_checker_authorizes_requests() {
@@ -85,6 +102,74 @@ mod tests {
                 method: "POST".to_string(),
                 path: "/v0/credentials".to_string(),
             }
+        );
+    }
+
+    #[tokio::test]
+    async fn authorize_request_allows_authorized_requests() {
+        let checker = Arc::new(TestAuthorizationChecker {
+            authorized: true,
+            ..Default::default()
+        });
+        let app = Router::new()
+            .route("/protected", get(|| async { StatusCode::OK }))
+            .layer(middleware::from_fn_with_state(
+                checker.clone() as SharedAuthorizationChecker,
+                authorize_request,
+            ));
+
+        let response = app
+            .oneshot(
+                Request::builder()
+                    .method("GET")
+                    .uri("/protected?ignored=true")
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(response.status(), StatusCode::OK);
+        assert_eq!(
+            checker.requests.lock().unwrap().as_slice(),
+            &[AuthorizationRequest {
+                method: "GET".to_string(),
+                path: "/protected".to_string(),
+            }]
+        );
+    }
+
+    #[tokio::test]
+    async fn authorize_request_rejects_unauthorized_requests() {
+        let checker = Arc::new(TestAuthorizationChecker {
+            authorized: false,
+            ..Default::default()
+        });
+        let app = Router::new()
+            .route("/protected", get(|| async { StatusCode::OK }))
+            .layer(middleware::from_fn_with_state(
+                checker.clone() as SharedAuthorizationChecker,
+                authorize_request,
+            ));
+
+        let response = app
+            .oneshot(
+                Request::builder()
+                    .method("DELETE")
+                    .uri("/protected")
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(response.status(), StatusCode::FORBIDDEN);
+        assert_eq!(
+            checker.requests.lock().unwrap().as_slice(),
+            &[AuthorizationRequest {
+                method: "DELETE".to_string(),
+                path: "/protected".to_string(),
+            }]
         );
     }
 }

--- a/agent_api_http/src/lib.rs
+++ b/agent_api_http/src/lib.rs
@@ -1,6 +1,7 @@
 pub mod public;
 pub mod v0;
 
+pub mod authorization;
 pub mod error;
 pub mod handlers;
 pub mod metrics;
@@ -28,6 +29,8 @@ use tower::ServiceBuilder;
 use tower_http::trace::TraceLayer;
 use tracing::{debug, info, info_span, Span};
 
+use crate::authorization::{AllowAllAuthorizationChecker, SharedAuthorizationChecker};
+
 pub const API_VERSION: &str = "/v0";
 
 pub const DOCUMENTATION_URL: &str = "https://beta.docs.impierce.com/unicore/";
@@ -40,6 +43,7 @@ pub struct ApplicationState {
     pub issuance_state: Option<Arc<IssuanceState>>,
     pub holder_state: Option<Arc<HolderState>>,
     pub verification_state: Option<Arc<VerificationState>>,
+    pub authorization_checker: Option<SharedAuthorizationChecker>,
 }
 
 pub fn app(
@@ -50,8 +54,12 @@ pub fn app(
         issuance_state,
         holder_state,
         verification_state,
+        authorization_checker,
     }: ApplicationState,
 ) -> Router {
+    let authorization_checker: SharedAuthorizationChecker =
+        authorization_checker.unwrap_or_else(|| Arc::new(AllowAllAuthorizationChecker));
+
     let app = Router::new()
         .merge(identity_state.map(v0::identity::router).unwrap_or_default())
         .merge(library_state.map(v0::library::router).unwrap_or_default())
@@ -95,6 +103,10 @@ pub fn app(
                             }
                         }),
                 )
+                .layer(middleware::from_fn_with_state(
+                    authorization_checker,
+                    authorization::authorize_request,
+                ))
                 .layer(middleware::from_fn(log_request_body)),
         );
 

--- a/agent_api_http/src/lib.rs
+++ b/agent_api_http/src/lib.rs
@@ -151,7 +151,10 @@ async fn buffer_request_body(request: Request) -> Result<Request, Response> {
 
 #[cfg(test)]
 mod tests {
+    use super::*;
     use agent_shared::config::config;
+    use axum::body::Body;
+    use http::Request;
     use oid4vci::credential_issuer::{
         credential_configurations_supported::CredentialConfigurationsSupportedObject,
         credential_issuer_metadata::CredentialIssuerMetadata,
@@ -264,5 +267,19 @@ mod tests {
             })]),
             ..Default::default()
         };
+    }
+
+    #[tokio::test]
+    async fn buffer_request_body_preserves_body_for_downstream_handlers() {
+        let request = Request::builder()
+            .method("POST")
+            .uri("/v0/test")
+            .body(Body::from(r#"{"message":"hello"}"#))
+            .unwrap();
+
+        let request = buffer_request_body(request).await.unwrap();
+        let bytes = request.into_body().collect().await.unwrap().to_bytes();
+
+        assert_eq!(&bytes[..], br#"{"message":"hello"}"#);
     }
 }

--- a/agent_application/Cargo.toml
+++ b/agent_application/Cargo.toml
@@ -27,3 +27,7 @@ serde_with.workspace = true
 tokio.workspace = true
 tower-http.workspace = true
 tracing.workspace = true
+
+[dev-dependencies]
+agent_shared = { path = "../agent_shared", features = ["test_utils"] }
+tower.workspace = true

--- a/agent_application/src/lib.rs
+++ b/agent_application/src/lib.rs
@@ -255,3 +255,29 @@ pub async fn start_server(alias: String, router: axum::Router, port: u16) {
 
     axum::serve(listener, router).await.unwrap();
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use axum::{
+        body::Body,
+        http::{Request, StatusCode},
+    };
+    use tower::ServiceExt;
+
+    #[tokio::test]
+    async fn router_exposes_liveness_probe() {
+        let response = router(ApplicationState::default())
+            .oneshot(
+                Request::builder()
+                    .method("GET")
+                    .uri("/healthz")
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(response.status(), StatusCode::OK);
+    }
+}

--- a/agent_application/src/lib.rs
+++ b/agent_application/src/lib.rs
@@ -188,6 +188,7 @@ pub async fn state() -> io::Result<ApplicationState> {
         issuance_state: Some(issuance_state),
         holder_state: Some(holder_state),
         verification_state: Some(verification_state),
+        authorization_checker: None,
     })
 }
 


### PR DESCRIPTION
# Description of change
Added a pluggable authorization checker hook to `agent_api_http`.

The open-source API now runs each request through an authorization middleware, while defaulting to an allow-all checker so existing behavior remains unchanged. Downstream implementations can provide their own checker through `ApplicationState` to enforce product-specific access rules without adding policy concepts to the open-source crate.

## Links to any relevant issues
N/A

## How the change has been tested
Verified locally with:

```sh
cargo fmt --check
cargo check -p agent_api_http
cargo test -p agent_api_http authorization
```

The focused test command covers the new authorization request mapping and default allow-all checker behavior, alongside existing filtered `agent_api_http` tests.

## Definition of Done checklist
- [x] I have followed the contribution guidelines for this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] I have successfully tested this change in a docker environment