### PR TITLE
fix: access token and credential endpoint error responses

### DIFF
--- a/agent_api_http/src/v0/issuance/credential_issuer/credential.rs
+++ b/agent_api_http/src/v0/issuance/credential_issuer/credential.rs
@@ -40,12 +40,12 @@ pub(crate) async fn credential(
     AuthBearer(access_token): AuthBearer,
     Json(credential_request): Json<CredentialRequest>,
 ) -> Result<Response, PublicError> {
-    let offer_id = AccessTokenValidationService::validate(&state, &access_token)
-        .await
-        .ok()
-        // The Access Token must contain the `issuer_state` claim, which is used to identify the `offer_id`.
-        .and_then(|claims| claims.issuer_state)
-        .ok_or_else(|| PublicError::from(CredentialErrorResponse::InvalidProof))?;
+    let claims = AccessTokenValidationService::validate(&state, &access_token).await?;
+    // The Access Token must contain the `issuer_state` claim, which is used to identify the `offer_id`.
+
+    let offer_id = claims
+        .issuer_state
+        .ok_or_else(|| PublicError::from(CredentialErrorResponse::InvalidCredentialRequest))?;
 
     NonceValidationService::validate(&state, &credential_request)
         .await

--- a/agent_api_http/src/v0/issuance/credential_issuer/credential.rs
+++ b/agent_api_http/src/v0/issuance/credential_issuer/credential.rs
@@ -7,7 +7,8 @@ use crate::{
 };
 use agent_issuance::{
     application::{
-        access_token_validation_service::AccessTokenValidationService, nonce_validation_service::NonceValidationService,
+        access_token_validation_service::{AccessTokenValidationError, AccessTokenValidationService},
+        nonce_validation_service::NonceValidationService,
     },
     credential::{command::CredentialCommand, views::CredentialView},
     offer::{command::OfferCommand, views::OfferView},
@@ -41,11 +42,11 @@ pub(crate) async fn credential(
     Json(credential_request): Json<CredentialRequest>,
 ) -> Result<Response, PublicError> {
     let claims = AccessTokenValidationService::validate(&state, &access_token).await?;
-    // The Access Token must contain the `issuer_state` claim, which is used to identify the `offer_id`.
 
+    // The Access Token must contain the `issuer_state` claim, which is used to identify the `offer_id`.
     let offer_id = claims
         .issuer_state
-        .ok_or_else(|| PublicError::from(CredentialErrorResponse::InvalidCredentialRequest))?;
+        .ok_or_else(|| PublicError::from(AccessTokenValidationError::InvalidToken))?;
 
     NonceValidationService::validate(&state, &credential_request)
         .await

--- a/agent_api_http/src/v0/issuance/credential_issuer/notification.rs
+++ b/agent_api_http/src/v0/issuance/credential_issuer/notification.rs
@@ -28,9 +28,7 @@ pub async fn notification(
     let notification_request: NotificationRequest = serde_json::from_value::<NotificationRequest>(raw_value)
         .map_err(|_| PublicError::from(NotificationErrorResponse::InvalidNotificationRequest))?;
 
-    let _claims = AccessTokenValidationService::validate(&state, &access_token)
-        .await
-        .map_err(|_err| PublicError::from(NotificationErrorResponse::InvalidNotificationRequest))?;
+    let _claims = AccessTokenValidationService::validate(&state, &access_token).await?;
 
     let credentials = match query_handler("all_credentials", &state.query.all_credentials).await? {
         Some(all_credentials) => all_credentials.credentials,
@@ -145,7 +143,7 @@ mod tests {
             name: &'static str,
             access_token: String,
             payload: String,
-            expected_error: NotificationErrorResponse,
+            expected_status: StatusCode,
         }
 
         let test_cases = vec![
@@ -158,7 +156,7 @@ mod tests {
                     event_description: None,
                 })
                 .unwrap(),
-                expected_error: NotificationErrorResponse::InvalidNotificationId,
+                expected_status: NotificationErrorResponse::InvalidNotificationId.status_code(),
             },
             TestCase {
                 name: "Invalid Access Token",
@@ -169,13 +167,13 @@ mod tests {
                     event_description: None,
                 })
                 .unwrap(),
-                expected_error: NotificationErrorResponse::InvalidNotificationRequest,
+                expected_status: StatusCode::UNAUTHORIZED,
             },
             TestCase {
                 name: "Invalid Notification Event",
                 access_token: access_token.clone(),
                 payload: format!(r#"{{"notification_id": "{notification_id}", "event": "InvalidEventValue"}}"#),
-                expected_error: NotificationErrorResponse::InvalidNotificationRequest,
+                expected_status: NotificationErrorResponse::InvalidNotificationRequest.status_code(),
             },
         ];
 
@@ -191,10 +189,10 @@ mod tests {
             let response = issuance_app.clone().oneshot(request).await.unwrap();
             assert_eq!(
                 response.status(),
-                test_case.expected_error.status_code(),
+                test_case.expected_status,
                 "Test case {} failed: expected status {}, got {}",
                 test_case.name,
-                test_case.expected_error.status_code(),
+                test_case.expected_status,
                 response.status(),
             );
         }

--- a/agent_api_http/src/v0/issuance/credential_issuer/notification.rs
+++ b/agent_api_http/src/v0/issuance/credential_issuer/notification.rs
@@ -25,10 +25,10 @@ pub async fn notification(
 ) -> Result<Response, PublicError> {
     info!("Notification Request: {}", json!(raw_value));
 
+    let _claims = AccessTokenValidationService::validate(&state, &access_token).await?;
+
     let notification_request: NotificationRequest = serde_json::from_value::<NotificationRequest>(raw_value)
         .map_err(|_| PublicError::from(NotificationErrorResponse::InvalidNotificationRequest))?;
-
-    let _claims = AccessTokenValidationService::validate(&state, &access_token).await?;
 
     let credentials = match query_handler("all_credentials", &state.query.all_credentials).await? {
         Some(all_credentials) => all_credentials.credentials,

--- a/agent_api_http/src/v0/issuance/error.rs
+++ b/agent_api_http/src/v0/issuance/error.rs
@@ -102,13 +102,13 @@ impl IntoApiErrorExt for OfferError {
             UnrequestedTxCodeError => ApiError::new(StatusCode::INTERNAL_SERVER_ERROR),
 
             // `/openid4vci/credential` endpoint
-            MissingCredentialError => ApiError::new(StatusCode::BAD_REQUEST),
-            MissingProofError => ApiError::new(StatusCode::BAD_REQUEST),
-            InvalidProofError(_) => ApiError::new(StatusCode::BAD_REQUEST),
-            MissingProofIssuerError => ApiError::new(StatusCode::BAD_REQUEST),
-            MissingCredentialConfigurationIdsError => ApiError::new(StatusCode::BAD_REQUEST),
-            UnknownCredentialConfiguration(_) => ApiError::new(StatusCode::BAD_REQUEST),
-            UnsupportedCredentialIdentifierError => ApiError::new(StatusCode::BAD_REQUEST),
+            MissingCredentialError => ApiError::new(StatusCode::INTERNAL_SERVER_ERROR),
+            MissingProofError => ApiError::new(StatusCode::INTERNAL_SERVER_ERROR),
+            InvalidProofError(_) => ApiError::new(StatusCode::INTERNAL_SERVER_ERROR),
+            MissingProofIssuerError => ApiError::new(StatusCode::INTERNAL_SERVER_ERROR),
+            MissingCredentialConfigurationIdsError => ApiError::new(StatusCode::INTERNAL_SERVER_ERROR),
+            UnknownCredentialConfiguration(_) => ApiError::new(StatusCode::INTERNAL_SERVER_ERROR),
+            UnsupportedCredentialIdentifierError => ApiError::new(StatusCode::INTERNAL_SERVER_ERROR),
         }
     }
 }
@@ -248,9 +248,10 @@ impl IntoPublicError for OfferError {
             UnsupportedCredentialIdentifierError => {
                 PublicError::CredentialError(OID4VCError::new(CredentialErrorResponse::UnknownCredentialIdentifier))
             }
-
             // Internal errors that shouldn't reach the public API
-            _ => PublicError::InternalServerError,
+            SendCredentialOfferError(_) => PublicError::InternalServerError,
+            UnsupportedTokenRequestGrantTypeError => PublicError::InternalServerError,
+            InvalidCredentialOfferUriError(_) => PublicError::InternalServerError,
         }
     }
 }

--- a/agent_api_http/src/v0/issuance/error.rs
+++ b/agent_api_http/src/v0/issuance/error.rs
@@ -179,7 +179,12 @@ impl axum::response::IntoResponse for PublicError {
                 let status = oid4vc_error.error.status_code();
                 (status, axum::Json(oid4vc_error)).into_response()
             }
-            PublicError::AccessTokenError(_) => StatusCode::INTERNAL_SERVER_ERROR.into_response(),
+            PublicError::AccessTokenError(_) => (
+                StatusCode::UNAUTHORIZED,
+                [("WWW-Authenticate", "Bearer error=\"invalid_token\"")],
+                Json(serde_json::json!({"error": "invalid_token"})),
+            )
+                .into_response(),
             PublicError::InternalServerError => StatusCode::INTERNAL_SERVER_ERROR.into_response(),
             PublicError::NotFoundError => StatusCode::NOT_FOUND.into_response(),
         }

--- a/agent_api_http/src/v0/issuance/error.rs
+++ b/agent_api_http/src/v0/issuance/error.rs
@@ -102,13 +102,13 @@ impl IntoApiErrorExt for OfferError {
             UnrequestedTxCodeError => ApiError::new(StatusCode::INTERNAL_SERVER_ERROR),
 
             // `/openid4vci/credential` endpoint
-            MissingCredentialError => ApiError::new(StatusCode::INTERNAL_SERVER_ERROR),
-            MissingProofError => ApiError::new(StatusCode::INTERNAL_SERVER_ERROR),
-            InvalidProofError(_) => ApiError::new(StatusCode::INTERNAL_SERVER_ERROR),
-            MissingProofIssuerError => ApiError::new(StatusCode::INTERNAL_SERVER_ERROR),
-            MissingCredentialConfigurationIdsError => ApiError::new(StatusCode::INTERNAL_SERVER_ERROR),
-            UnknownCredentialConfiguration(_) => ApiError::new(StatusCode::INTERNAL_SERVER_ERROR),
-            UnsupportedCredentialIdentifierError => ApiError::new(StatusCode::INTERNAL_SERVER_ERROR),
+            MissingCredentialError => ApiError::new(StatusCode::BAD_REQUEST),
+            MissingProofError => ApiError::new(StatusCode::BAD_REQUEST),
+            InvalidProofError(_) => ApiError::new(StatusCode::BAD_REQUEST),
+            MissingProofIssuerError => ApiError::new(StatusCode::BAD_REQUEST),
+            MissingCredentialConfigurationIdsError => ApiError::new(StatusCode::BAD_REQUEST),
+            UnknownCredentialConfiguration(_) => ApiError::new(StatusCode::BAD_REQUEST),
+            UnsupportedCredentialIdentifierError => ApiError::new(StatusCode::BAD_REQUEST),
         }
     }
 }
@@ -217,16 +217,39 @@ impl IntoPublicError for OfferError {
     fn into_public_error(self) -> PublicError {
         use OfferError::*;
         match self {
-            MissingCredentialOfferError => {
-                PublicError::CredentialError(OID4VCError::new(CredentialErrorResponse::InvalidCredentialRequest))
-            }
+            // `/auth/token` endpoint
             MissingTxCodeError => PublicError::TokenError(OID4VCError::new(TokenErrorResponse::InvalidRequest)),
             InvalidTxCodeError => PublicError::TokenError(OID4VCError::new(TokenErrorResponse::InvalidGrant)),
             InvalidPreAuthorizedCodeError => {
                 PublicError::TokenError(OID4VCError::new(TokenErrorResponse::InvalidGrant))
             }
             UnrequestedTxCodeError => PublicError::TokenError(OID4VCError::new(TokenErrorResponse::InvalidRequest)),
-            // TODO: check for missing error responses
+
+            // `/openid4vci/credential` endpoint
+            MissingCredentialOfferError => {
+                PublicError::CredentialError(OID4VCError::new(CredentialErrorResponse::InvalidCredentialRequest))
+            }
+            MissingCredentialError => {
+                PublicError::CredentialError(OID4VCError::new(CredentialErrorResponse::InvalidCredentialRequest))
+            }
+            MissingProofError => PublicError::CredentialError(OID4VCError::new(CredentialErrorResponse::InvalidProof)),
+            InvalidProofError(_) => {
+                PublicError::CredentialError(OID4VCError::new(CredentialErrorResponse::InvalidProof))
+            }
+            MissingProofIssuerError => {
+                PublicError::CredentialError(OID4VCError::new(CredentialErrorResponse::InvalidProof))
+            }
+            MissingCredentialConfigurationIdsError => {
+                PublicError::CredentialError(OID4VCError::new(CredentialErrorResponse::InvalidCredentialRequest))
+            }
+            UnknownCredentialConfiguration(_) => PublicError::CredentialError(OID4VCError::new(
+                CredentialErrorResponse::UnknownCredentialConfiguration,
+            )),
+            UnsupportedCredentialIdentifierError => {
+                PublicError::CredentialError(OID4VCError::new(CredentialErrorResponse::UnknownCredentialIdentifier))
+            }
+
+            // Internal errors that shouldn't reach the public API
             _ => PublicError::InternalServerError,
         }
     }

--- a/agent_issuance/src/application/access_token_validation_service.rs
+++ b/agent_issuance/src/application/access_token_validation_service.rs
@@ -31,6 +31,7 @@ pub enum AccessTokenValidationError {
     InvalidToken,
     #[error("Failed to resolve the public key for the token's `kid`")]
     KidResolutionError,
+    
 }
 
 impl AccessTokenValidationService {

--- a/agent_issuance/src/application/access_token_validation_service.rs
+++ b/agent_issuance/src/application/access_token_validation_service.rs
@@ -31,7 +31,6 @@ pub enum AccessTokenValidationError {
     InvalidToken,
     #[error("Failed to resolve the public key for the token's `kid`")]
     KidResolutionError,
-    
 }
 
 impl AccessTokenValidationService {


### PR DESCRIPTION
# Description of change
Previously, access token validation failures on the credential endpoint returned a 400 with `invalid_proof`, which was incorrect, as it mixed up authorization errors (defined in [RFC 6750](https://datatracker.ietf.org/doc/html/rfc6750#section-3.1), section 3) with credential request errors ([OID4VCI 1.0 section 8.3.1.2](https://openid.github.io/OpenID4VCI/openid-4-verifiable-credential-issuance-1_0-wg-draft.html#name-credential-request-errors)). A similar mistake was also caught in the notification endpoint. 

Access token validation failures now return 401 with` {"error": "invalid_token"}` and a WWW-Authenticate header per [RFC 6750 Section 3.](https://datatracker.ietf.org/doc/html/rfc6750#section-3.1)

Missing issuer_state now returns 400 with `{"error": "invalid_credential_request"}` per OID4VCI Section 8.3.1.2

Updated the IntoResponse impl for PublicError::AccessTokenError from 500 to the correct 401 with RFC 6750 response format. 

This PR also corrects the internal API error mappings for the credential endpoint errors (e.g. MissingProofError, InvalidProofError) from `INTERNAL_SERVER_ERROR` to `BAD_REQUEST`, and expanded the public error mappings to return proper OID4VCI error responses. 

## Links to any relevant issues
fixes issue #341 

## How the change has been tested
Describe the tests that you ran to verify your changes.
Make sure to provide instructions for the maintainer as well as any relevant configurations.

## Definition of Done checklist
Add an `x` to the boxes that are relevant to your changes.

- [ ] I have followed the contribution guidelines for this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] I have successfully tested this change in a docker environment 
