### PR TITLE
feat: exit on `SIGTERM` signal

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,3 @@
+{
+  "rust-analyzer.cargo.features": "all"
+}

--- a/agent_application/src/lib.rs
+++ b/agent_application/src/lib.rs
@@ -302,11 +302,20 @@ async fn serve(app: axum::Router) -> io::Result<()> {
 
     let app_handle = tokio::spawn(start_server("HTTP API".to_string(), app, port));
 
-    if config().metrics.enabled {
-        let metrics_handle = tokio::spawn(start_server("Metrics".to_string(), metrics(), config().metrics.port));
-        let _ = tokio::join!(app_handle, metrics_handle);
-    } else {
-        let _ = app_handle.await;
+    let servers = async {
+        if config().metrics.enabled {
+            let metrics_handle = tokio::spawn(start_server("Metrics".to_string(), metrics(), config().metrics.port));
+            let _ = tokio::join!(app_handle, metrics_handle);
+        } else {
+            let _ = app_handle.await;
+        }
+    };
+
+    tokio::select! {
+        _ = servers => {},
+        _ = shutdown_signal() => {
+            info!("Shutdown signal received, exiting immediately.");
+        }
     }
 
     Ok(())
@@ -331,4 +340,27 @@ pub async fn start_server(alias: String, router: axum::Router, port: u16) {
     };
 
     axum::serve(listener, router).await.unwrap();
+}
+
+/// Resolves when the process receives a termination signal: `SIGTERM` (sent by Kubernetes /
+/// `docker stop`) or `SIGINT` (Ctrl-C). Because the agent runs as PID 1 in the container, the
+/// kernel applies no default signal disposition, so we must handle these explicitly or the
+/// process would ignore `SIGTERM` and only die once the orchestrator escalates to `SIGKILL`.
+async fn shutdown_signal() {
+    use tokio::signal;
+
+    #[cfg(unix)]
+    let terminate = async {
+        signal::unix::signal(signal::unix::SignalKind::terminate())
+            .expect("failed to install SIGTERM handler")
+            .recv()
+            .await;
+    };
+    #[cfg(not(unix))]
+    let terminate = std::future::pending::<()>();
+
+    tokio::select! {
+        _ = signal::ctrl_c() => {},
+        _ = terminate => {},
+    }
 }


### PR DESCRIPTION
# Description of change

The application should handle `SIGTERM` commands and exit immediately. `SIGTERM` is currently unhandled and thus Kubernetes waits for 30 seconds, before it forcefully terminates the container. Graceful shutdowns are contrary to [Crash-only design](https://en.wikipedia.org/wiki/Crash-only_software), so graceful shutdowns (clean up, flush messages, properly close connections) can not always be expected anyway.

## Links to any relevant issues
Be sure to reference any related issues by adding `fixes issue #`.

## How the change has been tested
Describe the tests that you ran to verify your changes.
Make sure to provide instructions for the maintainer as well as any relevant configurations.

## Definition of Done checklist
Add an `x` to the boxes that are relevant to your changes.

- [ ] I have followed the contribution guidelines for this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] I have successfully tested this change in a docker environment 
