### PR TITLE
feat(test): support local E2E testing with `allow-localhost` feature

### DIFF
--- a/.github/workflows/format-lint-test.yaml
+++ b/.github/workflows/format-lint-test.yaml
@@ -32,8 +32,11 @@ jobs:
       - name: Lint
         run: cargo clippy --all-targets --all-features -- -D warnings
 
-      - name: Test
+      - name: Test (Default features)
         run: cargo test --workspace
+
+      - name: Test (All features)
+        run: cargo test --workspace --all-features
 
       - name: Generated files are unchanged
         run: git diff --exit-code

--- a/.github/workflows/format-lint-test.yaml
+++ b/.github/workflows/format-lint-test.yaml
@@ -35,8 +35,8 @@ jobs:
       - name: Test (Default features)
         run: cargo test --workspace
 
-      - name: Test (All features)
-        run: cargo test --workspace --all-features
+      - name: Test (allow-localhost)
+        run: cargo test -p agent_api_http -p agent_identity --features allow-localhost allow_localhost_tests
 
       - name: Generated files are unchanged
         run: git diff --exit-code

--- a/agent_api_http/Cargo.toml
+++ b/agent_api_http/Cargo.toml
@@ -93,3 +93,5 @@ wiremock.workspace = true
 
 [features]
 test_utils = []
+dev-tools = ["allow-localhost"]
+allow-localhost = ["agent_identity/allow-localhost"]

--- a/agent_api_http/Cargo.toml
+++ b/agent_api_http/Cargo.toml
@@ -93,5 +93,4 @@ wiremock.workspace = true
 
 [features]
 test_utils = []
-dev-tools = ["allow-localhost"]
 allow-localhost = ["agent_identity/allow-localhost"]

--- a/agent_api_http/src/v0/identity/connections/mod.rs
+++ b/agent_api_http/src/v0/identity/connections/mod.rs
@@ -335,14 +335,7 @@ pub mod tests {
         assert_eq!(parsed, Url::parse("https://a-via-lactea.example.com/").unwrap());
     }
 
-    #[test]
-    #[cfg(feature = "allow-localhost")]
-    fn test_parsing_with_http_prefix_preserves_http() {
-        let input_string = "http://a-via-lactea.example.com/";
-        let parsed = parse_url(input_string).unwrap();
 
-        assert_eq!(parsed, Url::parse("http://a-via-lactea.example.com/").unwrap());
-    }
 
     #[test]
     fn test_parsing_with_no_prefix() {
@@ -375,11 +368,23 @@ pub mod tests {
         assert!(parse_url(input_string).is_err());
     }
 
-    #[test]
     #[cfg(feature = "allow-localhost")]
-    fn invalid_input_no_tld_succeeds() {
-        let input_string = "localhost:8080";
-        let parsed = parse_url(input_string).unwrap();
-        assert_eq!(parsed, Url::parse("https://localhost:8080/").unwrap());
+    pub mod allow_localhost_tests {
+        use super::*;
+
+        #[test]
+        fn test_parsing_with_http_prefix_preserves_http() {
+            let input_string = "http://a-via-lactea.example.com/";
+            let parsed = parse_url(input_string).unwrap();
+
+            assert_eq!(parsed, Url::parse("http://a-via-lactea.example.com/").unwrap());
+        }
+
+        #[test]
+        fn invalid_input_no_tld_succeeds() {
+            let input_string = "localhost:8080";
+            let parsed = parse_url(input_string).unwrap();
+            assert_eq!(parsed, Url::parse("https://localhost:8080/").unwrap());
+        }
     }
 }

--- a/agent_api_http/src/v0/identity/connections/mod.rs
+++ b/agent_api_http/src/v0/identity/connections/mod.rs
@@ -290,7 +290,10 @@ pub(crate) async fn remove_connection(
 pub fn parse_url(input: &str) -> Result<Url, ApiError> {
     let input = input.trim();
     let with_scheme = match input.strip_prefix("http://") {
+        #[cfg(not(feature = "allow-localhost"))]
         Some(rest) => format!("https://{rest}"),
+        #[cfg(feature = "allow-localhost")]
+        Some(_rest) => input.to_string(),
         None if input.starts_with("https://") => input.to_string(),
         None => format!("https://{input}"),
     };
@@ -301,16 +304,19 @@ pub fn parse_url(input: &str) -> Result<Url, ApiError> {
             .finish()
     })?;
 
-    let host = url.host_str().ok_or_else(|| {
-        ApiError::builder(StatusCode::BAD_REQUEST)
-            .message("Url missing host".to_string())
-            .finish()
-    })?;
+    #[cfg(not(feature = "allow-localhost"))]
+    {
+        let host = url.host_str().ok_or_else(|| {
+            ApiError::builder(StatusCode::BAD_REQUEST)
+                .message("Url missing host".to_string())
+                .finish()
+        })?;
 
-    if !host.contains('.') {
-        return Err(ApiError::builder(StatusCode::BAD_REQUEST)
-            .message("Url must contain a top-level domain (e.g. .com, .nl, .eu).".to_string())
-            .finish());
+        if !host.contains('.') {
+            return Err(ApiError::builder(StatusCode::BAD_REQUEST)
+                .message("Url must contain a top-level domain (e.g. .com, .nl, .eu).".to_string())
+                .finish());
+        }
     }
 
     Ok(url)

--- a/agent_api_http/src/v0/identity/connections/mod.rs
+++ b/agent_api_http/src/v0/identity/connections/mod.rs
@@ -295,6 +295,8 @@ pub fn parse_url(input: &str) -> Result<Url, ApiError> {
         #[cfg(feature = "allow-localhost")]
         Some(_rest) => input.to_string(),
         None if input.starts_with("https://") => input.to_string(),
+        #[cfg(feature = "allow-localhost")]
+        None if input.starts_with("localhost") => format!("http://{input}"),
         None => format!("https://{input}"),
     };
 
@@ -334,8 +336,6 @@ pub mod tests {
 
         assert_eq!(parsed, Url::parse("https://a-via-lactea.example.com/").unwrap());
     }
-
-
 
     #[test]
     fn test_parsing_with_no_prefix() {
@@ -381,10 +381,10 @@ pub mod tests {
         }
 
         #[test]
-        fn invalid_input_no_tld_succeeds() {
+        fn test_parsing_localhost_defaults_to_http() {
             let input_string = "localhost:8080";
             let parsed = parse_url(input_string).unwrap();
-            assert_eq!(parsed, Url::parse("https://localhost:8080/").unwrap());
+            assert_eq!(parsed, Url::parse("http://localhost:8080/").unwrap());
         }
     }
 }

--- a/agent_api_http/src/v0/identity/connections/mod.rs
+++ b/agent_api_http/src/v0/identity/connections/mod.rs
@@ -327,11 +327,21 @@ pub mod tests {
     use super::*;
 
     #[test]
-    fn test_parsing_with_http_prefix() {
+    #[cfg(not(feature = "allow-localhost"))]
+    fn test_parsing_with_http_prefix_upgrades_to_https() {
         let input_string = "http://a-via-lactea.example.com/";
         let parsed = parse_url(input_string).unwrap();
 
         assert_eq!(parsed, Url::parse("https://a-via-lactea.example.com/").unwrap());
+    }
+
+    #[test]
+    #[cfg(feature = "allow-localhost")]
+    fn test_parsing_with_http_prefix_preserves_http() {
+        let input_string = "http://a-via-lactea.example.com/";
+        let parsed = parse_url(input_string).unwrap();
+
+        assert_eq!(parsed, Url::parse("http://a-via-lactea.example.com/").unwrap());
     }
 
     #[test]
@@ -359,8 +369,17 @@ pub mod tests {
     }
 
     #[test]
-    fn invalid_input_no_tld() {
+    #[cfg(not(feature = "allow-localhost"))]
+    fn invalid_input_no_tld_fails() {
         let input_string = "a-via-lactea";
         assert!(parse_url(input_string).is_err());
+    }
+
+    #[test]
+    #[cfg(feature = "allow-localhost")]
+    fn invalid_input_no_tld_succeeds() {
+        let input_string = "localhost:8080";
+        let parsed = parse_url(input_string).unwrap();
+        assert_eq!(parsed, Url::parse("https://localhost:8080/").unwrap());
     }
 }

--- a/agent_identity/Cargo.toml
+++ b/agent_identity/Cargo.toml
@@ -74,3 +74,4 @@ wiremock.workspace = true
 
 [features]
 test_utils = ["dep:futures", "dep:rstest"]
+allow-localhost = []

--- a/agent_identity/src/services.rs
+++ b/agent_identity/src/services.rs
@@ -216,7 +216,8 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn test_fetch_linked_dids_empty() {
+    #[cfg(not(feature = "allow-localhost"))]
+    async fn test_fetch_linked_dids_empty_fails() {
         let mock_server = MockServer::start().await;
 
         Mock::given(method("GET"))
@@ -235,5 +236,35 @@ mod tests {
         let result = services.fetch_linked_dids(&issuer_url).await;
 
         assert!(result.is_err());
+    }
+
+    #[tokio::test]
+    #[cfg(feature = "allow-localhost")]
+    // DISCLAIMER: The DID Configuration specification strictly requires a non-empty `linked_dids` array.
+    // This test asserts that the parser's validation error is intentionally swallowed, returning an
+    // empty list instead. This is a deliberate bypass to prevent local HTTP testing from failing
+    // due to domain linkage requirements. See ADR 0002 for the full context.
+    async fn test_fetch_linked_dids_empty_succeeds_with_fallback() {
+        let mock_server = MockServer::start().await;
+
+        Mock::given(method("GET"))
+            .and(path("/.well-known/did-configuration.json"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+                "@context": "https://identity.foundation/.well-known/did-configuration/v1",
+                "linked_dids": []
+            })))
+            .mount(&mock_server)
+            .await;
+
+        let subject = Arc::new(Subject::new().await);
+        let services = IdentityServices::new(subject);
+
+        let issuer_url: Url = mock_server.uri().parse().unwrap();
+        let result = services.fetch_linked_dids(&issuer_url).await;
+
+        // When allow-localhost is on, the error is swallowed and fallback is returned.
+        let (dids, valid) = result.unwrap();
+        assert_eq!(dids.len(), 0);
+        assert!(!valid);
     }
 }

--- a/agent_identity/src/services.rs
+++ b/agent_identity/src/services.rs
@@ -71,7 +71,8 @@ impl IdentityServices {
         // TODO: This essentially disables domain linkage fetching because HTTPS is strictly
         // required by `DomainLinkageConfiguration::from_json_value`. When running locally
         // with HTTP, the fetch fails and we gracefully default to no linked DIDs.
-        // See ADR 0002 for more context and the future plan to use `rcgen`.
+        // See `docs/adr/0002-allow-localhost-http-fallback-for-local-testing.md` for more context and the future plan
+        // to use `rcgen`.
         #[cfg(feature = "allow-localhost")]
         let config = match self.fetch_domain_linkage_configuration(url).await {
             Ok(config) => config,
@@ -246,7 +247,8 @@ mod tests {
         // DISCLAIMER: The DID Configuration specification strictly requires a non-empty `linked_dids` array.
         // This test asserts that the parser's validation error is intentionally swallowed, returning an
         // empty list instead. This is a deliberate bypass to prevent local HTTP testing from failing
-        // due to domain linkage requirements. See ADR 0002 for the full context.
+        // due to domain linkage requirements. See `docs/adr/0002-allow-localhost-http-fallback-for-local-testing.md`
+        // for the full context.
         async fn test_fetch_linked_dids_empty_succeeds_with_fallback() {
             let mock_server = MockServer::start().await;
 

--- a/agent_identity/src/services.rs
+++ b/agent_identity/src/services.rs
@@ -238,33 +238,37 @@ mod tests {
         assert!(result.is_err());
     }
 
-    #[tokio::test]
     #[cfg(feature = "allow-localhost")]
-    // DISCLAIMER: The DID Configuration specification strictly requires a non-empty `linked_dids` array.
-    // This test asserts that the parser's validation error is intentionally swallowed, returning an
-    // empty list instead. This is a deliberate bypass to prevent local HTTP testing from failing
-    // due to domain linkage requirements. See ADR 0002 for the full context.
-    async fn test_fetch_linked_dids_empty_succeeds_with_fallback() {
-        let mock_server = MockServer::start().await;
+    pub mod allow_localhost_tests {
+        use super::*;
 
-        Mock::given(method("GET"))
-            .and(path("/.well-known/did-configuration.json"))
-            .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
-                "@context": "https://identity.foundation/.well-known/did-configuration/v1",
-                "linked_dids": []
-            })))
-            .mount(&mock_server)
-            .await;
+        #[tokio::test]
+        // DISCLAIMER: The DID Configuration specification strictly requires a non-empty `linked_dids` array.
+        // This test asserts that the parser's validation error is intentionally swallowed, returning an
+        // empty list instead. This is a deliberate bypass to prevent local HTTP testing from failing
+        // due to domain linkage requirements. See ADR 0002 for the full context.
+        async fn test_fetch_linked_dids_empty_succeeds_with_fallback() {
+            let mock_server = MockServer::start().await;
 
-        let subject = Arc::new(Subject::new().await);
-        let services = IdentityServices::new(subject);
+            Mock::given(method("GET"))
+                .and(path("/.well-known/did-configuration.json"))
+                .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+                    "@context": "https://identity.foundation/.well-known/did-configuration/v1",
+                    "linked_dids": []
+                })))
+                .mount(&mock_server)
+                .await;
 
-        let issuer_url: Url = mock_server.uri().parse().unwrap();
-        let result = services.fetch_linked_dids(&issuer_url).await;
+            let subject = Arc::new(Subject::new().await);
+            let services = IdentityServices::new(subject);
 
-        // When allow-localhost is on, the error is swallowed and fallback is returned.
-        let (dids, valid) = result.unwrap();
-        assert_eq!(dids.len(), 0);
-        assert!(!valid);
+            let issuer_url: Url = mock_server.uri().parse().unwrap();
+            let result = services.fetch_linked_dids(&issuer_url).await;
+
+            // When allow-localhost is on, the error is swallowed and fallback is returned.
+            let (dids, valid) = result.unwrap();
+            assert_eq!(dids.len(), 0);
+            assert!(!valid);
+        }
     }
 }

--- a/agent_identity/src/services.rs
+++ b/agent_identity/src/services.rs
@@ -68,6 +68,17 @@ impl IdentityServices {
     }
 
     pub async fn fetch_linked_dids(&self, url: &Url) -> Result<(Vec<DIDUrl>, bool), ConnectionError> {
+        // TODO: This essentially disables domain linkage fetching because HTTPS is strictly
+        // required by `DomainLinkageConfiguration::from_json_value`. When running locally
+        // with HTTP, the fetch fails and we gracefully default to no linked DIDs.
+        // See ADR 0002 for more context and the future plan to use `rcgen`.
+        #[cfg(feature = "allow-localhost")]
+        let config = match self.fetch_domain_linkage_configuration(url).await {
+            Ok(config) => config,
+            Err(_) => return Ok((vec![], false)),
+        };
+
+        #[cfg(not(feature = "allow-localhost"))]
         let config = self.fetch_domain_linkage_configuration(url).await?;
         let linked_dids: Vec<DIDUrl> = config
             .linked_dids()

--- a/agent_shared/src/config/mod.rs
+++ b/agent_shared/src/config/mod.rs
@@ -60,9 +60,19 @@ pub static CONFIG: Lazy<RwLock<ApplicationConfiguration>> = Lazy::new(|| {
             // Set the default logging level to `info`, equivalent to `RUST_LOG=info`
             .with(tracing_subscriber::EnvFilter::try_from_default_env().unwrap_or_else(|_| "info".into()));
 
+        // We use TestWriter to ensure that `cargo test` can capture the logs.
+        // In a normal `cargo run` scenario, this falls back to standard stdout.
         match application_configuration.log_format {
-            LogFormat::Json => tracing_subscriber.with(tracing_subscriber::fmt::layer().json()).init(),
-            LogFormat::Text => tracing_subscriber.with(tracing_subscriber::fmt::layer()).init(),
+            LogFormat::Json => tracing_subscriber
+                .with(
+                    tracing_subscriber::fmt::layer()
+                        .json()
+                        .with_writer(tracing_subscriber::fmt::TestWriter::new()),
+                )
+                .init(),
+            LogFormat::Text => tracing_subscriber
+                .with(tracing_subscriber::fmt::layer().with_writer(tracing_subscriber::fmt::TestWriter::new()))
+                .init(),
         }
 
         info!("Configuration loaded successfully");

--- a/docs/adr/0002-allow-localhost-http-fallback-for-local-testing.md
+++ b/docs/adr/0002-allow-localhost-http-fallback-for-local-testing.md
@@ -1,0 +1,30 @@
+# ADR 0002: Localhost HTTP Fallback for Local Testing
+
+**Status**: Accepted  
+**Date**: 2026-07-07  
+**Context**: Support for local E2E testing without TLS  
+
+---
+
+## Context
+
+When testing identity services locally, protocols such as DID Configuration and OIDC specifically require the use of HTTPS for security reasons. For example, `DomainLinkageConfiguration::from_json_value` strictly mandates that fetched documents conform to these secure protocols. 
+
+However, during local development and automated E2E testing, running a full TLS server stack and managing certificates is burdensome. We needed a simple way to boot the application locally on HTTP (`http://localhost`) and still have tests run without failing due to strict HTTPS checks.
+
+---
+
+## Decision
+
+We introduced an `allow-localhost` feature flag that disables strict HTTPS checks for `localhost` URLs. 
+Specifically, in `fetch_linked_dids`, when the `allow-localhost` feature is active, we attempt to fetch the domain linkage configuration via HTTP. Since `DomainLinkageConfiguration::from_json_value` strictly requires HTTPS, this fetch inevitably fails. We gracefully catch this error and default to returning no linked DIDs `(vec![], false)`, rather than causing the entire connection flow to panic or fail.
+
+---
+
+## Rationale
+
+This approach provides a quick and non-intrusive workaround to allow local development and tests to proceed without needing a full TLS setup.
+
+## Future Work
+
+This is recognized as a non-ideal solution because it essentially disables domain linkage fetching in the local testing environment. In the future, we should implement a proper local HTTPS solution using a crate like `rcgen` to dynamically generate self-signed certificates during test initialization. This would allow the test harness to run on `https://localhost` natively, enabling us to test the entire domain linkage flow securely and without skipping validation logic.


### PR DESCRIPTION
# Description of change
This PR introduces a new `allow-localhost` feature flag designed to facilitate local development and automated E2E testing by loosening strict HTTPS requirements. 

**Key Changes:**
- **Localhost HTTP Fallback**: Skips top-level domain validation (allowing `localhost`) and stops automatically upgrading `http://` URLs to `https://` when the `allow-localhost` feature is active (`agent_api_http`).
- **Domain Linkage Bypass**: **Catches and ignores** HTTPS-related fetch errors during DID domain linkage fetching (`fetch_linked_dids`), **defaulting to an empty list** :warning:  rather than breaking the connection flow (`agent_identity`).
- **Test Logging**: Updates the `tracing` setup to use `TestWriter`, ensuring logs are properly captured and silenced during `cargo test` runs (`agent_shared`).
- **Documentation**: Adds an Architectural Decision Record (ADR 0002) explaining the rationale behind this HTTP fallback and outlining a future plan to use `rcgen` to dynamically generate self-signed certificates for testing.

## Links to any relevant issues
Be sure to reference any related issues by adding `fixes issue #`.

## How the change has been tested
Describe the tests that you ran to verify your changes.
Make sure to provide instructions for the maintainer as well as any relevant configurations.

## Definition of Done checklist
Add an `x` to the boxes that are relevant to your changes.

- [x] I have followed the contribution guidelines for this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] I have successfully tested this change in a docker environment 
