### PR TITLE
fix: use `jwt_vc_json` for B2B credentials

### DIFF
--- a/agent_issuance/src/application/credential_configuration_projection.rs
+++ b/agent_issuance/src/application/credential_configuration_projection.rs
@@ -1,6 +1,6 @@
 use crate::server_config::command::ServerConfigCommand;
 use crate::state::{IssuanceState, SERVER_CONFIG_ID};
-use agent_library::template::aggregate::{DataModel, PropertyAttribute, Template};
+use agent_library::template::aggregate::{DataModel, HolderType, PropertyAttribute, Template};
 use agent_library::template::views::TemplateView;
 use agent_shared::config::CredentialConfiguration;
 use agent_shared::handlers::{command_handler, public_query_handler};
@@ -117,6 +117,7 @@ impl CredentialConfigurationProjection {
 fn credential_configuration_from_template(template: &Template) -> CredentialConfiguration {
     let format = match template.data_model {
         DataModel::W3CVcDataModelV1_1 => "jwt_vc_json",
+        _ if template.holder_type == HolderType::Organization => "jwt_vc_json",
         _ => "vc+sd-jwt",
     }
     .to_string();

--- a/agent_issuance/src/application/credential_configuration_projection.rs
+++ b/agent_issuance/src/application/credential_configuration_projection.rs
@@ -297,15 +297,21 @@ impl Query<Template> for CredentialConfigurationProjection {
                 // On creation we have the full template state in the event itself.
                 TemplateCreated {
                     template_id,
+                    source_template_id,
                     title,
                     display,
                     data_model,
-                    r#type,
+                    holder_type,
+                    modified_at,
+                    tags,
                     status,
+                    visibility,
+                    credential_expiration,
+                    description,
+                    r#type,
                     schema,
                     schema_properties_attributes,
                     holder_authorization,
-                    ..
                 } => {
                     // Only published templates have a credential configuration.
                     if *status != Status::Published {
@@ -314,15 +320,21 @@ impl Query<Template> for CredentialConfigurationProjection {
 
                     let template = Template {
                         template_id: template_id.clone(),
+                        source_template_id: source_template_id.clone(),
                         title: title.clone(),
                         display: *display.clone(),
                         data_model: data_model.clone(),
-                        r#type: r#type.clone(),
+                        holder_type: holder_type.clone(),
+                        modified_at: Some(modified_at.clone()),
+                        tags: tags.clone(),
                         status: status.clone(),
+                        visibility: visibility.clone(),
+                        credential_expiration: credential_expiration.clone(),
+                        description: description.clone(),
+                        r#type: r#type.clone(),
                         schema: schema.clone(),
                         schema_properties_attributes: schema_properties_attributes.clone(),
                         holder_authorization: holder_authorization.clone(),
-                        ..Default::default()
                     };
 
                     let credential_configuration = credential_configuration_from_template(&template);


### PR DESCRIPTION
# Description of change

All B2B credentials are issued as `jwt_vc_json` instead of SD-JWT credentials.

## Links to any relevant issues
Be sure to reference any related issues by adding `fixes issue #`.

## How the change has been tested
Describe the tests that you ran to verify your changes.
Make sure to provide instructions for the maintainer as well as any relevant configurations.

## Definition of Done checklist
Add an `x` to the boxes that are relevant to your changes.

- [ ] I have followed the contribution guidelines for this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] I have successfully tested this change in a docker environment 
