### PR TITLE
docs: add OpenAPI definition for credential presentations

### DIFF
--- a/agent_api_http/openapi-generated.yaml
+++ b/agent_api_http/openapi-generated.yaml
@@ -631,6 +631,68 @@ paths:
                 $ref: '#/components/schemas/OfferView'
         '404':
           description: Offer not found
+  /v0/holder/presentations:
+    get:
+      tags:
+      - Identity
+      - Holder
+      summary: List all credential presentations
+      description: Retrieves all credential presentations held by your organisation.
+      operationId: get_all_holder_presentations
+      responses:
+        '200':
+          description: All presentations retrieved successfully
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/PresentationView'
+    post:
+      tags:
+      - Identity
+      - Holder
+      summary: Create a new credential presentation
+      description: Creates and signs a new credential presentation containing the given credentials held by your organisation.
+      operationId: create_holder_presentation
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/PresentationsEndpointRequest'
+        required: true
+      responses:
+        '201':
+          description: Presentation created successfully
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/PresentationView'
+        '404':
+          description: Credential not found
+  /v0/holder/presentations/{presentation_id}:
+    get:
+      tags:
+      - Identity
+      - Holder
+      summary: Get credential presentation by ID
+      description: Retrieves a single credential presentation held by your organisation by its ID.
+      operationId: get_holder_presentation_by_id
+      parameters:
+      - name: presentation_id
+        in: path
+        required: true
+        schema:
+          type: string
+      responses:
+        '200':
+          description: Presentation retrieved successfully
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/PresentationView'
+        '404':
+          description: Presentation not found
   /v0/list-all-templates:
     get:
       tags:
@@ -1655,6 +1717,26 @@ components:
           oneOf:
           - type: 'null'
           - $ref: '#/components/schemas/ConnectionDisplayProperties'
+    PresentationView:
+      type: object
+      required:
+      - id
+      properties:
+        id:
+          type: string
+        signed:
+          type:
+          - string
+          - 'null'
+    PresentationsEndpointRequest:
+      type: object
+      required:
+      - credentialIds
+      properties:
+        credentialIds:
+          type: array
+          items:
+            type: string
     Profile:
       type: object
       required:

--- a/agent_api_http/src/v0/holder/holder/presentations/mod.rs
+++ b/agent_api_http/src/v0/holder/holder/presentations/mod.rs
@@ -3,7 +3,9 @@ pub mod presentation_signed;
 use crate::extractors::RequestActor;
 use crate::handlers::{command_handler, query_handler};
 use agent_holder::{
-    credential::queries::HolderCredentialView, presentation::command::PresentationCommand, state::HolderState,
+    credential::queries::HolderCredentialView,
+    presentation::{aggregate::Presentation, command::PresentationCommand},
+    state::HolderState,
 };
 use axum::{
     extract::{Path, State},
@@ -15,6 +17,18 @@ use hyper::StatusCode;
 use serde::{Deserialize, Serialize};
 use std::sync::Arc;
 
+/// List all credential presentations
+///
+/// Retrieves all credential presentations held by your organisation.
+#[utoipa::path(
+    get,
+    path = "/holder/presentations",
+    operation_id = "get_all_holder_presentations",
+    tags = ["Identity", "Holder"],
+    responses(
+        (status = 200, description = "All presentations retrieved successfully", body = [Presentation]),
+    )
+)]
 #[axum_macros::debug_handler]
 pub(crate) async fn get_presentations(
     State(state): State<Arc<HolderState>>,
@@ -33,6 +47,19 @@ pub(crate) async fn get_presentations(
     Ok((StatusCode::OK, Json(all_presentations)).into_response())
 }
 
+/// Get credential presentation by ID
+///
+/// Retrieves a single credential presentation held by your organisation by its ID.
+#[utoipa::path(
+    get,
+    path = "/holder/presentations/{presentation_id}",
+    operation_id = "get_holder_presentation_by_id",
+    tags = ["Identity", "Holder"],
+    responses(
+        (status = 200, description = "Presentation retrieved successfully", body = Presentation),
+        (status = 404, description = "Presentation not found"),
+    )
+)]
 #[axum_macros::debug_handler]
 pub(crate) async fn presentation(
     State(state): State<Arc<HolderState>>,
@@ -50,12 +77,26 @@ pub(crate) async fn presentation(
     .ok_or_else(|| ApiError::new(StatusCode::NOT_FOUND))
 }
 
-#[derive(Deserialize, Serialize)]
+#[derive(Deserialize, Serialize, utoipa::ToSchema)]
 #[serde(rename_all = "camelCase")]
 pub struct PresentationsEndpointRequest {
     pub credential_ids: Vec<String>,
 }
 
+/// Create a new credential presentation
+///
+/// Creates and signs a new credential presentation containing the given credentials held by your organisation.
+#[utoipa::path(
+    post,
+    path = "/holder/presentations",
+    operation_id = "create_holder_presentation",
+    tags = ["Identity", "Holder"],
+    request_body = PresentationsEndpointRequest,
+    responses(
+        (status = 201, description = "Presentation created successfully", body = Presentation),
+        (status = 404, description = "Credential not found"),
+    )
+)]
 #[axum_macros::debug_handler]
 pub(crate) async fn post_presentations(
     State(state): State<Arc<HolderState>>,

--- a/agent_api_http/src/v0/holder/openapi.rs
+++ b/agent_api_http/src/v0/holder/openapi.rs
@@ -1,10 +1,23 @@
 use crate::v0::holder::holder::credentials::{__path_credential, __path_credentials};
 use crate::v0::holder::holder::offers::{__path_offer, __path_offers, accept::__path_accept, reject::__path_reject};
+use crate::v0::holder::holder::presentations::{
+    __path_get_presentations, __path_post_presentations, __path_presentation,
+};
 use utoipa::OpenApi;
 
 #[derive(OpenApi)]
 #[openapi(
-    paths(credential, credentials, offer, offers, accept, reject),
+    paths(
+        credential,
+        credentials,
+        offer,
+        offers,
+        accept,
+        reject,
+        get_presentations,
+        post_presentations,
+        presentation
+    ),
     tags(
         (name = "Identity", description = "Manage all aspects of your organisational identity."),
         (name = "Holder", description = "Manage the credentials your organisation holds itself."),

--- a/agent_holder/src/presentation/aggregate.rs
+++ b/agent_holder/src/presentation/aggregate.rs
@@ -11,10 +11,12 @@ use serde::{Deserialize, Serialize};
 use std::sync::Arc;
 use tracing::{debug, info};
 
-#[derive(Debug, Clone, Serialize, Deserialize, Default)]
+#[derive(Debug, Clone, Serialize, Deserialize, Default, utoipa::ToSchema)]
+#[schema(as = PresentationView)]
 pub struct Presentation {
     #[serde(rename = "id")]
     pub presentation_id: String,
+    #[schema(value_type = Option<String>)]
     pub signed: Option<Jwt>,
 }
 


### PR DESCRIPTION
# Description of change

Adds OpenAPI definitions for the following endpoints:

- ` GET /v0/holder/presentations`
- `POST /v0/holder/presentations`
- ` GET /v0/holder/presentations/{presentation_id}`

## Links to any relevant issues
Be sure to reference any related issues by adding `fixes issue #`.

## How the change has been tested
Describe the tests that you ran to verify your changes.
Make sure to provide instructions for the maintainer as well as any relevant configurations.

## Definition of Done checklist
Add an `x` to the boxes that are relevant to your changes.

- [x] I have followed the contribution guidelines for this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] I have successfully tested this change in a docker environment 
