### PR TITLE
feat(issuance): reissue credentials automatically

### DIFF
--- a/agent_api_http/openapi-generated.yaml
+++ b/agent_api_http/openapi-generated.yaml
@@ -139,6 +139,28 @@ paths:
       responses:
         '201':
           description: Credential configuration updated successfully
+  /v0/credential-refresh:
+    post:
+      tags:
+      - Issuance
+      operationId: refresh_credential
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/CredentialRefreshRequest'
+        required: true
+      responses:
+        '200':
+          description: Credential refresh continuation prepared successfully
+          content:
+            application/x-www-form-urlencoded:
+              schema:
+                type: string
+        '403':
+          description: Credential refresh cannot proceed
+        '404':
+          description: Refresh reference not found
   /v0/credential-reissuance:
     get:
       tags:
@@ -995,6 +1017,13 @@ components:
       - Created
       - Pending
       - Issued
+    CredentialRefreshRequest:
+      type: object
+      required:
+      - refreshToken
+      properties:
+        refreshToken:
+          type: string
     CredentialRefreshService:
       type: object
       required:

--- a/agent_api_http/openapi-generated.yaml
+++ b/agent_api_http/openapi-generated.yaml
@@ -139,7 +139,7 @@ paths:
       responses:
         '201':
           description: Credential configuration updated successfully
-  /v0/credential-refresh:
+  /v0/refresh-credential:
     post:
       tags:
       - Issuance
@@ -161,11 +161,11 @@ paths:
           description: Credential refresh cannot proceed
         '404':
           description: Refresh reference not found
-  /v0/credential-reissuance:
+  /v0/list-all-credential-reissuances:
     get:
       tags:
       - Issuance
-      operationId: get_all_credential_reissuances
+      operationId: list_all_credential_reissuances
       responses:
         '200':
           description: All credential reissuance relations retrieved successfully
@@ -175,10 +175,11 @@ paths:
                 type: array
                 items:
                   $ref: '#/components/schemas/Reissuance'
+  /v0/reissue-credential:
     post:
       tags:
       - Issuance
-      operationId: create_credential_reissuance
+      operationId: reissue_credential
       requestBody:
         content:
           application/json:
@@ -192,13 +193,13 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/CreateCredentialReissuanceResponse'
-  /v0/credential-reissuance/{reissuance_id}:
+  /v0/get-credential-reissuance/{id}:
     get:
       tags:
       - Issuance
-      operationId: get_credential_reissuance_by_id
+      operationId: get_credential_reissuance
       parameters:
-      - name: reissuance_id
+      - name: id
         in: path
         required: true
         schema:

--- a/agent_api_http/openapi-generated.yaml
+++ b/agent_api_http/openapi-generated.yaml
@@ -139,6 +139,57 @@ paths:
       responses:
         '201':
           description: Credential configuration updated successfully
+  /v0/credential-reissuance:
+    get:
+      tags:
+      - Issuance
+      operationId: get_all_credential_reissuances
+      responses:
+        '200':
+          description: All credential reissuance relations retrieved successfully
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/Reissuance'
+    post:
+      tags:
+      - Issuance
+      operationId: create_credential_reissuance
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/CreateCredentialReissuanceRequest'
+        required: true
+      responses:
+        '201':
+          description: Credential reissuance prepared successfully
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/CreateCredentialReissuanceResponse'
+  /v0/credential-reissuance/{reissuance_id}:
+    get:
+      tags:
+      - Issuance
+      operationId: get_credential_reissuance_by_id
+      parameters:
+      - name: reissuance_id
+        in: path
+        required: true
+        schema:
+          type: string
+      responses:
+        '200':
+          description: Credential reissuance relation retrieved successfully
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Reissuance'
+        '404':
+          description: Credential reissuance relation not found
   /v0/credentials:
     get:
       tags:
@@ -670,6 +721,60 @@ components:
           type:
           - string
           - 'null'
+    CreateCredentialReissuanceRequest:
+      type: object
+      required:
+      - originalCredentialId
+      - credentialConfigurationId
+      - credential
+      - expiresAt
+      properties:
+        credential: {}
+        credentialConfigurationId:
+          type: string
+        expiresAt:
+          $ref: '#/components/schemas/CredentialExpiry'
+        originalCredentialId:
+          type: string
+        reason:
+          type:
+          - string
+          - 'null'
+        statusAction:
+          type:
+          - string
+          - 'null'
+        triggerType:
+          type:
+          - string
+          - 'null'
+        triggeredBy:
+          type:
+          - string
+          - 'null'
+    CreateCredentialReissuanceResponse:
+      type: object
+      required:
+      - id
+      - originalCredentialId
+      - newCredentialId
+      - offerId
+      - credentialConfigurationId
+      properties:
+        credentialConfigurationId:
+          type: string
+        credentialOffer:
+          type:
+          - string
+          - 'null'
+        id:
+          type: string
+        newCredentialId:
+          type: string
+        offerId:
+          type: string
+        originalCredentialId:
+          type: string
     CreateTemplateEndpointRequest:
       type: object
       properties:
@@ -837,6 +942,10 @@ components:
           type:
           - string
           - 'null'
+        refresh_service:
+          oneOf:
+          - type: 'null'
+          - $ref: '#/components/schemas/CredentialRefreshService'
         signed: {}
         status:
           $ref: '#/components/schemas/IssuanceStatus'
@@ -866,6 +975,10 @@ components:
             type: string
           format:
             type: string
+          refreshService:
+            oneOf:
+            - type: 'null'
+            - $ref: '#/components/schemas/RefreshServiceConfiguration'
           type:
             type: array
             items:
@@ -882,6 +995,19 @@ components:
       - Created
       - Pending
       - Issued
+    CredentialRefreshService:
+      type: object
+      required:
+      - type
+      - url
+      - refreshToken
+      properties:
+        refreshToken:
+          type: string
+        type:
+          type: string
+        url:
+          type: string
     CredentialStatus:
       type: object
       required:
@@ -1281,6 +1407,53 @@ components:
       properties:
         selectivelyDisclosable:
           type: boolean
+    RefreshServiceConfiguration:
+      type: object
+      required:
+      - type
+      properties:
+        type:
+          type: string
+    Reissuance:
+      type: object
+      required:
+      - id
+      - original_credential_id
+      - new_credential_id
+      - offer_id
+      - credential_configuration_id
+      properties:
+        created_at:
+          type:
+          - string
+          - 'null'
+          format: date-time
+        credential_configuration_id:
+          type: string
+        id:
+          type: string
+        new_credential_id:
+          type: string
+        offer_id:
+          type: string
+        original_credential_id:
+          type: string
+        reason:
+          type:
+          - string
+          - 'null'
+        status_action:
+          type:
+          - string
+          - 'null'
+        trigger_type:
+          type:
+          - string
+          - 'null'
+        triggered_by:
+          type:
+          - string
+          - 'null'
     RemoveConnectionRequest:
       type: object
       required:

--- a/agent_api_http/src/v0/issuance/credential_refresh.rs
+++ b/agent_api_http/src/v0/issuance/credential_refresh.rs
@@ -1,0 +1,173 @@
+use std::sync::Arc;
+
+use crate::error::type_url;
+use agent_issuance::{
+    refresh_capability::{
+        continuation::{
+            PrepareRefreshContinuationRequest, RefreshContinuation, RefreshContinuationService,
+            RefreshContinuationServiceError,
+        },
+        preparation::{NoOpRefreshPreparationHook, RefreshPreparationError},
+        service::RefreshCapabilityServiceError,
+    },
+    state::IssuanceState,
+};
+use axum::{
+    extract::{Json, State},
+    http::{header, StatusCode},
+    response::{IntoResponse, Response},
+};
+use http_api_problem::ApiError;
+use serde::{Deserialize, Serialize};
+
+#[derive(Debug, Deserialize, Serialize, utoipa::ToSchema)]
+#[serde(rename_all = "camelCase")]
+pub struct CredentialRefreshRequest {
+    pub refresh_token: String,
+}
+
+#[utoipa::path(
+    post,
+    path = "/credential-refresh",
+    operation_id = "refresh_credential",
+    tags = ["Issuance"],
+    request_body = CredentialRefreshRequest,
+    responses(
+        (status = 200, description = "Credential refresh continuation prepared successfully", content_type = "application/x-www-form-urlencoded", body = String),
+        (status = 403, description = "Credential refresh cannot proceed"),
+        (status = 404, description = "Refresh reference not found"),
+    )
+)]
+#[axum_macros::debug_handler]
+pub(crate) async fn credential_refresh(
+    State(state): State<Arc<IssuanceState>>,
+    Json(CredentialRefreshRequest { refresh_token }): Json<CredentialRefreshRequest>,
+) -> Result<Response, ApiError> {
+    let continuation = RefreshContinuationService::new(NoOpRefreshPreparationHook)
+        .prepare(
+            state.as_ref(),
+            PrepareRefreshContinuationRequest {
+                refresh_reference: refresh_token,
+            },
+        )
+        .await
+        .map_err(refresh_continuation_error)?;
+
+    match continuation {
+        RefreshContinuation::CredentialOffer {
+            form_url_encoded_credential_offer,
+        } => Ok((
+            StatusCode::OK,
+            [(header::CONTENT_TYPE, "application/x-www-form-urlencoded")],
+            form_url_encoded_credential_offer,
+        )
+            .into_response()),
+    }
+}
+
+fn refresh_continuation_error(error: RefreshContinuationServiceError) -> ApiError {
+    match error {
+        RefreshContinuationServiceError::RefreshCapability(RefreshCapabilityServiceError::NotFound) => {
+            ApiError::builder(StatusCode::NOT_FOUND)
+                .title("Refresh reference not found")
+                .type_url(type_url("issuance#refresh-reference-not-found"))
+                .message("The refresh reference was not found.")
+                .finish()
+        }
+        RefreshContinuationServiceError::Preparation(RefreshPreparationError::RefreshUnavailable) => {
+            ApiError::builder(StatusCode::FORBIDDEN)
+                .title("Credential refresh cannot proceed")
+                .type_url(type_url("issuance#credential-refresh-unavailable"))
+                .message("Credential refresh cannot proceed.")
+                .finish()
+        }
+        RefreshContinuationServiceError::Preparation(RefreshPreparationError::PreparationFailed(message)) => {
+            ApiError::builder(StatusCode::INTERNAL_SERVER_ERROR)
+                .title("Credential refresh preparation failed")
+                .type_url(type_url("issuance#credential-refresh-preparation-failed"))
+                .message(message)
+                .finish()
+        }
+        error => ApiError::builder(StatusCode::INTERNAL_SERVER_ERROR)
+            .title("Credential refresh failed")
+            .type_url(type_url("issuance#credential-refresh-failed"))
+            .message(error.to_string())
+            .finish(),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::{v0::issuance::router, API_VERSION};
+    use agent_issuance::{
+        refresh_capability::service::RefreshCapabilityService,
+        services::IssuanceServices,
+        state::{initialize, IssuanceState},
+    };
+    use agent_secret_manager::service::Service;
+    use agent_shared::config::RefreshServiceConfiguration;
+    use agent_store::{in_memory::InMemory, issuance_state};
+    use axum::{
+        body::Body,
+        http::{self, Request},
+    };
+    use serde_json::json;
+    use tower::ServiceExt;
+
+    async fn test_state() -> Arc<IssuanceState> {
+        let state = Arc::new(issuance_state(&InMemory, IssuanceServices::default().await, Default::default()).await);
+        initialize(&state).await.unwrap();
+        state
+    }
+
+    async fn post_credential_refresh(state: Arc<IssuanceState>, refresh_token: &str) -> StatusCode {
+        let app = router(state);
+
+        app.oneshot(
+            Request::builder()
+                .method(http::Method::POST)
+                .uri(format!("{API_VERSION}/credential-refresh"))
+                .header(http::header::CONTENT_TYPE, mime::APPLICATION_JSON.as_ref())
+                .body(Body::from(
+                    serde_json::to_vec(&json!({
+                        "refreshToken": refresh_token
+                    }))
+                    .unwrap(),
+                ))
+                .unwrap(),
+        )
+        .await
+        .unwrap()
+        .status()
+    }
+
+    #[tokio::test]
+    async fn credential_refresh_returns_not_found_for_unknown_reference() {
+        let state = test_state().await;
+
+        let status = post_credential_refresh(state, "unknown-refresh-reference").await;
+
+        assert_eq!(status, StatusCode::NOT_FOUND);
+    }
+
+    #[tokio::test]
+    async fn credential_refresh_returns_forbidden_when_noop_hook_cannot_prepare() {
+        let state = test_state().await;
+        let refresh_capability = RefreshCapabilityService::default()
+            .create_for_credential(
+                &state,
+                "credential-id",
+                Some(&RefreshServiceConfiguration {
+                    type_: "VerifiableCredentialRefreshService2021".to_string(),
+                }),
+            )
+            .await
+            .unwrap()
+            .unwrap();
+
+        let status = post_credential_refresh(state, &refresh_capability.refresh_reference).await;
+
+        assert_eq!(status, StatusCode::FORBIDDEN);
+    }
+}

--- a/agent_api_http/src/v0/issuance/credential_refresh.rs
+++ b/agent_api_http/src/v0/issuance/credential_refresh.rs
@@ -28,7 +28,7 @@ pub struct CredentialRefreshRequest {
 
 #[utoipa::path(
     post,
-    path = "/credential-refresh",
+    path = "/refresh-credential",
     operation_id = "refresh_credential",
     tags = ["Issuance"],
     request_body = CredentialRefreshRequest,
@@ -127,7 +127,7 @@ mod tests {
         app.oneshot(
             Request::builder()
                 .method(http::Method::POST)
-                .uri(format!("{API_VERSION}/credential-refresh"))
+                .uri(format!("{API_VERSION}/refresh-credential"))
                 .header(http::header::CONTENT_TYPE, mime::APPLICATION_JSON.as_ref())
                 .body(Body::from(
                     serde_json::to_vec(&json!({

--- a/agent_api_http/src/v0/issuance/credential_refresh.rs
+++ b/agent_api_http/src/v0/issuance/credential_refresh.rs
@@ -101,12 +101,12 @@ mod tests {
     use super::*;
     use crate::{v0::issuance::router, API_VERSION};
     use agent_issuance::{
-        refresh_capability::service::RefreshCapabilityService,
+        refresh_capability::{command::RefreshCapabilityCommand, service::RefreshCapabilityService},
         services::IssuanceServices,
         state::{initialize, IssuanceState},
     };
     use agent_secret_manager::service::Service;
-    use agent_shared::config::RefreshServiceConfiguration;
+    use agent_shared::{config::RefreshServiceConfiguration, handlers::command_handler};
     use agent_store::{in_memory::InMemory, issuance_state};
     use axum::{
         body::Body,
@@ -169,5 +169,33 @@ mod tests {
         let status = post_credential_refresh(state, &refresh_capability.refresh_reference).await;
 
         assert_eq!(status, StatusCode::FORBIDDEN);
+    }
+
+    #[tokio::test]
+    async fn credential_refresh_returns_not_found_for_disabled_reference() {
+        let state = test_state().await;
+        let refresh_capability = RefreshCapabilityService::default()
+            .create_for_credential(
+                &state,
+                "credential-id",
+                Some(&RefreshServiceConfiguration {
+                    type_: "VerifiableCredentialRefreshService2021".to_string(),
+                }),
+            )
+            .await
+            .unwrap()
+            .unwrap();
+
+        command_handler(
+            &refresh_capability.refresh_reference,
+            &state.command.refresh_capability,
+            RefreshCapabilityCommand::DisableRefreshCapability,
+        )
+        .await
+        .unwrap();
+
+        let status = post_credential_refresh(state, &refresh_capability.refresh_reference).await;
+
+        assert_eq!(status, StatusCode::NOT_FOUND);
     }
 }

--- a/agent_api_http/src/v0/issuance/credentials.rs
+++ b/agent_api_http/src/v0/issuance/credentials.rs
@@ -85,7 +85,7 @@ pub(crate) async fn credentials(
 ) -> Result<Response, ApiError> {
     let credential_id = uuid::Uuid::new_v4().to_string();
 
-    let (_, credential_configuration, authorization) = query_handler(SERVER_CONFIG_ID, &state.query.server_config)
+    let (_, credential_configuration, authorization, _) = query_handler(SERVER_CONFIG_ID, &state.query.server_config)
         .await?
         .and_then(|server_config_view| {
             server_config_view

--- a/agent_api_http/src/v0/issuance/credentials.rs
+++ b/agent_api_http/src/v0/issuance/credentials.rs
@@ -1,6 +1,7 @@
 use crate::error::type_url;
 use crate::handlers::{command_handler, query_handler};
 use crate::API_VERSION;
+use agent_issuance::refresh_capability::service::RefreshCapabilityService;
 use agent_issuance::status_list::command::StatusListCommand;
 use agent_issuance::{
     credential::{
@@ -85,23 +86,24 @@ pub(crate) async fn credentials(
 ) -> Result<Response, ApiError> {
     let credential_id = uuid::Uuid::new_v4().to_string();
 
-    let (_, credential_configuration, authorization, _) = query_handler(SERVER_CONFIG_ID, &state.query.server_config)
-        .await?
-        .and_then(|server_config_view| {
-            server_config_view
-                .credential_configurations
-                .get(&credential_configuration_id)
-                .cloned()
-        })
-        .ok_or_else(|| {
-            ApiError::builder(StatusCode::NOT_FOUND)
-                .title("No Credential Configuration Found")
-                .type_url(type_url("issuance#no-credential-configuration-found"))
-                .message(format!(
-                    "No Credential Configuration found with id: `{credential_configuration_id}`"
-                ))
-                .finish()
-        })?;
+    let (_, credential_configuration, authorization, refresh_service) =
+        query_handler(SERVER_CONFIG_ID, &state.query.server_config)
+            .await?
+            .and_then(|server_config_view| {
+                server_config_view
+                    .credential_configurations
+                    .get(&credential_configuration_id)
+                    .cloned()
+            })
+            .ok_or_else(|| {
+                ApiError::builder(StatusCode::NOT_FOUND)
+                    .title("No Credential Configuration Found")
+                    .type_url(type_url("issuance#no-credential-configuration-found"))
+                    .message(format!(
+                        "No Credential Configuration found with id: `{credential_configuration_id}`"
+                    ))
+                    .finish()
+            })?;
 
     let command = if is_signed {
         // For a signed credential, ensure that the credential is a string.
@@ -137,6 +139,19 @@ pub(crate) async fn credentials(
 
     // Create an unsigned/signed credential.
     command_handler(&credential_id, &state.command.credential, command).await?;
+
+    if !is_signed {
+        RefreshCapabilityService::default()
+            .create_for_credential(&state, &credential_id, refresh_service.as_ref())
+            .await
+            .map_err(|err| {
+                ApiError::builder(StatusCode::INTERNAL_SERVER_ERROR)
+                    .title("Failed to create refresh capability")
+                    .type_url(type_url("issuance#create-refresh-capability-failed"))
+                    .message(err.to_string())
+                    .finish()
+            })?;
+    }
 
     // Create an offer if it does not exist yet.
     if query_handler(&offer_id, &state.query.offer).await?.is_none() {

--- a/agent_api_http/src/v0/issuance/credentials.rs
+++ b/agent_api_http/src/v0/issuance/credentials.rs
@@ -153,7 +153,7 @@ pub(crate) async fn credentials(
                     type_: refresh_service.type_.clone(),
                     url: config()
                         .public_url
-                        .append_path_segment("credential-refresh")
+                        .append_path_segment("refresh-credential")
                         .to_string(),
                     refresh_token: refresh_capability.refresh_reference.clone(),
                 },

--- a/agent_api_http/src/v0/issuance/credentials.rs
+++ b/agent_api_http/src/v0/issuance/credentials.rs
@@ -1,6 +1,7 @@
 use crate::error::type_url;
 use crate::handlers::{command_handler, query_handler};
 use crate::API_VERSION;
+use agent_issuance::credential::aggregate::CredentialRefreshService;
 use agent_issuance::refresh_capability::service::RefreshCapabilityService;
 use agent_issuance::status_list::command::StatusListCommand;
 use agent_issuance::{
@@ -12,6 +13,8 @@ use agent_issuance::{
     offer::command::OfferCommand,
     state::{IssuanceState, SERVER_CONFIG_ID},
 };
+use agent_shared::config::config;
+use agent_shared::UrlAppendHelpers;
 use axum::{
     extract::{Json, Path, State},
     http::StatusCode,
@@ -105,53 +108,68 @@ pub(crate) async fn credentials(
                     .finish()
             })?;
 
-    let command = if is_signed {
-        // For a signed credential, ensure that the credential is a string.
-        if !credential.is_string() {
-            return Err(ApiError::builder(StatusCode::BAD_REQUEST)
-                .title("Invalid Credential Type")
-                .type_url(type_url("issuance#invalid-credential-type"))
-                .message("For signed credentials, the credential must be a string.")
-                .finish());
-        }
+    let command =
+        if is_signed {
+            // For a signed credential, ensure that the credential is a string.
+            if !credential.is_string() {
+                return Err(ApiError::builder(StatusCode::BAD_REQUEST)
+                    .title("Invalid Credential Type")
+                    .type_url(type_url("issuance#invalid-credential-type"))
+                    .message("For signed credentials, the credential must be a string.")
+                    .finish());
+            }
 
-        CredentialCommand::CreateSignedCredential {
-            credential_id: credential_id.clone(),
-            signed_credential: credential,
-        }
-    } else {
-        // For an unsigned credential, ensure that the credential is an object.
-        if !credential.is_object() {
-            return Err(ApiError::builder(StatusCode::BAD_REQUEST)
-                .title("Invalid Credential Type")
-                .type_url(type_url("issuance#invalid-credential-type"))
-                .message("For unsigned credentials, the credential must be an object.")
-                .finish());
-        }
+            CredentialCommand::CreateSignedCredential {
+                credential_id: credential_id.clone(),
+                signed_credential: credential,
+            }
+        } else {
+            // For an unsigned credential, ensure that the credential is an object.
+            if !credential.is_object() {
+                return Err(ApiError::builder(StatusCode::BAD_REQUEST)
+                    .title("Invalid Credential Type")
+                    .type_url(type_url("issuance#invalid-credential-type"))
+                    .message("For unsigned credentials, the credential must be an object.")
+                    .finish());
+            }
 
-        CredentialCommand::CreateUnsignedCredential {
-            credential_id: credential_id.clone(),
-            data: Data { raw: credential },
-            credential_configuration: Box::new(credential_configuration.clone()),
-            expires_at,
-        }
-    };
+            let refresh_capability = if !is_signed {
+                RefreshCapabilityService::default()
+                    .create_for_credential(&state, &credential_id, refresh_service.as_ref())
+                    .await
+                    .map_err(|err| {
+                        ApiError::builder(StatusCode::INTERNAL_SERVER_ERROR)
+                            .title("Failed to create refresh capability")
+                            .type_url(type_url("issuance#create-refresh-capability-failed"))
+                            .message(err.to_string())
+                            .finish()
+                    })?
+            } else {
+                None
+            };
+
+            let credential_refresh_service = refresh_service.as_ref().zip(refresh_capability.as_ref()).map(
+                |(refresh_service, refresh_capability)| CredentialRefreshService {
+                    type_: refresh_service.type_.clone(),
+                    url: config()
+                        .public_url
+                        .append_path_segment("credential-refresh")
+                        .to_string(),
+                    refresh_token: refresh_capability.refresh_reference.clone(),
+                },
+            );
+
+            CredentialCommand::CreateUnsignedCredential {
+                credential_id: credential_id.clone(),
+                data: Data { raw: credential },
+                credential_configuration: Box::new(credential_configuration.clone()),
+                refresh_service: credential_refresh_service,
+                expires_at,
+            }
+        };
 
     // Create an unsigned/signed credential.
     command_handler(&credential_id, &state.command.credential, command).await?;
-
-    if !is_signed {
-        RefreshCapabilityService::default()
-            .create_for_credential(&state, &credential_id, refresh_service.as_ref())
-            .await
-            .map_err(|err| {
-                ApiError::builder(StatusCode::INTERNAL_SERVER_ERROR)
-                    .title("Failed to create refresh capability")
-                    .type_url(type_url("issuance#create-refresh-capability-failed"))
-                    .message(err.to_string())
-                    .finish()
-            })?;
-    }
 
     // Create an offer if it does not exist yet.
     if query_handler(&offer_id, &state.query.offer).await?.is_none() {

--- a/agent_api_http/src/v0/issuance/error.rs
+++ b/agent_api_http/src/v0/issuance/error.rs
@@ -195,6 +195,13 @@ impl IntoApiErrorExt for ReissuanceServiceError {
                     .message(error)
                     .finish()
             }
+            ReissuanceServiceError::RefreshCapability(error) => {
+                ApiError::builder(StatusCode::INTERNAL_SERVER_ERROR)
+                    .title("Credential Reissuance Failed")
+                    .type_url(type_url("issuance#credential-reissuance-failed"))
+                    .message(error.to_string())
+                    .finish()
+            }
         }
     }
 }

--- a/agent_api_http/src/v0/issuance/ietf_oauth_sd_jwt_vc.rs
+++ b/agent_api_http/src/v0/issuance/ietf_oauth_sd_jwt_vc.rs
@@ -31,7 +31,7 @@ pub(crate) async fn type_metadata(
             server_config_view
                 .credential_configurations
                 .get(&credential_configuration_id)
-                .map(|(_, credential_configuration, _authorization)| credential_configuration)
+                .map(|(_, credential_configuration, _authorization, _refresh_service)| credential_configuration)
                 .cloned()
         })
         .ok_or(PublicError::NotFoundError)?;

--- a/agent_api_http/src/v0/issuance/mod.rs
+++ b/agent_api_http/src/v0/issuance/mod.rs
@@ -1,6 +1,7 @@
 // Endpoint handlers
 pub mod credential_configurations;
 pub mod credential_issuer;
+pub mod credential_refresh;
 pub mod credentials;
 pub mod ietf_oauth_sd_jwt_vc;
 pub mod nonce;
@@ -21,6 +22,7 @@ use crate::v0::issuance::{
             oauth_authorization_server::oauth_authorization_server, openid_credential_issuer::openid_credential_issuer,
         },
     },
+    credential_refresh::credential_refresh,
     credentials::{all_credentials, credentials, patch_credential},
     nonce::nonce,
     offers::{
@@ -50,6 +52,7 @@ pub fn router(issuance_state: Arc<IssuanceState>) -> Router {
                     "/credential-reissuance",
                     post(credential_reissuances).get(all_credential_reissuances),
                 )
+                .route("/credential-refresh", post(credential_refresh))
                 .route("/credential-reissuance/{reissuance_id}", get(credential_reissuance))
                 .route("/offers", post(offers).get(all_offers))
                 .route("/offers/{offer_id}", get(offer))

--- a/agent_api_http/src/v0/issuance/mod.rs
+++ b/agent_api_http/src/v0/issuance/mod.rs
@@ -48,12 +48,10 @@ pub fn router(issuance_state: Arc<IssuanceState>) -> Router {
                     get(credentials::credential).patch(patch_credential),
                 )
                 .route("/credential-configurations", post(credential_configurations))
-                .route(
-                    "/credential-reissuance",
-                    post(credential_reissuances).get(all_credential_reissuances),
-                )
-                .route("/credential-refresh", post(credential_refresh))
-                .route("/credential-reissuance/{reissuance_id}", get(credential_reissuance))
+                .route("/reissue-credential", post(credential_reissuances))
+                .route("/list-all-credential-reissuances", get(all_credential_reissuances))
+                .route("/refresh-credential", post(credential_refresh))
+                .route("/get-credential-reissuance/{id}", get(credential_reissuance))
                 .route("/offers", post(offers).get(all_offers))
                 .route("/offers/{offer_id}", get(offer))
                 .route("/offers/send-offer-to-individual", post(individual_offer))

--- a/agent_api_http/src/v0/issuance/offers/mod.rs
+++ b/agent_api_http/src/v0/issuance/offers/mod.rs
@@ -61,7 +61,7 @@ pub(crate) async fn offers(
 
     let authorization = credential_configurations
         .into_iter()
-        .find_map(|(credential_configuration_id, (_, _, authorization))| {
+        .find_map(|(credential_configuration_id, (_, _, authorization, _))| {
             credential_configuration_ids
                 .contains(&credential_configuration_id)
                 .then_some(authorization)

--- a/agent_api_http/src/v0/issuance/openapi.rs
+++ b/agent_api_http/src/v0/issuance/openapi.rs
@@ -1,4 +1,5 @@
 use crate::v0::issuance::credential_configurations::__path_credential_configurations;
+use crate::v0::issuance::credential_refresh::__path_credential_refresh;
 use crate::v0::issuance::credentials::{__path_all_credentials, __path_credential, __path_credentials};
 use crate::v0::issuance::offers::{
     __path_all_offers, __path_offer,
@@ -22,7 +23,8 @@ use utoipa::OpenApi;
         organization_offer,
         credential_reissuances,
         all_credential_reissuances,
-        credential_reissuance
+        credential_reissuance,
+        credential_refresh
     ),
     tags(
         (name = "Credentials", description = "Create and revoke verifiable credentials."),

--- a/agent_api_http/src/v0/issuance/reissuance.rs
+++ b/agent_api_http/src/v0/issuance/reissuance.rs
@@ -271,6 +271,7 @@ mod tests {
                     }),
                 },
                 credential_configuration: Box::new(credential_configuration),
+                refresh_service: None,
                 expires_at: CredentialExpiry::Never,
             },
         )

--- a/agent_api_http/src/v0/issuance/reissuance.rs
+++ b/agent_api_http/src/v0/issuance/reissuance.rs
@@ -44,8 +44,8 @@ pub struct CreateCredentialReissuanceResponse {
 
 #[utoipa::path(
     post,
-    path = "/credential-reissuance",
-    operation_id = "create_credential_reissuance",
+    path = "/reissue-credential",
+    operation_id = "reissue_credential",
     tags = ["Issuance"],
     responses(
         (status = 201, description = "Credential reissuance prepared successfully", body = CreateCredentialReissuanceResponse)
@@ -113,8 +113,8 @@ pub(crate) async fn credential_reissuances(
 
 #[utoipa::path(
     get,
-    path = "/credential-reissuance",
-    operation_id = "get_all_credential_reissuances",
+    path = "/list-all-credential-reissuances",
+    operation_id = "list_all_credential_reissuances",
     tags = ["Issuance"],
     responses(
         (status = 200, description = "All credential reissuance relations retrieved successfully", body = [ReissuanceView])
@@ -139,8 +139,8 @@ pub(crate) async fn all_credential_reissuances(State(state): State<Arc<IssuanceS
 
 #[utoipa::path(
     get,
-    path = "/credential-reissuance/{reissuance_id}",
-    operation_id = "get_credential_reissuance_by_id",
+    path = "/get-credential-reissuance/{id}",
+    operation_id = "get_credential_reissuance",
     tags = ["Issuance"],
     responses(
         (status = 200, description = "Credential reissuance relation retrieved successfully", body = ReissuanceView),
@@ -285,7 +285,7 @@ mod tests {
             .oneshot(
                 Request::builder()
                     .method(http::Method::POST)
-                    .uri(format!("{API_VERSION}/credential-reissuance"))
+                    .uri(format!("{API_VERSION}/reissue-credential"))
                     .header(http::header::CONTENT_TYPE, mime::APPLICATION_JSON.as_ref())
                     .body(Body::from(
                         serde_json::to_vec(&json!({
@@ -446,7 +446,7 @@ mod tests {
             .oneshot(
                 Request::builder()
                     .method(http::Method::GET)
-                    .uri(format!("{API_VERSION}/credential-reissuance"))
+                    .uri(format!("{API_VERSION}/list-all-credential-reissuances"))
                     .body(Body::empty())
                     .unwrap(),
             )
@@ -475,7 +475,7 @@ mod tests {
             .oneshot(
                 Request::builder()
                     .method(http::Method::GET)
-                    .uri(format!("{API_VERSION}/credential-reissuance/{reissuance_id}"))
+                    .uri(format!("{API_VERSION}/get-credential-reissuance/{reissuance_id}"))
                     .body(Body::empty())
                     .unwrap(),
             )
@@ -500,7 +500,7 @@ mod tests {
             .oneshot(
                 Request::builder()
                     .method(http::Method::GET)
-                    .uri(format!("{API_VERSION}/credential-reissuance/unknown-reissuance-id"))
+                    .uri(format!("{API_VERSION}/get-credential-reissuance/unknown-reissuance-id"))
                     .body(Body::empty())
                     .unwrap(),
             )

--- a/agent_event_publisher_http/src/lib.rs
+++ b/agent_event_publisher_http/src/lib.rs
@@ -9,6 +9,7 @@ use agent_identity::{
 };
 use agent_issuance::{
     credential::aggregate::Credential, nonce::aggregate::Nonce, offer::aggregate::Offer,
+    refresh_capability::aggregate::RefreshCapability, reissuance::aggregate::Reissuance,
     server_config::aggregate::ServerConfig, status_list::aggregate::StatusListAggregate,
 };
 use agent_library::template::aggregate::Template;
@@ -50,6 +51,8 @@ pub struct EventPublisherHttp {
     // Issuance
     pub server_config: Option<AggregateEventPublisherHttp<ServerConfig>>,
     pub credential: Option<AggregateEventPublisherHttp<Credential>>,
+    pub reissuance: Option<AggregateEventPublisherHttp<Reissuance>>,
+    pub refresh_capability: Option<AggregateEventPublisherHttp<RefreshCapability>>,
     pub offer: Option<AggregateEventPublisherHttp<Offer>>,
     pub nonce: Option<AggregateEventPublisherHttp<Nonce>>,
     pub status_list: Option<AggregateEventPublisherHttp<StatusListAggregate>>,
@@ -216,6 +219,32 @@ impl EventPublisherHttp {
             )
         });
 
+        let reissuance = (!event_publisher_http.events.reissuance.is_empty()).then(|| {
+            AggregateEventPublisherHttp::<Reissuance>::new(
+                event_publisher_http.target_url.clone(),
+                event_publisher_http.headers.clone(),
+                event_publisher_http
+                    .events
+                    .reissuance
+                    .iter()
+                    .map(ToString::to_string)
+                    .collect(),
+            )
+        });
+
+        let refresh_capability = (!event_publisher_http.events.refresh_capability.is_empty()).then(|| {
+            AggregateEventPublisherHttp::<RefreshCapability>::new(
+                event_publisher_http.target_url.clone(),
+                event_publisher_http.headers.clone(),
+                event_publisher_http
+                    .events
+                    .refresh_capability
+                    .iter()
+                    .map(ToString::to_string)
+                    .collect(),
+            )
+        });
+
         let offer = (!event_publisher_http.events.offer.is_empty()).then(|| {
             AggregateEventPublisherHttp::<Offer>::new(
                 event_publisher_http.target_url.clone(),
@@ -319,6 +348,8 @@ impl EventPublisherHttp {
             template,
             server_config,
             credential,
+            reissuance,
+            refresh_capability,
             offer,
             nonce,
             status_list,
@@ -441,11 +472,15 @@ impl EventPublisher for EventPublisherHttp {
     }
 
     fn reissuance(&mut self) -> Option<ReissuanceEventPublisher> {
-        None
+        self.reissuance
+            .take()
+            .map(|publisher| Box::new(publisher) as ReissuanceEventPublisher)
     }
 
     fn refresh_capability(&mut self) -> Option<RefreshCapabilityEventPublisher> {
-        None
+        self.refresh_capability
+            .take()
+            .map(|publisher| Box::new(publisher) as RefreshCapabilityEventPublisher)
     }
 }
 
@@ -544,11 +579,15 @@ mod tests {
         set_config().enable_event_publisher_http();
         set_config().set_event_publisher_http_target_url(target_url.clone());
         set_config().set_event_publisher_http_target_events(Events {
+            reissuance: vec![agent_shared::config::ReissuanceEvent::ReissuanceCreated],
+            refresh_capability: vec![agent_shared::config::RefreshCapabilityEvent::RefreshCapabilityCreated],
             offer: vec![agent_shared::config::OfferEvent::FormUrlEncodedCredentialOfferCreated],
             ..Default::default()
         });
 
         let publisher = EventPublisherHttp::load().unwrap();
+        assert!(publisher.reissuance.is_some());
+        assert!(publisher.refresh_capability.is_some());
 
         // A new event for the `Offer` aggregate.
         let offer_event = OfferEvent::FormUrlEncodedCredentialOfferCreated {

--- a/agent_event_publisher_http/src/lib.rs
+++ b/agent_event_publisher_http/src/lib.rs
@@ -17,8 +17,9 @@ use agent_store::{
     AccessTokenEventPublisher, AuthorizationCodeEventPublisher, AuthorizationRequestEventPublisher,
     ClientEventPublisher, ConnectionEventPublisher, CredentialEventPublisher, DocumentEventPublisher, EventPublisher,
     HolderCredentialEventPublisher, NonceEventPublisher, OAuth2AuthorizationRequestEventPublisher, OfferEventPublisher,
-    PresentationEventPublisher, ProfileEventPublisher, ReceivedOfferEventPublisher, ReissuanceEventPublisher,
-    ServerConfigEventPublisher, ServiceEventPublisher, StatusListEventPublisher, TemplateEventPublisher,
+    PresentationEventPublisher, ProfileEventPublisher, ReceivedOfferEventPublisher, RefreshCapabilityEventPublisher,
+    ReissuanceEventPublisher, ServerConfigEventPublisher, ServiceEventPublisher, StatusListEventPublisher,
+    TemplateEventPublisher,
 };
 use agent_verification::authorization_request::aggregate::AuthorizationRequest;
 use async_trait::async_trait;
@@ -440,6 +441,10 @@ impl EventPublisher for EventPublisherHttp {
     }
 
     fn reissuance(&mut self) -> Option<ReissuanceEventPublisher> {
+        None
+    }
+
+    fn refresh_capability(&mut self) -> Option<RefreshCapabilityEventPublisher> {
         None
     }
 }

--- a/agent_event_publisher_nats/src/lib.rs
+++ b/agent_event_publisher_nats/src/lib.rs
@@ -1,11 +1,14 @@
-use agent_issuance::offer::aggregate::Offer;
+use agent_issuance::{
+    offer::aggregate::Offer, refresh_capability::aggregate::RefreshCapability, reissuance::aggregate::Reissuance,
+};
 use agent_shared::config::config;
 use agent_store::{
     AccessTokenEventPublisher, AuthorizationCodeEventPublisher, AuthorizationRequestEventPublisher,
     ClientEventPublisher, ConnectionEventPublisher, CredentialEventPublisher, DocumentEventPublisher, EventPublisher,
     HolderCredentialEventPublisher, NonceEventPublisher, OAuth2AuthorizationRequestEventPublisher, OfferEventPublisher,
-    PresentationEventPublisher, ProfileEventPublisher, ReceivedOfferEventPublisher, ReissuanceEventPublisher,
-    ServerConfigEventPublisher, ServiceEventPublisher, StatusListEventPublisher, TemplateEventPublisher,
+    PresentationEventPublisher, ProfileEventPublisher, ReceivedOfferEventPublisher, RefreshCapabilityEventPublisher,
+    ReissuanceEventPublisher, ServerConfigEventPublisher, ServiceEventPublisher, StatusListEventPublisher,
+    TemplateEventPublisher,
 };
 use async_nats::Client;
 use async_trait::async_trait;
@@ -20,6 +23,8 @@ use uuid::Uuid;
 #[derive(Default, Debug)]
 pub struct EventPublisherNats {
     pub offer: Option<AggregateEventPublisherNats<Offer>>,
+    pub reissuance: Option<AggregateEventPublisherNats<Reissuance>>,
+    pub refresh_capability: Option<AggregateEventPublisherNats<RefreshCapability>>,
 }
 
 #[derive(Debug)]
@@ -66,10 +71,12 @@ impl EventPublisherNats {
         }
 
         let mut offer = None;
+        let mut reissuance = None;
+        let mut refresh_capability = None;
 
         // Iterate through the list of subjects from the config.
         for subject_config in &nats_config.subjects {
-            if !subject_config.events.offer.is_empty() {
+            if !subject_config.events.offer.is_empty() && offer.is_none() {
                 offer = Some(
                     AggregateEventPublisherNats::<Offer>::new(
                         nats_config.nats_url.clone(),
@@ -79,12 +86,48 @@ impl EventPublisherNats {
                     .await
                     .map_err(|e| anyhow::anyhow!("Failed to create NATS client: {}", e))?,
                 );
-                break;
-                // TODO: Extend this to loop for other aggregates if added.
+            }
+
+            if !subject_config.events.reissuance.is_empty() && reissuance.is_none() {
+                reissuance = Some(
+                    AggregateEventPublisherNats::<Reissuance>::new(
+                        nats_config.nats_url.clone(),
+                        subject_config.name.clone(),
+                        subject_config
+                            .events
+                            .reissuance
+                            .iter()
+                            .map(ToString::to_string)
+                            .collect(),
+                    )
+                    .await
+                    .map_err(|e| anyhow::anyhow!("Failed to create NATS client: {}", e))?,
+                );
+            }
+
+            if !subject_config.events.refresh_capability.is_empty() && refresh_capability.is_none() {
+                refresh_capability = Some(
+                    AggregateEventPublisherNats::<RefreshCapability>::new(
+                        nats_config.nats_url.clone(),
+                        subject_config.name.clone(),
+                        subject_config
+                            .events
+                            .refresh_capability
+                            .iter()
+                            .map(ToString::to_string)
+                            .collect(),
+                    )
+                    .await
+                    .map_err(|e| anyhow::anyhow!("Failed to create NATS client: {}", e))?,
+                );
             }
         }
 
-        let event_publisher = EventPublisherNats { offer };
+        let event_publisher = EventPublisherNats {
+            offer,
+            reissuance,
+            refresh_capability,
+        };
 
         info!("Loaded NATS event publisher: {:?}", event_publisher);
 
@@ -168,11 +211,15 @@ impl EventPublisher for EventPublisherNats {
     }
 
     fn reissuance(&mut self) -> Option<ReissuanceEventPublisher> {
-        None
+        self.reissuance
+            .take()
+            .map(|publisher| Box::new(publisher) as ReissuanceEventPublisher)
     }
 
-    fn refresh_capability(&mut self) -> Option<agent_store::RefreshCapabilityEventPublisher> {
-        None
+    fn refresh_capability(&mut self) -> Option<RefreshCapabilityEventPublisher> {
+        self.refresh_capability
+            .take()
+            .map(|publisher| Box::new(publisher) as RefreshCapabilityEventPublisher)
     }
 }
 

--- a/agent_event_publisher_nats/src/lib.rs
+++ b/agent_event_publisher_nats/src/lib.rs
@@ -170,6 +170,10 @@ impl EventPublisher for EventPublisherNats {
     fn reissuance(&mut self) -> Option<ReissuanceEventPublisher> {
         None
     }
+
+    fn refresh_capability(&mut self) -> Option<agent_store::RefreshCapabilityEventPublisher> {
+        None
+    }
 }
 
 #[async_trait]

--- a/agent_issuance/src/credential/aggregate.rs
+++ b/agent_issuance/src/credential/aggregate.rs
@@ -80,6 +80,15 @@ pub struct CredentialStatus {
     pub status_list_url: String,
 }
 
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, utoipa::ToSchema)]
+#[serde(rename_all = "camelCase")]
+pub struct CredentialRefreshService {
+    #[serde(rename = "type")]
+    pub type_: String,
+    pub url: String,
+    pub refresh_token: String,
+}
+
 #[derive(Debug, Clone, Serialize, Deserialize, Default, PartialEq, utoipa::ToSchema)]
 pub struct Credential {
     #[serde(rename = "id")]
@@ -93,6 +102,7 @@ pub struct Credential {
     #[schema(schema_with = holder_notifications)]
     pub holder_notifications: Vec<NotificationRequest>,
     pub credential_status: CredentialStatus,
+    pub refresh_service: Option<CredentialRefreshService>,
     #[schema(value_type = Option<String>)]
     pub created_at: Option<DateTime<Utc>>,
     #[schema(value_type = Option<String>)]
@@ -122,6 +132,7 @@ impl Aggregate for Credential {
                 credential_id,
                 data,
                 credential_configuration,
+                refresh_service,
                 expires_at,
             } => {
                 #[cfg(feature = "test_utils")]
@@ -145,7 +156,7 @@ impl Aggregate for Credential {
 
                 let mut credential_data = data.raw.clone();
 
-                let credential_data = match &credential_configuration.credential_format {
+                let mut credential_data = match &credential_configuration.credential_format {
                     CredentialFormats::JwtVcJson(Parameters::<JwtVcJson> {
                         parameters:
                             JwtVcJsonParameters {
@@ -204,11 +215,27 @@ impl Aggregate for Credential {
                     }
                 };
 
+                if let Some(refresh_service) = &refresh_service {
+                    credential_data
+                        .insert_at_path(
+                            &["refreshService"],
+                            json!({
+                                "type": refresh_service.type_,
+                                "url": refresh_service.url,
+                                "refreshToken": refresh_service.refresh_token,
+                            }),
+                        )
+                        .ok_or(BuildCredentialError(
+                            "Failed to enter refreshService into the credential".to_string(),
+                        ))?;
+                }
+
                 return Ok(vec![UnsignedCredentialCreated {
                     credential_id,
                     notification_id: Some(notification_id),
                     data: Data { raw: credential_data },
                     credential_configuration,
+                    refresh_service,
                     created_at: Some(created_at),
                     expires_at,
                 }]);
@@ -514,6 +541,7 @@ impl Aggregate for Credential {
                 credential_id,
                 data,
                 credential_configuration,
+                refresh_service,
                 notification_id,
                 created_at,
                 expires_at,
@@ -521,6 +549,7 @@ impl Aggregate for Credential {
                 self.credential_id = credential_id;
                 self.data.replace(data);
                 self.credential_configuration = *credential_configuration;
+                self.refresh_service = refresh_service;
                 self.notification_id = notification_id;
                 self.created_at = created_at;
                 self.expires_at = expires_at;
@@ -1021,6 +1050,7 @@ pub mod credential_tests {
                     raw: credential_subject,
                 },
                 credential_configuration: Box::new(credential_configuration.clone()),
+                refresh_service: None,
                 expires_at: CredentialExpiry::Never,
             })
             .then_expect_events(vec![CredentialEvent::UnsignedCredentialCreated {
@@ -1030,7 +1060,47 @@ pub mod credential_tests {
                 },
                 notification_id: Some(notification_id.clone()),
                 credential_configuration: Box::new(credential_configuration),
+                refresh_service: None,
                 created_at: Some(created_at),
+                expires_at: None,
+            }])
+    }
+
+    #[async_std::test]
+    async fn create_unsigned_credential_embeds_refresh_service() {
+        let refresh_service = CredentialRefreshService {
+            type_: "VerifiableCredentialRefreshService2021".to_string(),
+            url: "https://issuer.example.com/credential-refresh".to_string(),
+            refresh_token: "opaque-refresh-reference".to_string(),
+        };
+
+        let mut expected_credential = UNSIGNED_DC_SD_JWT_CREDENTIAL.clone();
+        expected_credential["refreshService"] = json!({
+            "type": "VerifiableCredentialRefreshService2021",
+            "url": "https://issuer.example.com/credential-refresh",
+            "refreshToken": "opaque-refresh-reference"
+        });
+
+        CredentialTestFramework::with(IssuanceServices::default().await)
+            .given_no_previous_events()
+            .when(CredentialCommand::CreateUnsignedCredential {
+                credential_id: "credential-id".to_string(),
+                data: Data {
+                    raw: BASIC_CREDENTIAL_SUBJECT["credentialSubject"].clone(),
+                },
+                credential_configuration: Box::new(DC_SD_JWT_CREDENTIAL_CONFIGURATION.clone()),
+                refresh_service: Some(refresh_service.clone()),
+                expires_at: CredentialExpiry::Never,
+            })
+            .then_expect_events(vec![CredentialEvent::UnsignedCredentialCreated {
+                credential_id: "credential-id".to_string(),
+                data: Data {
+                    raw: expected_credential,
+                },
+                notification_id: Some(test_utils::notification_id()),
+                credential_configuration: Box::new(DC_SD_JWT_CREDENTIAL_CONFIGURATION.clone()),
+                refresh_service: Some(refresh_service),
+                created_at: Some(test_utils::created_at()),
                 expires_at: None,
             }])
     }
@@ -1101,6 +1171,7 @@ pub mod credential_tests {
                 },
                 credential_configuration: Box::new(credential_configuration),
                 notification_id: None,
+                refresh_service: None,
                 created_at: Some(created_at),
                 expires_at: None,
             }])

--- a/agent_issuance/src/credential/command.rs
+++ b/agent_issuance/src/credential/command.rs
@@ -4,7 +4,7 @@ use oid4vci::{
 };
 use serde::Deserialize;
 
-use crate::credential::aggregate::CredentialStatus;
+use crate::credential::aggregate::{CredentialRefreshService, CredentialStatus};
 
 use super::{aggregate::CredentialExpiry, entity::Data};
 
@@ -15,6 +15,7 @@ pub enum CredentialCommand {
         credential_id: String,
         data: Data,
         credential_configuration: Box<CredentialConfigurationsSupportedObject>,
+        refresh_service: Option<CredentialRefreshService>,
         expires_at: CredentialExpiry,
     },
     CreateSignedCredential {

--- a/agent_issuance/src/credential/event.rs
+++ b/agent_issuance/src/credential/event.rs
@@ -1,4 +1,4 @@
-use crate::credential::aggregate::CredentialStatus;
+use crate::credential::aggregate::{CredentialRefreshService, CredentialStatus};
 
 use super::{aggregate::Status, entity::Data};
 use chrono::{DateTime, Utc};
@@ -18,6 +18,7 @@ pub enum CredentialEvent {
         data: Data,
         notification_id: Option<String>,
         credential_configuration: Box<CredentialConfigurationsSupportedObject>,
+        refresh_service: Option<CredentialRefreshService>,
         created_at: Option<DateTime<Utc>>,
         expires_at: Option<DateTime<Utc>>,
     },

--- a/agent_issuance/src/credential/views/mod.rs
+++ b/agent_issuance/src/credential/views/mod.rs
@@ -14,6 +14,7 @@ impl View<Credential> for Credential {
                 data,
                 credential_configuration,
                 notification_id,
+                refresh_service,
                 created_at,
                 expires_at,
             } => {
@@ -21,6 +22,7 @@ impl View<Credential> for Credential {
                 self.data.replace(data.clone());
                 self.credential_configuration = *credential_configuration.clone();
                 self.notification_id.clone_from(notification_id);
+                self.refresh_service.clone_from(refresh_service);
                 self.created_at.clone_from(created_at);
                 self.expires_at.clone_from(expires_at);
             }

--- a/agent_issuance/src/lib.rs
+++ b/agent_issuance/src/lib.rs
@@ -9,6 +9,7 @@ use tracing::info;
 pub mod credential;
 pub mod nonce;
 pub mod offer;
+pub mod refresh_capability;
 pub mod reissuance;
 pub mod server_config;
 pub mod status_list;

--- a/agent_issuance/src/refresh_capability/aggregate.rs
+++ b/agent_issuance/src/refresh_capability/aggregate.rs
@@ -1,0 +1,196 @@
+use std::sync::Arc;
+
+use async_trait::async_trait;
+use chrono::{DateTime, Utc};
+use cqrs_es::Aggregate;
+use serde::{Deserialize, Serialize};
+use tracing::{debug, info};
+
+use crate::{
+    refresh_capability::{
+        command::RefreshCapabilityCommand,
+        error::RefreshCapabilityError,
+        event::RefreshCapabilityEvent::{self, RefreshCapabilityCreated, RefreshCapabilityDisabled},
+    },
+    services::IssuanceServices,
+};
+
+#[derive(Debug, Clone, Default, Deserialize, Serialize, PartialEq, utoipa::ToSchema)]
+pub struct RefreshCapability {
+    #[serde(rename = "id")]
+    pub refresh_reference: String,
+    pub credential_id: String,
+    pub status: RefreshCapabilityStatus,
+    pub created_at: Option<DateTime<Utc>>,
+}
+
+#[derive(Debug, Clone, Default, Deserialize, Serialize, PartialEq, utoipa::ToSchema)]
+#[serde(rename_all = "snake_case")]
+pub enum RefreshCapabilityStatus {
+    #[default]
+    Active,
+    Disabled,
+}
+
+#[async_trait]
+impl Aggregate for RefreshCapability {
+    type Command = RefreshCapabilityCommand;
+    type Event = RefreshCapabilityEvent;
+    type Error = RefreshCapabilityError;
+    type Services = Arc<IssuanceServices>;
+
+    fn aggregate_type() -> String {
+        "refresh_capability".to_string()
+    }
+
+    async fn handle(
+        &self,
+        command: Self::Command,
+        _services: &Self::Services,
+    ) -> Result<Vec<Self::Event>, Self::Error> {
+        info!("Handling command: {:?}", command);
+
+        match command {
+            RefreshCapabilityCommand::CreateRefreshCapability {
+                refresh_reference,
+                credential_id,
+            } => {
+                if self.created_at.is_some() {
+                    return Err(RefreshCapabilityError::AlreadyExists);
+                }
+
+                #[cfg(feature = "test_utils")]
+                let created_at: DateTime<Utc> = "2010-01-01T00:00:00Z".parse().map_err(|e| {
+                    RefreshCapabilityError::BuildRefreshCapabilityError(format!("Failed to parse created_at: {e}"))
+                })?;
+                #[cfg(not(feature = "test_utils"))]
+                let created_at: DateTime<Utc> = chrono::Utc::now();
+
+                Ok(vec![RefreshCapabilityCreated {
+                    refresh_reference,
+                    credential_id,
+                    created_at,
+                }])
+            }
+            RefreshCapabilityCommand::DisableRefreshCapability => {
+                if self.created_at.is_none() {
+                    return Err(RefreshCapabilityError::NotFound);
+                }
+
+                if self.status == RefreshCapabilityStatus::Disabled {
+                    return Err(RefreshCapabilityError::AlreadyDisabled);
+                }
+
+                Ok(vec![RefreshCapabilityDisabled])
+            }
+        }
+    }
+
+    fn apply(&mut self, event: Self::Event) {
+        debug!("Applying event: {:?}", event);
+
+        match event {
+            RefreshCapabilityCreated {
+                refresh_reference,
+                credential_id,
+                created_at,
+            } => {
+                self.refresh_reference = refresh_reference;
+                self.credential_id = credential_id;
+                self.status = RefreshCapabilityStatus::Active;
+                self.created_at = Some(created_at);
+            }
+            RefreshCapabilityDisabled => {
+                self.status = RefreshCapabilityStatus::Disabled;
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::services::IssuanceServices;
+    use agent_secret_manager::service::Service;
+
+    fn create_refresh_capability_command() -> RefreshCapabilityCommand {
+        RefreshCapabilityCommand::CreateRefreshCapability {
+            refresh_reference: "refresh-reference".to_string(),
+            credential_id: "credential-id".to_string(),
+        }
+    }
+
+    #[async_std::test]
+    async fn create_refresh_capability_records_reference() {
+        let services = IssuanceServices::default().await;
+        let mut refresh_capability = RefreshCapability::default();
+
+        let events = refresh_capability
+            .handle(create_refresh_capability_command(), &services)
+            .await
+            .expect("refresh capability creation should succeed");
+
+        assert_eq!(events.len(), 1);
+
+        let RefreshCapabilityCreated {
+            refresh_reference,
+            credential_id,
+            created_at,
+        } = events
+            .first()
+            .expect("refresh capability creation should emit an event")
+            .clone()
+        else {
+            panic!("expected refresh capability created event");
+        };
+
+        assert_eq!(refresh_reference, "refresh-reference");
+        assert_eq!(credential_id, "credential-id");
+
+        refresh_capability.apply(RefreshCapabilityCreated {
+            refresh_reference,
+            credential_id,
+            created_at,
+        });
+
+        assert_eq!(refresh_capability.refresh_reference, "refresh-reference");
+        assert_eq!(refresh_capability.credential_id, "credential-id");
+        assert_eq!(refresh_capability.status, RefreshCapabilityStatus::Active);
+        assert!(refresh_capability.created_at.is_some());
+
+        let error = refresh_capability
+            .handle(create_refresh_capability_command(), &services)
+            .await
+            .expect_err("existing refresh capability should not be recreated");
+
+        assert_eq!(error, RefreshCapabilityError::AlreadyExists);
+    }
+
+    #[async_std::test]
+    async fn disable_refresh_capability_marks_reference_disabled() {
+        let services = IssuanceServices::default().await;
+        let mut refresh_capability = RefreshCapability::default();
+
+        let events = refresh_capability
+            .handle(create_refresh_capability_command(), &services)
+            .await
+            .expect("refresh capability creation should succeed");
+
+        for event in events {
+            refresh_capability.apply(event);
+        }
+
+        let events = refresh_capability
+            .handle(RefreshCapabilityCommand::DisableRefreshCapability, &services)
+            .await
+            .expect("refresh capability disable should succeed");
+
+        assert_eq!(events, vec![RefreshCapabilityDisabled]);
+
+        for event in events {
+            refresh_capability.apply(event);
+        }
+
+        assert_eq!(refresh_capability.status, RefreshCapabilityStatus::Disabled);
+    }
+}

--- a/agent_issuance/src/refresh_capability/command.rs
+++ b/agent_issuance/src/refresh_capability/command.rs
@@ -1,0 +1,10 @@
+use serde::{Deserialize, Serialize};
+
+#[derive(Debug, Clone, Deserialize, Serialize)]
+pub enum RefreshCapabilityCommand {
+    CreateRefreshCapability {
+        refresh_reference: String,
+        credential_id: String,
+    },
+    DisableRefreshCapability,
+}

--- a/agent_issuance/src/refresh_capability/continuation.rs
+++ b/agent_issuance/src/refresh_capability/continuation.rs
@@ -1,0 +1,326 @@
+use agent_shared::handlers::query_handler;
+
+use crate::{
+    refresh_capability::{
+        preparation::{RefreshPreparationError, RefreshPreparationHook, RefreshPreparationRequest},
+        service::{RefreshCapabilityService, RefreshCapabilityServiceError},
+    },
+    reissuance::service::{CreateReissuanceRequest, ReissuanceService, ReissuanceServiceError},
+    state::IssuanceState,
+};
+
+#[derive(Debug, Clone, PartialEq)]
+pub struct PrepareRefreshContinuationRequest {
+    pub refresh_reference: String,
+}
+
+#[derive(Debug, Clone, PartialEq)]
+pub enum RefreshContinuation {
+    CredentialOffer { form_url_encoded_credential_offer: String },
+}
+
+#[derive(Debug, thiserror::Error)]
+pub enum RefreshContinuationServiceError {
+    #[error(transparent)]
+    RefreshCapability(#[from] RefreshCapabilityServiceError),
+    #[error(transparent)]
+    Preparation(#[from] RefreshPreparationError),
+    #[error(transparent)]
+    Reissuance(#[from] ReissuanceServiceError),
+    #[error("Credential offer was not found")]
+    CredentialOfferNotFound,
+    #[error("Failed to query state: {0}")]
+    Query(String),
+}
+
+pub struct RefreshContinuationService<H> {
+    preparation_hook: H,
+}
+
+impl<H> RefreshContinuationService<H>
+where
+    H: RefreshPreparationHook,
+{
+    pub fn new(preparation_hook: H) -> Self {
+        Self { preparation_hook }
+    }
+
+    pub async fn prepare(
+        &self,
+        state: &IssuanceState,
+        request: PrepareRefreshContinuationRequest,
+    ) -> Result<RefreshContinuation, RefreshContinuationServiceError> {
+        let resolved = RefreshCapabilityService::default()
+            .resolve_active(state, &request.refresh_reference)
+            .await?;
+
+        let input = self
+            .preparation_hook
+            .prepare(&RefreshPreparationRequest {
+                refresh_reference: resolved.refresh_reference.clone(),
+                credential_id: resolved.credential_id.clone(),
+            })
+            .await?;
+
+        let response = ReissuanceService::default()
+            .create(
+                state,
+                CreateReissuanceRequest {
+                    reissuance_id: uuid::Uuid::new_v4().to_string(),
+                    original_credential_id: resolved.credential_id,
+                    new_credential_id: uuid::Uuid::new_v4().to_string(),
+                    offer_id: uuid::Uuid::new_v4().to_string(),
+                    credential_configuration_id: input.credential_configuration_id,
+                    credential: input.credential,
+                    expires_at: input.expires_at,
+                    reason: input.metadata.reason,
+                    trigger_type: input.metadata.trigger_type,
+                    triggered_by: input.metadata.triggered_by,
+                    status_action: None,
+                },
+            )
+            .await?;
+
+        let form_url_encoded_credential_offer = query_handler(&response.offer_id, &state.query.offer)
+            .await
+            .map_err(|err| RefreshContinuationServiceError::Query(err.to_string()))?
+            .and_then(|offer| offer.form_url_encoded_credential_offer)
+            .ok_or(RefreshContinuationServiceError::CredentialOfferNotFound)?;
+
+        Ok(RefreshContinuation::CredentialOffer {
+            form_url_encoded_credential_offer,
+        })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use async_trait::async_trait;
+
+    use agent_issuance::{
+        credential::{aggregate::CredentialExpiry, command::CredentialCommand, entity::Data},
+        refresh_capability::{
+            continuation::{
+                PrepareRefreshContinuationRequest, RefreshContinuation, RefreshContinuationService,
+                RefreshContinuationServiceError,
+            },
+            preparation::{
+                RefreshPreparationError, RefreshPreparationHook, RefreshPreparationInput, RefreshPreparationMetadata,
+                RefreshPreparationRequest,
+            },
+            service::RefreshCapabilityService,
+        },
+        server_config::command::ServerConfigCommand,
+        services::IssuanceServices,
+        state::{initialize, IssuanceState, SERVER_CONFIG_ID},
+    };
+    use agent_secret_manager::service::Service;
+    use agent_shared::{
+        config::CredentialConfiguration,
+        handlers::{command_handler, query_handler},
+        UrlAppendHelpers,
+    };
+    use agent_store::{in_memory::InMemory, issuance_state};
+    use serde_json::json;
+    use std::sync::Arc;
+
+    struct TestRefreshPreparationHook;
+
+    #[async_trait]
+    impl RefreshPreparationHook for TestRefreshPreparationHook {
+        async fn prepare(
+            &self,
+            request: &RefreshPreparationRequest,
+        ) -> Result<RefreshPreparationInput, RefreshPreparationError> {
+            Ok(RefreshPreparationInput {
+                credential_configuration_id: "SD-JWT VC".to_string(),
+                credential: json!({
+                    "first_name": "Ferris",
+                    "last_name": "Refreshed",
+                    "dob": "2010-01-01"
+                }),
+                expires_at: CredentialExpiry::Never,
+                metadata: RefreshPreparationMetadata {
+                    reason: Some("test".to_string()),
+                    trigger_type: Some("refresh_service".to_string()),
+                    triggered_by: Some(request.refresh_reference.clone()),
+                },
+            })
+        }
+    }
+
+    async fn test_state() -> Arc<IssuanceState> {
+        let state = Arc::new(issuance_state(&InMemory, IssuanceServices::default().await, Default::default()).await);
+        initialize(state.as_ref()).await.unwrap();
+        state
+    }
+
+    async fn make_sd_jwt_configuration_refreshable(state: &IssuanceState) {
+        let credential_configuration = serde_json::from_value::<CredentialConfiguration>(json!({
+            "credential_configuration_id": "SD-JWT VC",
+            "format": "dc+sd-jwt",
+            "display": [
+                {
+                    "name": "SD-JWT VC Credential",
+                    "locale": "en"
+                }
+            ],
+            "claims": [
+                {
+                    "path": ["first_name"]
+                },
+                {
+                    "path": ["last_name"]
+                },
+                {
+                    "path": ["dob"]
+                }
+            ],
+            "refreshService": {
+                "type": "VerifiableCredentialRefreshService2021"
+            }
+        }))
+        .unwrap();
+
+        command_handler(
+            SERVER_CONFIG_ID,
+            &state.command.server_config,
+            ServerConfigCommand::UpdateCredentialConfiguration {
+                credential_configuration,
+                provisioned: false,
+            },
+        )
+        .await
+        .unwrap();
+    }
+
+    async fn create_original_credential(state: &IssuanceState) {
+        let (_, credential_configuration, _, refresh_service) =
+            query_handler(SERVER_CONFIG_ID, &state.query.server_config)
+                .await
+                .unwrap()
+                .and_then(|server_config| server_config.credential_configurations.get("SD-JWT VC").cloned())
+                .unwrap();
+
+        let refresh_capability = RefreshCapabilityService::default()
+            .create_for_credential(state, "original-credential-id", refresh_service.as_ref())
+            .await
+            .unwrap();
+
+        let credential_refresh_service =
+            refresh_service
+                .as_ref()
+                .zip(refresh_capability.as_ref())
+                .map(|(refresh_service, refresh_capability)| {
+                    agent_issuance::credential::aggregate::CredentialRefreshService {
+                        type_: refresh_service.type_.clone(),
+                        url: agent_shared::config::config()
+                            .public_url
+                            .append_path_segment("credential-refresh")
+                            .to_string(),
+                        refresh_token: refresh_capability.refresh_reference.clone(),
+                    }
+                });
+
+        command_handler(
+            "original-credential-id",
+            &state.command.credential,
+            CredentialCommand::CreateUnsignedCredential {
+                credential_id: "original-credential-id".to_string(),
+                data: Data {
+                    raw: json!({
+                        "first_name": "Ferris",
+                        "last_name": "Original",
+                        "dob": "2010-01-01"
+                    }),
+                },
+                credential_configuration: Box::new(credential_configuration),
+                expires_at: CredentialExpiry::Never,
+                refresh_service: credential_refresh_service,
+            },
+        )
+        .await
+        .unwrap();
+    }
+
+    #[async_std::test]
+    async fn prepare_returns_credential_offer_continuation() {
+        let state = test_state().await;
+        make_sd_jwt_configuration_refreshable(&state).await;
+        create_original_credential(&state).await;
+
+        let original_credential = query_handler("original-credential-id", &state.query.credential)
+            .await
+            .unwrap()
+            .unwrap();
+
+        let refresh_reference = original_credential
+            .refresh_service
+            .expect("original credential should be refreshable")
+            .refresh_token;
+
+        let continuation = RefreshContinuationService::new(TestRefreshPreparationHook)
+            .prepare(state.as_ref(), PrepareRefreshContinuationRequest { refresh_reference })
+            .await
+            .unwrap();
+
+        let RefreshContinuation::CredentialOffer {
+            form_url_encoded_credential_offer,
+        } = continuation;
+
+        assert!(form_url_encoded_credential_offer.starts_with("openid-credential-offer://"));
+
+        let all_reissuances = query_handler("all_reissuances", &state.query.all_reissuances)
+            .await
+            .unwrap()
+            .unwrap();
+
+        let reissuance = all_reissuances
+            .reissuances
+            .values()
+            .find(|reissuance| reissuance.original_credential_id == "original-credential-id")
+            .expect("refresh should create a reissuance relation");
+
+        assert_eq!(reissuance.reason.as_deref(), Some("test"));
+        assert_eq!(reissuance.trigger_type.as_deref(), Some("refresh_service"));
+    }
+
+    struct DenyingRefreshPreparationHook;
+
+    #[async_trait]
+    impl RefreshPreparationHook for DenyingRefreshPreparationHook {
+        async fn prepare(
+            &self,
+            _request: &RefreshPreparationRequest,
+        ) -> Result<RefreshPreparationInput, RefreshPreparationError> {
+            Err(RefreshPreparationError::RefreshUnavailable)
+        }
+    }
+
+    #[async_std::test]
+    async fn denial_should_fail_refresh_continuation() {
+        let state = test_state().await;
+        make_sd_jwt_configuration_refreshable(&state).await;
+        create_original_credential(&state).await;
+
+        let original_credential = query_handler("original-credential-id", &state.query.credential)
+            .await
+            .unwrap()
+            .unwrap();
+
+        let refresh_reference = original_credential
+            .refresh_service
+            .expect("original credential should be refreshable")
+            .refresh_token;
+
+        let error = RefreshContinuationService::new(DenyingRefreshPreparationHook)
+            .prepare(&state, PrepareRefreshContinuationRequest { refresh_reference })
+            .await
+            .expect_err("hook denial should fail refresh continuation");
+
+        assert!(matches!(
+            error,
+            RefreshContinuationServiceError::Preparation(RefreshPreparationError::RefreshUnavailable)
+        ));
+    }
+}

--- a/agent_issuance/src/refresh_capability/error.rs
+++ b/agent_issuance/src/refresh_capability/error.rs
@@ -1,0 +1,13 @@
+use thiserror::Error;
+
+#[derive(Error, Debug, PartialEq)]
+pub enum RefreshCapabilityError {
+    #[error("Refresh capability already exists")]
+    AlreadyExists,
+    #[error("Refresh capability does not exist")]
+    NotFound,
+    #[error("Refresh capability is already disabled")]
+    AlreadyDisabled,
+    #[error("Failed to create refresh capability: {0}")]
+    BuildRefreshCapabilityError(String),
+}

--- a/agent_issuance/src/refresh_capability/event.rs
+++ b/agent_issuance/src/refresh_capability/event.rs
@@ -1,0 +1,24 @@
+use chrono::{DateTime, Utc};
+use cqrs_es::DomainEvent;
+use serde::{Deserialize, Serialize};
+use strum::Display;
+
+#[derive(Debug, Clone, Deserialize, Serialize, PartialEq, Display)]
+pub enum RefreshCapabilityEvent {
+    RefreshCapabilityCreated {
+        refresh_reference: String,
+        credential_id: String,
+        created_at: DateTime<Utc>,
+    },
+    RefreshCapabilityDisabled,
+}
+
+impl DomainEvent for RefreshCapabilityEvent {
+    fn event_type(&self) -> String {
+        self.to_string()
+    }
+
+    fn event_version(&self) -> String {
+        "1".to_string()
+    }
+}

--- a/agent_issuance/src/refresh_capability/mod.rs
+++ b/agent_issuance/src/refresh_capability/mod.rs
@@ -1,0 +1,5 @@
+pub mod aggregate;
+pub mod command;
+pub mod error;
+pub mod event;
+pub mod views;

--- a/agent_issuance/src/refresh_capability/mod.rs
+++ b/agent_issuance/src/refresh_capability/mod.rs
@@ -3,4 +3,5 @@ pub mod command;
 pub mod error;
 pub mod event;
 pub mod service;
+pub mod preparation;
 pub mod views;

--- a/agent_issuance/src/refresh_capability/mod.rs
+++ b/agent_issuance/src/refresh_capability/mod.rs
@@ -2,4 +2,5 @@ pub mod aggregate;
 pub mod command;
 pub mod error;
 pub mod event;
+pub mod service;
 pub mod views;

--- a/agent_issuance/src/refresh_capability/mod.rs
+++ b/agent_issuance/src/refresh_capability/mod.rs
@@ -1,5 +1,6 @@
 pub mod aggregate;
 pub mod command;
+pub mod continuation;
 pub mod error;
 pub mod event;
 pub mod preparation;

--- a/agent_issuance/src/refresh_capability/mod.rs
+++ b/agent_issuance/src/refresh_capability/mod.rs
@@ -2,6 +2,6 @@ pub mod aggregate;
 pub mod command;
 pub mod error;
 pub mod event;
-pub mod service;
 pub mod preparation;
+pub mod service;
 pub mod views;

--- a/agent_issuance/src/refresh_capability/preparation.rs
+++ b/agent_issuance/src/refresh_capability/preparation.rs
@@ -1,0 +1,87 @@
+use async_trait::async_trait;
+use thiserror::Error;
+
+use crate::credential::aggregate::CredentialExpiry;
+
+#[derive(Debug, Clone, PartialEq)]
+pub struct RefreshPreparationRequest {
+    pub refresh_reference: String,
+    pub credential_id: String,
+}
+
+#[derive(Debug, Clone, PartialEq)]
+pub struct RefreshPreparationInput {
+    pub credential_configuration_id: String,
+    pub credential: serde_json::Value,
+    pub expires_at: CredentialExpiry,
+    pub metadata: RefreshPreparationMetadata,
+}
+
+#[derive(Debug, Clone, Default, PartialEq)]
+pub struct RefreshPreparationMetadata {
+    pub reason: Option<String>,
+    pub trigger_type: Option<String>,
+    pub triggered_by: Option<String>,
+}
+
+#[derive(Debug, Error, PartialEq)]
+pub enum RefreshPreparationError {
+    #[error("Refresh cannot proceed")]
+    RefreshUnavailable,
+    #[error("Refresh preparation failed: {0}")]
+    PreparationFailed(String),
+}
+
+#[async_trait]
+pub trait RefreshPreparationHook: Send + Sync {
+    async fn prepare(
+        &self,
+        request: &RefreshPreparationRequest,
+    ) -> Result<RefreshPreparationInput, RefreshPreparationError>;
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    struct TestRefreshPreparationHook;
+
+    #[async_trait]
+    impl RefreshPreparationHook for TestRefreshPreparationHook {
+        async fn prepare(
+            &self,
+            request: &RefreshPreparationRequest,
+        ) -> Result<RefreshPreparationInput, RefreshPreparationError> {
+            Ok(RefreshPreparationInput {
+                credential_configuration_id: "credential-configuration-id".to_string(),
+                credential: serde_json::json!({
+                    "subject": request.credential_id
+                }),
+                expires_at: CredentialExpiry::Never,
+                metadata: RefreshPreparationMetadata {
+                    reason: Some("test".to_string()),
+                    trigger_type: Some("refresh_service".to_string()),
+                    triggered_by: None,
+                },
+            })
+        }
+    }
+
+    #[async_std::test]
+    async fn refresh_preparation_hook_can_return_neutral_preparation_input() {
+        let hook = TestRefreshPreparationHook;
+
+        let input = hook
+            .prepare(&RefreshPreparationRequest {
+                refresh_reference: "refresh-reference".to_string(),
+                credential_id: "credential-id".to_string(),
+            })
+            .await
+            .unwrap();
+
+        assert_eq!(input.credential_configuration_id, "credential-configuration-id");
+        assert_eq!(input.credential["subject"], "credential-id");
+        assert_eq!(input.expires_at, CredentialExpiry::Never);
+        assert_eq!(input.metadata.reason.as_deref(), Some("test"));
+    }
+}

--- a/agent_issuance/src/refresh_capability/preparation.rs
+++ b/agent_issuance/src/refresh_capability/preparation.rs
@@ -40,6 +40,19 @@ pub trait RefreshPreparationHook: Send + Sync {
     ) -> Result<RefreshPreparationInput, RefreshPreparationError>;
 }
 
+#[derive(Debug, Default, Clone)]
+pub struct NoOpRefreshPreparationHook;
+
+#[async_trait]
+impl RefreshPreparationHook for NoOpRefreshPreparationHook {
+    async fn prepare(
+        &self,
+        _request: &RefreshPreparationRequest,
+    ) -> Result<RefreshPreparationInput, RefreshPreparationError> {
+        Err(RefreshPreparationError::RefreshUnavailable)
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/agent_issuance/src/refresh_capability/service.rs
+++ b/agent_issuance/src/refresh_capability/service.rs
@@ -1,0 +1,100 @@
+use agent_shared::config::RefreshServiceConfiguration;
+use agent_shared::generate_random_string;
+use agent_shared::handlers::command_handler;
+
+use crate::{refresh_capability::command::RefreshCapabilityCommand, state::IssuanceState};
+
+#[derive(Debug, PartialEq)]
+pub struct CreateRefreshCapabilityResponse {
+    pub refresh_reference: String,
+}
+
+#[derive(Debug, thiserror::Error)]
+pub enum RefreshCapabilityServiceError {
+    #[error("Failed to execute command: {0}")]
+    Command(String),
+}
+
+#[derive(Default)]
+pub struct RefreshCapabilityService;
+
+impl RefreshCapabilityService {
+    pub async fn create_for_credential(
+        &self,
+        state: &IssuanceState,
+        credential_id: &str,
+        refresh_service: Option<&RefreshServiceConfiguration>,
+    ) -> Result<Option<CreateRefreshCapabilityResponse>, RefreshCapabilityServiceError> {
+        if refresh_service.is_none() {
+            return Ok(None);
+        }
+
+        let refresh_reference = generate_random_string();
+
+        let command = RefreshCapabilityCommand::CreateRefreshCapability {
+            refresh_reference: refresh_reference.clone(),
+            credential_id: credential_id.to_string(),
+        };
+
+        command_handler(&refresh_reference, &state.command.refresh_capability, command)
+            .await
+            .map_err(|err| RefreshCapabilityServiceError::Command(err.to_string()))?;
+
+        Ok(Some(CreateRefreshCapabilityResponse { refresh_reference }))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use agent_issuance::refresh_capability::service::RefreshCapabilityService;
+    use agent_issuance::services::IssuanceServices;
+    use agent_issuance::state::{initialize, IssuanceState};
+    use agent_secret_manager::service::Service;
+    use agent_shared::config::RefreshServiceConfiguration;
+    use agent_shared::handlers::query_handler;
+    use agent_store::{in_memory::InMemory, issuance_state};
+    use std::sync::Arc;
+
+    async fn test_state() -> Arc<IssuanceState> {
+        let state = Arc::new(issuance_state(&InMemory, IssuanceServices::default().await, Default::default()).await);
+        initialize(&state).await.unwrap();
+        state
+    }
+
+    #[async_std::test]
+    async fn create_for_credential_skips_when_refresh_service_is_absent() {
+        let state = test_state().await;
+
+        let response = RefreshCapabilityService::default()
+            .create_for_credential(&state, "credential-id", None)
+            .await
+            .unwrap();
+
+        assert_eq!(response, None);
+    }
+
+    #[async_std::test]
+    async fn create_for_credential_creates_capability_when_refresh_service_is_present() {
+        let state = test_state().await;
+
+        let response = RefreshCapabilityService::default()
+            .create_for_credential(
+                &state,
+                "credential-id",
+                Some(&RefreshServiceConfiguration {
+                    type_: "VerifiableCredentialRefreshService2021".to_string(),
+                }),
+            )
+            .await
+            .unwrap()
+            .unwrap();
+
+        let refresh_capability = query_handler(&response.refresh_reference, &state.query.refresh_capability)
+            .await
+            .unwrap()
+            .unwrap();
+
+        assert_eq!(refresh_capability.refresh_reference, response.refresh_reference);
+        assert_eq!(refresh_capability.credential_id, "credential-id");
+    }
+}

--- a/agent_issuance/src/refresh_capability/service.rs
+++ b/agent_issuance/src/refresh_capability/service.rs
@@ -1,7 +1,8 @@
-use agent_shared::config::RefreshServiceConfiguration;
 use agent_shared::generate_random_string;
 use agent_shared::handlers::command_handler;
+use agent_shared::{config::RefreshServiceConfiguration, handlers::query_handler};
 
+use crate::refresh_capability::aggregate::RefreshCapabilityStatus;
 use crate::{refresh_capability::command::RefreshCapabilityCommand, state::IssuanceState};
 
 #[derive(Debug, PartialEq)]
@@ -9,10 +10,20 @@ pub struct CreateRefreshCapabilityResponse {
     pub refresh_reference: String,
 }
 
+#[derive(Debug, Clone, PartialEq)]
+pub struct ResolveRefreshCapabilityResponse {
+    pub refresh_reference: String,
+    pub credential_id: String,
+}
+
 #[derive(Debug, thiserror::Error)]
 pub enum RefreshCapabilityServiceError {
+    #[error("Refresh capability was not found")]
+    NotFound,
     #[error("Failed to execute command: {0}")]
     Command(String),
+    #[error("Failed to query state: {0}")]
+    Query(String),
 }
 
 #[derive(Default)]
@@ -42,16 +53,38 @@ impl RefreshCapabilityService {
 
         Ok(Some(CreateRefreshCapabilityResponse { refresh_reference }))
     }
+
+    pub async fn resolve_active(
+        &self,
+        state: &IssuanceState,
+        refresh_reference: &str,
+    ) -> Result<ResolveRefreshCapabilityResponse, RefreshCapabilityServiceError> {
+        let refresh_capability = query_handler(refresh_reference, &state.query.refresh_capability)
+            .await
+            .map_err(|err| RefreshCapabilityServiceError::Query(err.to_string()))?
+            .ok_or(RefreshCapabilityServiceError::NotFound)?;
+
+        if refresh_capability.status != RefreshCapabilityStatus::Active {
+            return Err(RefreshCapabilityServiceError::NotFound);
+        }
+
+        Ok(ResolveRefreshCapabilityResponse {
+            refresh_reference: refresh_capability.refresh_reference,
+            credential_id: refresh_capability.credential_id,
+        })
+    }
 }
 
 #[cfg(test)]
 mod tests {
+    use agent_issuance::refresh_capability::command::RefreshCapabilityCommand;
+    use agent_issuance::refresh_capability::service::RefreshCapabilityServiceError;
     use agent_issuance::refresh_capability::service::RefreshCapabilityService;
     use agent_issuance::services::IssuanceServices;
     use agent_issuance::state::{initialize, IssuanceState};
     use agent_secret_manager::service::Service;
     use agent_shared::config::RefreshServiceConfiguration;
-    use agent_shared::handlers::query_handler;
+    use agent_shared::handlers::{command_handler, query_handler};
     use agent_store::{in_memory::InMemory, issuance_state};
     use std::sync::Arc;
 
@@ -96,5 +129,74 @@ mod tests {
 
         assert_eq!(refresh_capability.refresh_reference, response.refresh_reference);
         assert_eq!(refresh_capability.credential_id, "credential-id");
+    }
+
+    #[async_std::test]
+    async fn resolve_active_returns_active_refresh_capability() {
+        let state = test_state().await;
+
+        let created = RefreshCapabilityService::default()
+            .create_for_credential(
+                &state,
+                "credential-id",
+                Some(&RefreshServiceConfiguration {
+                    type_: "VerifiableCredentialRefreshService2021".to_string(),
+                }),
+            )
+            .await
+            .unwrap()
+            .unwrap();
+
+        let resolved = RefreshCapabilityService::default()
+            .resolve_active(&state, &created.refresh_reference)
+            .await
+            .unwrap();
+
+        assert_eq!(resolved.refresh_reference, created.refresh_reference);
+        assert_eq!(resolved.credential_id, "credential-id");
+    }
+
+    #[async_std::test]
+    async fn resolve_active_returns_not_found_for_unknown_reference() {
+        let state = test_state().await;
+
+        let error = RefreshCapabilityService::default()
+            .resolve_active(&state, "unknown-refresh-reference")
+            .await
+            .expect_err("unknown reference should not resolve");
+
+        assert!(matches!(error, RefreshCapabilityServiceError::NotFound));
+    }
+
+    #[async_std::test]
+    async fn resolve_active_returns_not_found_for_disabled_reference() {
+        let state = test_state().await;
+
+        let created = RefreshCapabilityService::default()
+            .create_for_credential(
+                &state,
+                "credential-id",
+                Some(&RefreshServiceConfiguration {
+                    type_: "VerifiableCredentialRefreshService2021".to_string(),
+                }),
+            )
+            .await
+            .unwrap()
+            .unwrap();
+
+        command_handler(
+            &created.refresh_reference,
+            &state.command.refresh_capability,
+            RefreshCapabilityCommand::DisableRefreshCapability,
+        )
+        .await
+        .unwrap();
+
+        let error = RefreshCapabilityService::default()
+            .resolve_active(&state, &created.refresh_reference)
+            .await
+            .expect_err("disabled reference should not resolve");
+
+        assert!(matches!(error, RefreshCapabilityServiceError::NotFound));
     }
 }

--- a/agent_issuance/src/refresh_capability/service.rs
+++ b/agent_issuance/src/refresh_capability/service.rs
@@ -78,8 +78,8 @@ impl RefreshCapabilityService {
 #[cfg(test)]
 mod tests {
     use agent_issuance::refresh_capability::command::RefreshCapabilityCommand;
-    use agent_issuance::refresh_capability::service::RefreshCapabilityServiceError;
     use agent_issuance::refresh_capability::service::RefreshCapabilityService;
+    use agent_issuance::refresh_capability::service::RefreshCapabilityServiceError;
     use agent_issuance::services::IssuanceServices;
     use agent_issuance::state::{initialize, IssuanceState};
     use agent_secret_manager::service::Service;

--- a/agent_issuance/src/refresh_capability/views/all_refresh_capabilities.rs
+++ b/agent_issuance/src/refresh_capability/views/all_refresh_capabilities.rs
@@ -1,0 +1,22 @@
+use std::collections::HashMap;
+
+use crate::refresh_capability::aggregate::RefreshCapability;
+
+use super::RefreshCapabilityView;
+use cqrs_es::{EventEnvelope, View};
+use serde::{Deserialize, Serialize};
+
+#[derive(Debug, Default, Serialize, Deserialize, Clone)]
+pub struct AllRefreshCapabilitiesView {
+    #[serde(flatten)]
+    pub refresh_capabilities: HashMap<String, RefreshCapabilityView>,
+}
+
+impl View<RefreshCapability> for AllRefreshCapabilitiesView {
+    fn update(&mut self, event: &EventEnvelope<RefreshCapability>) {
+        self.refresh_capabilities
+            .entry(event.aggregate_id.clone())
+            .or_default()
+            .update(event);
+    }
+}

--- a/agent_issuance/src/refresh_capability/views/mod.rs
+++ b/agent_issuance/src/refresh_capability/views/mod.rs
@@ -1,0 +1,26 @@
+pub mod all_refresh_capabilities;
+
+use super::aggregate::{RefreshCapability, RefreshCapabilityStatus};
+use super::event::RefreshCapabilityEvent;
+use cqrs_es::{EventEnvelope, View};
+
+pub type RefreshCapabilityView = RefreshCapability;
+
+impl View<RefreshCapability> for RefreshCapability {
+    fn update(&mut self, event: &EventEnvelope<RefreshCapability>) {
+        match &event.payload {
+            RefreshCapabilityEvent::RefreshCapabilityCreated {
+                refresh_reference,
+                credential_id,
+                created_at,
+            } => {
+                self.refresh_reference.clone_from(refresh_reference);
+                self.credential_id.clone_from(credential_id);
+                self.created_at.replace(*created_at);
+            }
+            RefreshCapabilityEvent::RefreshCapabilityDisabled => {
+                self.status = RefreshCapabilityStatus::Disabled;
+            }
+        }
+    }
+}

--- a/agent_issuance/src/reissuance/service.rs
+++ b/agent_issuance/src/reissuance/service.rs
@@ -1,8 +1,16 @@
-use agent_shared::handlers::{command_handler, query_handler};
+use agent_shared::{
+    config::config,
+    handlers::{command_handler, query_handler},
+    UrlAppendHelpers,
+};
 use oid4vci::{credential_format_profiles::CredentialFormats, credential_offer::GrantType};
 
 use crate::{
-    credential::{aggregate::CredentialExpiry, command::CredentialCommand, entity::Data},
+    credential::{
+        aggregate::{CredentialExpiry, CredentialRefreshService},
+        command::CredentialCommand,
+        entity::Data,
+    },
     offer::command::OfferCommand,
     refresh_capability::service::{RefreshCapabilityService, RefreshCapabilityServiceError},
     reissuance::{
@@ -124,12 +132,30 @@ where
             })
             .await?;
 
+        let refresh_capability = RefreshCapabilityService::default()
+            .create_for_credential(state, &request.new_credential_id, refresh_service.as_ref())
+            .await?;
+
+        let credential_refresh_service =
+            refresh_service
+                .as_ref()
+                .zip(refresh_capability.as_ref())
+                .map(|(refresh_service, refresh_capability)| CredentialRefreshService {
+                    type_: refresh_service.type_.clone(),
+                    url: config()
+                        .public_url
+                        .append_path_segment("credential-refresh")
+                        .to_string(),
+                    refresh_token: refresh_capability.refresh_reference.clone(),
+                });
+
         let create_credential_command = CredentialCommand::CreateUnsignedCredential {
             credential_id: request.new_credential_id.clone(),
             data: Data {
                 raw: request.credential,
             },
             credential_configuration: Box::new(credential_configuration.clone()),
+            refresh_service: credential_refresh_service,
             expires_at: request.expires_at,
         };
 
@@ -140,10 +166,6 @@ where
         )
         .await
         .map_err(|err| ReissuanceServiceError::Command(err.to_string()))?;
-
-        RefreshCapabilityService::default()
-            .create_for_credential(state, &request.new_credential_id, refresh_service.as_ref())
-            .await?;
 
         if query_handler(&request.offer_id, &state.query.offer)
             .await
@@ -402,6 +424,7 @@ mod tests {
                 credential_id: credential_id.to_string(),
                 data: Data { raw: credential },
                 credential_configuration: Box::new(credential_configuration),
+                refresh_service: None,
                 expires_at: CredentialExpiry::Never,
             },
         )
@@ -581,6 +604,21 @@ mod tests {
             .expect("new credential should have a refresh capability");
 
         assert_eq!(refresh_capability.status, RefreshCapabilityStatus::Active);
+
+        let new_credential = query_handler("new-credential-id", &state.query.credential)
+            .await
+            .unwrap()
+            .unwrap();
+        let new_credential_data = new_credential.data.unwrap().raw;
+
+        assert_eq!(
+            new_credential_data["refreshService"],
+            json!({
+                "type": "VerifiableCredentialRefreshService2021",
+                "url": "https://my-domain.example.org/credential-refresh",
+                "refreshToken": refresh_capability.refresh_reference
+            })
+        );
     }
 
     #[async_std::test]

--- a/agent_issuance/src/reissuance/service.rs
+++ b/agent_issuance/src/reissuance/service.rs
@@ -91,18 +91,19 @@ where
                 ReissuanceServiceError::OriginalCredentialNotFound(request.original_credential_id.clone())
             })?;
 
-        let (_, credential_configuration, authorization) = query_handler(SERVER_CONFIG_ID, &state.query.server_config)
-            .await
-            .map_err(|err| ReissuanceServiceError::Query(err.to_string()))?
-            .and_then(|server_config_view| {
-                server_config_view
-                    .credential_configurations
-                    .get(&request.credential_configuration_id)
-                    .cloned()
-            })
-            .ok_or_else(|| {
-                ReissuanceServiceError::CredentialConfigurationNotFound(request.credential_configuration_id.clone())
-            })?;
+        let (_, credential_configuration, authorization, _) =
+            query_handler(SERVER_CONFIG_ID, &state.query.server_config)
+                .await
+                .map_err(|err| ReissuanceServiceError::Query(err.to_string()))?
+                .and_then(|server_config_view| {
+                    server_config_view
+                        .credential_configurations
+                        .get(&request.credential_configuration_id)
+                        .cloned()
+                })
+                .ok_or_else(|| {
+                    ReissuanceServiceError::CredentialConfigurationNotFound(request.credential_configuration_id.clone())
+                })?;
 
         match &credential_configuration.credential_format {
             CredentialFormats::DcSdJwt(_) | CredentialFormats::VcSdJwt(_) => {}

--- a/agent_issuance/src/reissuance/service.rs
+++ b/agent_issuance/src/reissuance/service.rs
@@ -4,6 +4,7 @@ use oid4vci::{credential_format_profiles::CredentialFormats, credential_offer::G
 use crate::{
     credential::{aggregate::CredentialExpiry, command::CredentialCommand, entity::Data},
     offer::command::OfferCommand,
+    refresh_capability::service::{RefreshCapabilityService, RefreshCapabilityServiceError},
     reissuance::{
         command::ReissuanceCommand,
         policy::{NoOpReissuancePolicy, ReissuancePolicy, ReissuancePolicyError, ReissuancePolicyRequest},
@@ -39,24 +40,20 @@ pub struct CreateReissuanceResponse {
 pub enum ReissuanceServiceError {
     #[error("Original credential `{0}` was not found")]
     OriginalCredentialNotFound(String),
-
     #[error("Credential configuration `{0}` was not found")]
     CredentialConfigurationNotFound(String),
-
     #[error("Credential payload must be a JSON object")]
     InvalidCredentialPayload,
-
     #[error("Credential format is not supported for reissuance: {0}")]
     UnsupportedCredentialFormat(serde_json::Value),
-
     #[error(transparent)]
     Policy(#[from] ReissuancePolicyError),
-
     #[error("Failed to query state: {0}")]
     Query(String),
-
     #[error("Failed to execute command: {0}")]
     Command(String),
+    #[error(transparent)]
+    RefreshCapability(#[from] RefreshCapabilityServiceError),
 }
 
 pub struct ReissuanceService<P = NoOpReissuancePolicy> {
@@ -91,7 +88,7 @@ where
                 ReissuanceServiceError::OriginalCredentialNotFound(request.original_credential_id.clone())
             })?;
 
-        let (_, credential_configuration, authorization, _) =
+        let (_, credential_configuration, authorization, refresh_service) =
             query_handler(SERVER_CONFIG_ID, &state.query.server_config)
                 .await
                 .map_err(|err| ReissuanceServiceError::Query(err.to_string()))?
@@ -143,6 +140,10 @@ where
         )
         .await
         .map_err(|err| ReissuanceServiceError::Command(err.to_string()))?;
+
+        RefreshCapabilityService::default()
+            .create_for_credential(state, &request.new_credential_id, refresh_service.as_ref())
+            .await?;
 
         if query_handler(&request.offer_id, &state.query.offer)
             .await
@@ -216,6 +217,7 @@ where
 #[cfg(test)]
 mod tests {
     use agent_issuance::credential::{aggregate::CredentialExpiry, command::CredentialCommand, entity::Data};
+    use agent_issuance::refresh_capability::aggregate::RefreshCapabilityStatus;
     use agent_issuance::reissuance::service::{CreateReissuanceRequest, ReissuanceService, ReissuanceServiceError};
     use agent_issuance::server_config::command::ServerConfigCommand;
     use agent_issuance::services::IssuanceServices;
@@ -296,6 +298,48 @@ mod tests {
                     "display": [{ "name": "Date of Birth", "locale": "en" }]
                 }
             ]
+        }))
+        .unwrap();
+
+        command_handler(
+            SERVER_CONFIG_ID,
+            &state.command.server_config,
+            ServerConfigCommand::UpdateCredentialConfiguration {
+                credential_configuration,
+                provisioned: false,
+            },
+        )
+        .await
+        .unwrap();
+    }
+
+    async fn add_refreshable_sd_jwt_credential_configuration(state: &IssuanceState) {
+        let credential_configuration = serde_json::from_value::<CredentialConfiguration>(json!({
+            "credential_configuration_id": "SD-JWT VC",
+            "format": "dc+sd-jwt",
+            "display": [
+                {
+                    "name": "SD-JWT VC Credential",
+                    "locale": "en"
+                }
+            ],
+            "claims": [
+                {
+                    "path": ["first_name"],
+                    "display": [{ "name": "First Name", "locale": "en" }]
+                },
+                {
+                    "path": ["last_name"],
+                    "display": [{ "name": "Last Name", "locale": "en" }]
+                },
+                {
+                    "path": ["dob"],
+                    "display": [{ "name": "Date of Birth", "locale": "en" }]
+                }
+            ],
+            "refreshService": {
+                "type": "VerifiableCredentialRefreshService2021"
+            }
         }))
         .unwrap();
 
@@ -500,6 +544,43 @@ mod tests {
         assert_eq!(reissuance.trigger_type.as_deref(), Some("manual"));
         assert_eq!(reissuance.triggered_by.as_deref(), Some("unitrust"));
         assert_eq!(reissuance.status_action, None);
+    }
+
+    #[async_std::test]
+    async fn create_reissuance_creates_refresh_capability_for_refreshable_configuration() {
+        let state = test_state().await;
+        add_refreshable_sd_jwt_credential_configuration(&state).await;
+        create_original_credential(&state, "original-credential-id", "SD-JWT VC").await;
+        let service = ReissuanceService::default();
+
+        service
+            .create(
+                &state,
+                reissuance_request(
+                    "SD-JWT VC",
+                    json!({
+                        "first_name": "Ferris",
+                        "last_name": "Reissued",
+                        "dob": "2010-01-01"
+                    }),
+                ),
+            )
+            .await
+            .unwrap();
+
+        // wrong spelling because this is generated by a `format!("all_{}s")`
+        let all_refresh_capabilities = query_handler("all_refresh_capabilitys", &state.query.all_refresh_capabilities)
+            .await
+            .unwrap()
+            .unwrap();
+
+        let refresh_capability = all_refresh_capabilities
+            .refresh_capabilities
+            .values()
+            .find(|refresh_capability| refresh_capability.credential_id == "new-credential-id")
+            .expect("new credential should have a refresh capability");
+
+        assert_eq!(refresh_capability.status, RefreshCapabilityStatus::Active);
     }
 
     #[async_std::test]

--- a/agent_issuance/src/server_config/aggregate.rs
+++ b/agent_issuance/src/server_config/aggregate.rs
@@ -1,4 +1,4 @@
-use agent_shared::config::{config, Authorization};
+use agent_shared::config::{config, Authorization, RefreshServiceConfiguration};
 use agent_shared::UrlAppendHelpers as _;
 use async_trait::async_trait;
 use base64::{engine::general_purpose::URL_SAFE_NO_PAD, Engine};
@@ -25,14 +25,23 @@ use crate::server_config::event::ServerConfigEvent;
 use crate::services::IssuanceServices;
 
 fn into_credential_configurations_supported(
-    credential_configurations: &HashMap<String, (bool, CredentialConfigurationsSupportedObject, Authorization)>,
+    credential_configurations: &HashMap<
+        String,
+        (
+            bool,
+            CredentialConfigurationsSupportedObject,
+            Authorization,
+            Option<RefreshServiceConfiguration>,
+        ),
+    >,
 ) -> HashMap<String, CredentialConfigurationsSupportedObject> {
     credential_configurations
         .iter()
         .map(
-            |(credential_configuration_id, (_provisioned, credential_configuration, _authorization_grant))| {
-                (credential_configuration_id.clone(), credential_configuration.clone())
-            },
+            |(
+                credential_configuration_id,
+                (_provisioned, credential_configuration, _authorization_grant, _refresh_service),
+            )| { (credential_configuration_id.clone(), credential_configuration.clone()) },
         )
         .collect()
 }
@@ -65,7 +74,15 @@ fn into_proof_types_supported(signing_algorithms_supported: &[Algorithm]) -> Has
 pub struct ServerConfig {
     pub authorization_server_metadata: AuthorizationServerMetadata,
     pub credential_issuer_metadata: CredentialIssuerMetadata,
-    pub credential_configurations: HashMap<String, (bool, CredentialConfigurationsSupportedObject, Authorization)>,
+    pub credential_configurations: HashMap<
+        String,
+        (
+            bool,
+            CredentialConfigurationsSupportedObject,
+            Authorization,
+            Option<RefreshServiceConfiguration>,
+        ),
+    >,
     pub cryptographic_binding_methods_supported: Vec<String>,
     pub signing_algorithms_supported: Vec<Algorithm>,
 }
@@ -135,8 +152,10 @@ impl Aggregate for ServerConfig {
             } => {
                 let mut credential_configurations = self.credential_configurations.clone();
 
-                for (_credential_configuration_id, (_provisioned, credential_configuration, _authorization_grant)) in
-                    credential_configurations.iter_mut()
+                for (
+                    _credential_configuration_id,
+                    (_provisioned, credential_configuration, _authorization_grant, _refresh_service),
+                ) in credential_configurations.iter_mut()
                 {
                     credential_configuration.cryptographic_binding_methods_supported =
                         cryptographic_binding_methods_supported.clone();
@@ -157,8 +176,10 @@ impl Aggregate for ServerConfig {
             } => {
                 let mut credential_configurations = self.credential_configurations.clone();
 
-                for (_credential_configuration_id, (_provisioned, credential_configuration, _authorization_grant)) in
-                    credential_configurations.iter_mut()
+                for (
+                    _credential_configuration_id,
+                    (_provisioned, credential_configuration, _authorization_grant, _refresh_service),
+                ) in credential_configurations.iter_mut()
                 {
                     credential_configuration.credential_signing_alg_values_supported =
                         into_credential_signing_alg_values_supported(&signing_algorithms_supported);
@@ -180,6 +201,8 @@ impl Aggregate for ServerConfig {
                 credential_configuration,
                 provisioned,
             } => {
+                let refresh_service = credential_configuration.refresh_service.clone();
+
                 let credential_format = match credential_configuration.format.as_str() {
                     "jwt_vc_json" => CredentialFormats::JwtVcJson(Parameters {
                         parameters: (jwt_vc_json::CredentialDefinition {
@@ -228,8 +251,12 @@ impl Aggregate for ServerConfig {
                 };
 
                 let mut credential_configurations = self.credential_configurations.clone();
-                if let Some((existing_provisioned, existing_credential_configuration, existing_authorization_grant)) =
-                    credential_configurations.get_mut(&credential_configuration.credential_configuration_id)
+                if let Some((
+                    existing_provisioned,
+                    existing_credential_configuration,
+                    existing_authorization_grant,
+                    existing_refresh_service,
+                )) = credential_configurations.get_mut(&credential_configuration.credential_configuration_id)
                 {
                     if !provisioned && *existing_provisioned {
                         return Err(UpdateProvisionedCredentialConfigurationError);
@@ -238,6 +265,7 @@ impl Aggregate for ServerConfig {
                     *existing_credential_configuration = credential_configuration_object;
                     *existing_provisioned = provisioned;
                     *existing_authorization_grant = credential_configuration.authorization.clone();
+                    *existing_refresh_service = refresh_service;
                 } else {
                     credential_configurations.insert(
                         credential_configuration.credential_configuration_id.clone(),
@@ -245,6 +273,7 @@ impl Aggregate for ServerConfig {
                             provisioned,
                             credential_configuration_object,
                             credential_configuration.authorization.clone(),
+                            refresh_service,
                         ),
                     );
                 }
@@ -267,7 +296,7 @@ impl Aggregate for ServerConfig {
 
                 let existing_provisioned = credential_configurations
                     .get(&credential_configuration_id)
-                    .map(|(provisioned, _, _)| *provisioned)
+                    .map(|(provisioned, _, _, _)| *provisioned)
                     .unwrap_or(false);
 
                 if !provisioned && existing_provisioned {
@@ -363,7 +392,7 @@ pub mod server_config_tests {
     use crate::server_config::aggregate::ServerConfig;
     use crate::server_config::event::ServerConfigEvent;
     use agent_secret_manager::service::Service;
-    use agent_shared::config::{Authorization, CredentialConfiguration};
+    use agent_shared::config::{Authorization, CredentialConfiguration, RefreshServiceConfiguration};
     use cqrs_es::test::TestFramework;
     use oid4vci::credential_issuer::credential_configurations_supported::CredentialMetadata;
     use oid4vci::credential_issuer::credential_configurations_supported::{
@@ -403,7 +432,15 @@ pub mod server_config_tests {
         cryptographic_binding_methods_supported: Vec<String>,
         signing_algorithms_supported: Vec<Algorithm>,
         credential_configuration_id: String,
-        credential_configurations: HashMap<String, (bool, CredentialConfigurationsSupportedObject, Authorization)>,
+        credential_configurations: HashMap<
+            String,
+            (
+                bool,
+                CredentialConfigurationsSupportedObject,
+                Authorization,
+                Option<RefreshServiceConfiguration>,
+            ),
+        >,
         credential_issuer_metadata_with_credential_configuration: Box<CredentialIssuerMetadata>,
     ) {
         ServerConfigTestFramework::with(IssuanceServices::default().await)
@@ -437,6 +474,7 @@ pub mod server_config_tests {
                         pre_authorized: true,
                         tx_code_constraints: None,
                     },
+                    refresh_service: None,
                 },
                 provisioned: false,
             })
@@ -479,7 +517,15 @@ pub mod test_utils {
     #[fixture]
     pub fn credential_configurations(
         credential_configuration_id: String,
-    ) -> HashMap<String, (bool, CredentialConfigurationsSupportedObject, Authorization)> {
+    ) -> HashMap<
+        String,
+        (
+            bool,
+            CredentialConfigurationsSupportedObject,
+            Authorization,
+            Option<RefreshServiceConfiguration>,
+        ),
+    > {
         HashMap::from_iter(vec![(
             credential_configuration_id,
             (
@@ -489,20 +535,30 @@ pub mod test_utils {
                     pre_authorized: true,
                     tx_code_constraints: None,
                 },
+                None,
             ),
         )])
     }
 
     #[fixture]
     pub fn credential_configurations_supported(
-        credential_configurations: HashMap<String, (bool, CredentialConfigurationsSupportedObject, Authorization)>,
+        credential_configurations: HashMap<
+            String,
+            (
+                bool,
+                CredentialConfigurationsSupportedObject,
+                Authorization,
+                Option<RefreshServiceConfiguration>,
+            ),
+        >,
     ) -> HashMap<String, CredentialConfigurationsSupportedObject> {
         credential_configurations
             .into_iter()
             .map(
-                |(credential_configuration_id, (_provisioned, credential_configuration, _authorization_grant))| {
-                    (credential_configuration_id, credential_configuration)
-                },
+                |(
+                    credential_configuration_id,
+                    (_provisioned, credential_configuration, _authorization_grant, _refresh_service),
+                )| { (credential_configuration_id, credential_configuration) },
             )
             .collect()
     }

--- a/agent_issuance/src/server_config/event.rs
+++ b/agent_issuance/src/server_config/event.rs
@@ -1,4 +1,4 @@
-use agent_shared::config::Authorization;
+use agent_shared::config::{Authorization, RefreshServiceConfiguration};
 use cqrs_es::DomainEvent;
 use jsonwebtoken::Algorithm;
 use oid4vci::credential_issuer::{
@@ -28,22 +28,54 @@ pub enum ServerConfigEvent {
     CryptographicBindingMethodsUpdated {
         cryptographic_binding_methods_supported: Vec<String>,
         credential_issuer_metadata: Box<CredentialIssuerMetadata>,
-        credential_configurations: HashMap<String, (bool, CredentialConfigurationsSupportedObject, Authorization)>,
+        credential_configurations: HashMap<
+            String,
+            (
+                bool,
+                CredentialConfigurationsSupportedObject,
+                Authorization,
+                Option<RefreshServiceConfiguration>,
+            ),
+        >,
     },
     SigningAlgorithmsUpdated {
         signing_algorithms_supported: Vec<Algorithm>,
         credential_issuer_metadata: Box<CredentialIssuerMetadata>,
-        credential_configurations: HashMap<String, (bool, CredentialConfigurationsSupportedObject, Authorization)>,
+        credential_configurations: HashMap<
+            String,
+            (
+                bool,
+                CredentialConfigurationsSupportedObject,
+                Authorization,
+                Option<RefreshServiceConfiguration>,
+            ),
+        >,
     },
     CredentialConfigurationUpdated {
         credential_configuration_id: String,
         credential_issuer_metadata: Box<CredentialIssuerMetadata>,
-        credential_configurations: HashMap<String, (bool, CredentialConfigurationsSupportedObject, Authorization)>,
+        credential_configurations: HashMap<
+            String,
+            (
+                bool,
+                CredentialConfigurationsSupportedObject,
+                Authorization,
+                Option<RefreshServiceConfiguration>,
+            ),
+        >,
     },
     CredentialConfigurationRemoved {
         credential_configuration_id: String,
         credential_issuer_metadata: Box<CredentialIssuerMetadata>,
-        credential_configurations: HashMap<String, (bool, CredentialConfigurationsSupportedObject, Authorization)>,
+        credential_configurations: HashMap<
+            String,
+            (
+                bool,
+                CredentialConfigurationsSupportedObject,
+                Authorization,
+                Option<RefreshServiceConfiguration>,
+            ),
+        >,
     },
 }
 

--- a/agent_issuance/src/state.rs
+++ b/agent_issuance/src/state.rs
@@ -383,7 +383,10 @@ pub async fn update_credential_configurations(state: &IssuanceState) -> anyhow::
                 .credential_configurations
                 .into_iter()
                 .filter_map(
-                    |(credential_configuration_id, (provisioned, _credential_configuration, _authorization))| {
+                    |(
+                        credential_configuration_id,
+                        (provisioned, _credential_configuration, _authorization, _refresh_service),
+                    )| {
                         (provisioned
                             && !provisioned_credential_configurations.iter().any(
                                 |provisioned_credential_configuration| {

--- a/agent_issuance/src/state.rs
+++ b/agent_issuance/src/state.rs
@@ -20,6 +20,9 @@ use crate::nonce::views::NonceView;
 use crate::offer::aggregate::Offer;
 use crate::offer::views::all_offers::AllOffersView;
 use crate::offer::views::OfferView;
+use crate::refresh_capability::aggregate::RefreshCapability;
+use crate::refresh_capability::views::all_refresh_capabilities::AllRefreshCapabilitiesView;
+use crate::refresh_capability::views::RefreshCapabilityView;
 use crate::reissuance::aggregate::Reissuance;
 use crate::reissuance::views::all_reissuances::AllReissuancesView;
 use crate::reissuance::views::ReissuanceView;
@@ -46,6 +49,7 @@ pub struct CommandHandlers {
     pub offer: CommandHandler<Offer>,
     pub nonce: CommandHandler<Nonce>,
     pub status_list: CommandHandler<StatusListAggregate>,
+    pub refresh_capability: CommandHandler<RefreshCapability>,
 }
 
 /// This type is used to define the queries that are used to query the view repositories. We make use of `dyn` here, so
@@ -57,6 +61,8 @@ type Queries = ViewRepositories<
     dyn ViewRepository<AllCredentialsView, Credential>,
     dyn ViewRepository<ReissuanceView, Reissuance>,
     dyn ViewRepository<AllReissuancesView, Reissuance>,
+    dyn ViewRepository<RefreshCapabilityView, RefreshCapability>,
+    dyn ViewRepository<AllRefreshCapabilitiesView, RefreshCapability>,
     dyn ViewRepository<OfferView, Offer>,
     dyn ViewRepository<AllOffersView, Offer>,
     dyn ViewRepository<NonceView, Nonce>,
@@ -64,13 +70,15 @@ type Queries = ViewRepositories<
     dyn ViewRepository<AllStatusListsView, StatusListAggregate>,
 >;
 
-pub struct ViewRepositories<SC, C, C1, R, R1, O, O1, N, SL, SL1>
+pub struct ViewRepositories<SC, C, C1, R, R1, RC, RC1, O, O1, N, SL, SL1>
 where
     SC: ViewRepository<ServerConfigView, ServerConfig> + ?Sized,
     C: ViewRepository<CredentialView, Credential> + ?Sized,
     C1: ViewRepository<AllCredentialsView, Credential> + ?Sized,
     R: ViewRepository<ReissuanceView, Reissuance> + ?Sized,
     R1: ViewRepository<AllReissuancesView, Reissuance> + ?Sized,
+    RC: ViewRepository<RefreshCapabilityView, RefreshCapability> + ?Sized,
+    RC1: ViewRepository<AllRefreshCapabilitiesView, RefreshCapability> + ?Sized,
     O: ViewRepository<OfferView, Offer> + ?Sized,
     O1: ViewRepository<AllOffersView, Offer> + ?Sized,
     N: ViewRepository<NonceView, Nonce> + ?Sized,
@@ -82,6 +90,8 @@ where
     pub all_credentials: Arc<C1>,
     pub reissuance: Arc<R>,
     pub all_reissuances: Arc<R1>,
+    pub refresh_capability: Arc<RC>,
+    pub all_refresh_capabilities: Arc<RC1>,
     pub offer: Arc<O>,
     pub all_offers: Arc<O1>,
     pub nonce: Arc<N>,
@@ -97,6 +107,8 @@ impl Clone for Queries {
             all_credentials: self.all_credentials.clone(),
             reissuance: self.reissuance.clone(),
             all_reissuances: self.all_reissuances.clone(),
+            refresh_capability: self.refresh_capability.clone(),
+            all_refresh_capabilities: self.all_refresh_capabilities.clone(),
             offer: self.offer.clone(),
             all_offers: self.all_offers.clone(),
             nonce: self.nonce.clone(),

--- a/agent_shared/src/config/mod.rs
+++ b/agent_shared/src/config/mod.rs
@@ -540,6 +540,14 @@ pub struct CredentialConfiguration {
     #[schema(schema_with = authorization)]
     #[serde(default)]
     pub authorization: Authorization,
+    #[serde(default, rename = "refreshService", skip_serializing_if = "Option::is_none")]
+    pub refresh_service: Option<RefreshServiceConfiguration>,
+}
+
+#[derive(Deserialize, Serialize, Debug, Clone, PartialEq, utoipa::ToSchema)]
+pub struct RefreshServiceConfiguration {
+    #[serde(rename = "type")]
+    pub type_: String,
 }
 
 #[derive(Deserialize, Serialize, Debug, Clone, PartialEq)]
@@ -1079,6 +1087,28 @@ mod tests {
 
         let json = serde_json::to_value(&value).unwrap();
         assert_eq!(json, json!({"type": "in_memory"}));
+    }
+
+    #[test]
+    #[serial]
+    fn credential_configuration_accepts_refresh_service() {
+        let credential_configuration = serde_json::from_value::<CredentialConfiguration>(json!({
+            "credential_configuration_id": "employee-id",
+            "format": "vc+sd-jwt",
+            "type": ["VerifiableCredential"],
+            "refreshService": {
+                "type": "VerifiableCredentialRefreshService2021"
+            }
+        }))
+        .unwrap();
+
+        assert_eq!(
+            credential_configuration
+                .refresh_service
+                .expect("refresh service should parse")
+                .type_,
+            "VerifiableCredentialRefreshService2021"
+        );
     }
 
     #[test]

--- a/agent_shared/src/config/mod.rs
+++ b/agent_shared/src/config/mod.rs
@@ -631,6 +631,10 @@ pub struct Events {
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub credential: Vec<CredentialEvent>,
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub reissuance: Vec<ReissuanceEvent>,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub refresh_capability: Vec<RefreshCapabilityEvent>,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub offer: Vec<OfferEvent>,
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub nonce: Vec<NonceEvent>,
@@ -729,6 +733,17 @@ pub enum CredentialEvent {
     SignedCredentialCreated,
     CredentialSigned,
     NotificationReceived,
+}
+
+#[derive(Debug, Serialize, Deserialize, Clone, strum::Display)]
+pub enum ReissuanceEvent {
+    ReissuanceCreated,
+}
+
+#[derive(Debug, Serialize, Deserialize, Clone, strum::Display)]
+pub enum RefreshCapabilityEvent {
+    RefreshCapabilityCreated,
+    RefreshCapabilityDisabled,
 }
 
 #[derive(Debug, Serialize, Deserialize, Clone, strum::Display)]

--- a/agent_store/src/lib.rs
+++ b/agent_store/src/lib.rs
@@ -35,6 +35,9 @@ use agent_issuance::credential::views::CredentialView;
 use agent_issuance::nonce::views::NonceView;
 use agent_issuance::offer::views::all_offers::AllOffersView;
 use agent_issuance::offer::views::OfferView;
+use agent_issuance::refresh_capability::aggregate::RefreshCapability;
+use agent_issuance::refresh_capability::views::all_refresh_capabilities::AllRefreshCapabilitiesView;
+use agent_issuance::refresh_capability::views::RefreshCapabilityView;
 use agent_issuance::reissuance::views::all_reissuances::AllReissuancesView;
 use agent_issuance::reissuance::views::ReissuanceView;
 use agent_issuance::server_config::views::ServerConfigView;
@@ -316,6 +319,7 @@ pub async fn issuance_state<CCB: CqrsComponentBuilder>(
     let Partitions {
         credential_event_publishers,
         reissuance_event_publishers,
+        refresh_capability_event_publishers,
         offer_event_publishers,
         server_config_event_publishers,
         nonce_event_publishers,
@@ -333,6 +337,12 @@ pub async fn issuance_state<CCB: CqrsComponentBuilder>(
         .commands_and_queries::<ReissuanceView, Reissuance, AllReissuancesView>(
             services.clone(),
             reissuance_event_publishers,
+        )
+        .await;
+    let (refresh_capability_command_handler, refresh_capability, all_refresh_capabilities) = builder
+        .commands_and_queries::<RefreshCapabilityView, RefreshCapability, AllRefreshCapabilitiesView>(
+            services.clone(),
+            refresh_capability_event_publishers,
         )
         .await;
     let (offer_command_handler, offer, all_offers) = builder
@@ -358,6 +368,7 @@ pub async fn issuance_state<CCB: CqrsComponentBuilder>(
         command: agent_issuance::state::CommandHandlers {
             credential: credential_command_handler,
             reissuance: reissuance_command_handler,
+            refresh_capability: refresh_capability_command_handler,
             offer: offer_command_handler,
             server_config: server_config_command_handler,
             nonce: nonce_command_handler,
@@ -369,6 +380,8 @@ pub async fn issuance_state<CCB: CqrsComponentBuilder>(
             all_credentials,
             reissuance,
             all_reissuances,
+            refresh_capability,
+            all_refresh_capabilities,
             offer,
             all_offers,
             nonce,
@@ -471,6 +484,7 @@ pub type AccessTokenEventPublisher = Box<dyn Query<AccessToken>>;
 pub type ServerConfigEventPublisher = Box<dyn Query<ServerConfig>>;
 pub type CredentialEventPublisher = Box<dyn Query<Credential>>;
 pub type ReissuanceEventPublisher = Box<dyn Query<Reissuance>>;
+pub type RefreshCapabilityEventPublisher = Box<dyn Query<RefreshCapability>>;
 pub type StatusListEventPublisher = Box<dyn Query<StatusListAggregate>>;
 pub type OfferEventPublisher = Box<dyn Query<Offer>>;
 pub type NonceEventPublisher = Box<dyn Query<Nonce>>;
@@ -494,6 +508,7 @@ pub struct Partitions {
     pub server_config_event_publishers: Vec<ServerConfigEventPublisher>,
     pub credential_event_publishers: Vec<CredentialEventPublisher>,
     pub reissuance_event_publishers: Vec<ReissuanceEventPublisher>,
+    pub refresh_capability_event_publishers: Vec<RefreshCapabilityEventPublisher>,
     pub status_list_event_publishers: Vec<StatusListEventPublisher>,
     pub offer_event_publishers: Vec<OfferEventPublisher>,
     pub nonce_event_publishers: Vec<NonceEventPublisher>,
@@ -523,6 +538,7 @@ pub trait EventPublisher {
     fn server_config(&mut self) -> Option<ServerConfigEventPublisher>;
     fn credential(&mut self) -> Option<CredentialEventPublisher>;
     fn reissuance(&mut self) -> Option<ReissuanceEventPublisher>;
+    fn refresh_capability(&mut self) -> Option<RefreshCapabilityEventPublisher>;
     fn offer(&mut self) -> Option<OfferEventPublisher>;
     fn nonce(&mut self) -> Option<NonceEventPublisher>;
     fn status_list(&mut self) -> Option<StatusListEventPublisher>;
@@ -575,6 +591,9 @@ pub(crate) fn partition_event_publishers(event_publishers: Vec<Box<dyn EventPubl
             }
             if let Some(reissuance) = event_publisher.reissuance() {
                 partitions.reissuance_event_publishers.push(reissuance);
+            }
+            if let Some(refresh_capability) = event_publisher.refresh_capability() {
+                partitions.refresh_capability_event_publishers.push(refresh_capability);
             }
             if let Some(offer) = event_publisher.offer() {
                 partitions.offer_event_publishers.push(offer);
@@ -674,6 +693,10 @@ mod test {
             None
         }
 
+        fn refresh_capability(&mut self) -> Option<RefreshCapabilityEventPublisher> {
+            None
+        }
+
         fn offer(&mut self) -> Option<OfferEventPublisher> {
             None
         }
@@ -752,6 +775,10 @@ mod test {
             None
         }
 
+        fn refresh_capability(&mut self) -> Option<RefreshCapabilityEventPublisher> {
+            None
+        }
+
         fn offer(&mut self) -> Option<OfferEventPublisher> {
             None
         }
@@ -799,6 +826,7 @@ mod test {
             server_config_event_publishers,
             credential_event_publishers,
             reissuance_event_publishers,
+            refresh_capability_event_publishers,
             offer_event_publishers,
             nonce_event_publishers,
             status_list_event_publishers,
@@ -820,6 +848,7 @@ mod test {
         assert_eq!(server_config_event_publishers.len(), 1);
         assert_eq!(credential_event_publishers.len(), 0);
         assert_eq!(reissuance_event_publishers.len(), 0);
+        assert_eq!(refresh_capability_event_publishers.len(), 0);
         assert_eq!(status_list_event_publishers.len(), 0);
         assert_eq!(offer_event_publishers.len(), 0);
         assert_eq!(nonce_event_publishers.len(), 0);

--- a/docs/problem-details/issuance.md
+++ b/docs/problem-details/issuance.md
@@ -219,3 +219,24 @@ This error occurs when the `format` specified in a credential configuration is n
 ### Resolution
 
 Ensure that the `format` field in the credential configuration is set to a supported value. Supported values include: `jwt_vc_json` and `dc+sd-jwt`.
+
+## Credential Reissuance Errors
+
+Credential reissuance can return:
+
+- `issuance#original-credential-not-found` with `404 Not Found` when the original credential does not exist.
+- `issuance#credential-configuration-not-found` with `404 Not Found` when the requested credential configuration does not exist.
+- `issuance#reissuance-not-allowed` with `403 Forbidden` when the reissuance policy rejects the request.
+- `issuance#credential-reissuance-failed` with `500 Internal Server Error` when creating or recording the reissuance fails.
+- `issuance#query-credential-offer-failed`, `issuance#query-credential-reissuances-failed`, or `issuance#query-credential-reissuance-failed` with `500 Internal Server Error` when reading prepared reissuance data fails.
+- A status-only `404 Not Found` when a credential reissuance relation does not exist.
+
+## Credential Refresh Errors
+
+Credential refresh can return:
+
+- `issuance#create-refresh-capability-failed` with `500 Internal Server Error` when creating a refresh capability for a credential fails.
+- `issuance#refresh-reference-not-found` with `404 Not Found` when the refresh reference does not exist or has been disabled.
+- `issuance#credential-refresh-unavailable` with `403 Forbidden` when refresh is known but cannot proceed.
+- `issuance#credential-refresh-preparation-failed` with `500 Internal Server Error` when refresh preparation fails.
+- `issuance#credential-refresh-failed` with `500 Internal Server Error` for other refresh failures.


### PR DESCRIPTION
# Description of change

Adds the HTTP surface for automatic credential refresh on top of the credential reissuance flow.

This introduces a new `POST /v0/credential-refresh` endpoint that accepts a `refreshToken`, resolves it through the refresh continuation service, and returns a form-url-encoded credential offer continuation when refresh preparation succeeds. The endpoint maps missing or disabled refresh references to `404`, unavailable refresh preparation to `403`, and other preparation failures to API problem responses.

The change also wires the endpoint into the issuance router and OpenAPI generation, updates `openapi-generated.yaml`, and adds a default no-op refresh preparation hook so the API can expose the refresh contract before a real domain-specific preparation implementation is plugged in.

## Links to any relevant issues

N/A

## How the change has been tested

Added endpoint/unit coverage for:

- unknown refresh references returning `404`
- disabled refresh references returning `404`
- valid refresh references using the no-op preparation hook returning `403`
- refresh preparation hook behavior in `agent_issuance`

Validated locally with:

```sh
cargo test -p agent_api_http credential_refresh
cargo test -p agent_issuance refresh_preparation_hook
```

Both commands passed locally.
## Definition of Done checklist

- [x] I have followed the contribution guidelines for this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] I have successfully tested this change in a docker environment

## Blocked by
- #363