### PR TITLE
fix: send B2B credential offers to `/credential_offer`

### DIFF
--- a/agent_api_http/src/v0/holder/mod.rs
+++ b/agent_api_http/src/v0/holder/mod.rs
@@ -39,9 +39,8 @@ pub fn router(holder_state: Arc<HolderState>) -> Router {
                 .route("/holder/offers/{offer_id}/accept", post(accept))
                 .route("/holder/offers/{offer_id}/reject", post(reject)),
         )
-        // TODO: move these behind some sort of authentication?
+        // TODO: move this behind some sort of authentication?
         .route("/credential_offer", get(openid4vci::offers_params))
-        .route("/", get(openid4vci::offers_params))
         .route(
             "/linked-verifiable-presentations/{presentation_id}",
             get(presentation_signed),

--- a/agent_api_http/src/v0/holder/openid4vci/mod.rs
+++ b/agent_api_http/src/v0/holder/openid4vci/mod.rs
@@ -1,5 +1,4 @@
-use crate::extractors::RequestActor;
-use crate::handlers::command_handler;
+use crate::handlers::public_command_handler;
 use agent_holder::{offer::command::OfferCommand, state::HolderState};
 use axum::{
     extract::State,
@@ -16,7 +15,6 @@ use tracing::info;
 #[axum_macros::debug_handler]
 pub(crate) async fn offers_params(
     State(state): State<Arc<HolderState>>,
-    RequestActor(actor): RequestActor,
     // TODO: Can this be changed to `StringifiedForm`?
     Form(payload): Form<serde_json::Value>,
 ) -> Result<Response, ApiError> {
@@ -45,14 +43,7 @@ pub(crate) async fn offers_params(
     };
 
     // Add the Credential Offer to the state.
-    command_handler(
-        state.authorization_checker.clone(),
-        actor.clone(),
-        &received_offer_id,
-        &state.command.offer,
-        command,
-    )
-    .await?;
+    public_command_handler(&received_offer_id, &state.command.offer, command).await?;
 
     Ok(StatusCode::OK.into_response())
 }

--- a/agent_issuance/src/offer/aggregate.rs
+++ b/agent_issuance/src/offer/aggregate.rs
@@ -237,8 +237,18 @@ impl Aggregate for Offer {
                 match delivery_method {
                     DeliveryMethod::TargetUrl { target_url } => {
                         let client = reqwest::Client::new();
-                        let target = form_url_encoded_credential_offer
-                            .replace("openid-credential-offer://", target_url.as_str());
+
+                        // TODO: Currently, we are hardcoding the `/credential_offer` endpoint on the target URL.
+                        // According to the OpenID4VCI specification, we should instead retrieve the `credential_offer_endpoint`
+                        // from the Wallet's Client Metadata.
+                        // See: https://openid.net/specs/openid-4-verifiable-credential-issuance-1_0.html#name-client-metadata
+                        let target = form_url_encoded_credential_offer.replace(
+                            "openid-credential-offer://",
+                            target_url
+                                .join("credential_offer")
+                                .map_err(InvalidCredentialOfferUriError)?
+                                .as_str(),
+                        );
 
                         info!("Sending credential offer to: {}", target);
 


### PR DESCRIPTION
# Description of change
This PR fixes B2B credential issuance by:
* hardcoding the `/credential_offer` path segment when sending a Credential Offer to a `target_url` (of an organization)
* using `public_command_handler` inside the `/credential_offer` endpoints endpoint handler.

:warning: Note that this only works for UniCore to UniCore b2b Credential Issuance (as was already the case). In the future we should make sure the `credential_offer_endpoint` is obtained through the (Organizational) Wallet's Client Metadata as described here: https://openid.net/specs/openid-4-verifiable-credential-issuance-1_0.html#name-client-metadata

## Links to any relevant issues
n/a

## How the change has been tested
Manually tested:
1. Create new Template
2. Create new Credential (only works with `"dataModel": "w3c_vc_data_model_v1-1"`)
3. Send the offer through (e.g.):
```curl
curl --location 'http://localhost:3033/v0/offers/send-offer-to-organization' \
--header 'Content-Type: application/json' \
--header 'X-API-KEY: ***' \
--data '{
    "offerId": "123",
    "targetUrl": "http://localhost:3033"
}'
```

## Definition of Done checklist
Add an `x` to the boxes that are relevant to your changes.

- [x] I have followed the contribution guidelines for this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] I have successfully tested this change in a docker environment 
