### PR TITLE
build: ignore advisories for `quick-xml`, pin `clippy` version

### DIFF
--- a/.cargo/audit.toml
+++ b/.cargo/audit.toml
@@ -62,6 +62,14 @@ ignore = [
     # configurations, so CRL parsing code is never reached in this application.
     "RUSTSEC-2026-0104",
 
+    # RUSTSEC-2026-0194: quick-xml 0.39.4 — Quadratic run time in duplicate-attribute check
+    # Same crate and dependency chain as RUSTSEC-2026-0195 below: quick-xml is only pulled in
+    # through object_store inside the IOTA SDK. The ssi-agent never parses XML; the vulnerable
+    # attribute iteration only runs when object_store parses S3/Azure-style XML API responses,
+    # and no object-storage backend is configured or reachable from application code.
+    # TODO: revisit once the IOTA SDK upgrades quick-xml to >= 0.41.0.
+    "RUSTSEC-2026-0194",
+
     # RUSTSEC-2026-0195: quick-xml 0.39.4 — Unbounded namespace-declaration allocation in NsReader
     # The vulnerable quick-xml code is pulled in through object_store inside the IOTA SDK
     # dependency chain. This workspace does not use object_store or any XML/object-storage

--- a/.cargo/audit.toml
+++ b/.cargo/audit.toml
@@ -61,4 +61,11 @@ ignore = [
     # via did-web/hyper-rustls) nor async-nats enable CRL checking in their TLS
     # configurations, so CRL parsing code is never reached in this application.
     "RUSTSEC-2026-0104",
+
+    # RUSTSEC-2026-0195: quick-xml 0.39.4 — Unbounded namespace-declaration allocation in NsReader
+    # The vulnerable quick-xml code is pulled in through object_store inside the IOTA SDK
+    # dependency chain. This workspace does not use object_store or any XML/object-storage
+    # client directly, so the NsReader path is not reachable from ssi-agent application code.
+    # TODO: revisit once the IOTA SDK upgrades quick-xml to >= 0.41.0.
+    "RUSTSEC-2026-0195",
 ]

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -4,7 +4,7 @@
 
 **ssi-agent** is a Self-Sovereign Identity (SSI) agent implementing OpenID4VCI (issuance) and OpenID4VP (verification) protocols. It's a Rust Tokio-based service that manages identity credentials, digital wallets, and credential verification flows.
 
-- **Language**: Rust 1.76.0+ (enforced in Cargo.toml `rust-version`)
+- **Language**: Rust 1.94.0+ (enforced in Cargo.toml `rust-version`)
 - **Build System**: Cargo workspace with 18 crates
 - **HTTP Framework**: Axum 0.8 with Tokio async runtime
 - **Persistence**: PostgreSQL with CQRS-ES event sourcing pattern
@@ -18,12 +18,12 @@ All commands run from repository root. **Always use `cargo` commands; do not use
 ### Bootstrap (one-time setup)
 
 ```bash
-# Install Rust 1.76.0+ (use dtolnay/rust-toolchain@stable for CI version)
+# Install Rust 1.94.0+ (use dtolnay/rust-toolchain@stable for CI version)
 curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh
 rustup component add rustfmt clippy
 
 # Verify installation
-cargo --version  # Should show 1.76.0+
+cargo --version  # Should show 1.94.0+
 ```
 
 ### Build

--- a/.github/workflows/audit.yaml
+++ b/.github/workflows/audit.yaml
@@ -5,6 +5,7 @@ on:
     - cron: "0 3 * * *" # run at 3 AM every day
   workflow_dispatch:
   pull_request:
+  push:
     branches:
       - main
       - next

--- a/.github/workflows/format-lint-test.yaml
+++ b/.github/workflows/format-lint-test.yaml
@@ -20,7 +20,7 @@ jobs:
     steps:
       - uses: actions/checkout@v6
 
-      - uses: dtolnay/rust-toolchain@stable
+      - uses: dtolnay/rust-toolchain@1.94.0
         with:
           components: rustfmt, clippy
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2515,9 +2515,9 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-epoch"
-version = "0.9.18"
+version = "0.9.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b82ac4a3c2ca9c3460964f020e1402edd5753411d7737aa39c3714ad1b5420e"
+checksum = "2d6914041f254d6e9176c01941b21115dcfb7089e55135a35411081bd106ef3f"
 dependencies = [
  "crossbeam-utils",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,7 +25,7 @@ members = [
 [workspace.package]
 version = "0.1.0"
 edition = "2021"
-rust-version = "1.76.0"
+rust-version = "1.94.0"
 license-file = "LICENSE"
 publish = false
 

--- a/agent_api_http/src/v0/identity/connections/mod.rs
+++ b/agent_api_http/src/v0/identity/connections/mod.rs
@@ -130,9 +130,9 @@ pub(crate) async fn get_connections(
             .filter(|connection| {
                 display
                     .as_ref()
-                    .map_or(true, |display| connection.display.as_ref() == Some(display))
-                    && url.as_ref().map_or(true, |url| *url == connection.url)
-                    && did.as_ref().map_or(true, |did| connection.dids.contains(did))
+                    .is_none_or(|display| connection.display.as_ref() == Some(display))
+                    && url.as_ref().is_none_or(|url| *url == connection.url)
+                    && did.as_ref().is_none_or(|did| connection.dids.contains(did))
             })
             .collect();
 

--- a/agent_api_http/src/v0/identity/documents/mod.rs
+++ b/agent_api_http/src/v0/identity/documents/mod.rs
@@ -54,7 +54,7 @@ pub(crate) async fn get_documents(
             .filter(|document| {
                 did_method
                     .as_ref()
-                    .map_or(true, |method| document.did_method.as_ref() == Some(method))
+                    .is_none_or(|method| document.did_method.as_ref() == Some(method))
             })
             .collect();
 


### PR DESCRIPTION
# Description of change

- Ignores the following RustSec security advisories as "non-applicable":
  - `RUSTSEC-2026-0194` (quick-xml) 
  - `RUSTSEC-2026-0195` (quick-xml)
- Bumps vulnerable `crossbeam-epoch` version.
- The pinned Rust version is updated to `1.94.0` and the clippy version is pinned so prevent diverging lint results.

## Links to any relevant issues
Be sure to reference any related issues by adding `fixes issue #`.

## How the change has been tested
Describe the tests that you ran to verify your changes.
Make sure to provide instructions for the maintainer as well as any relevant configurations.

## Definition of Done checklist
Add an `x` to the boxes that are relevant to your changes.

- [x] I have followed the contribution guidelines for this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] I have successfully tested this change in a docker environment 
