### PR TITLE
feat: store custom template field types, add `profile` field in OBv3

### DIFF
--- a/agent_api_http/openapi-generated.yaml
+++ b/agent_api_http/openapi-generated.yaml
@@ -1785,6 +1785,8 @@ components:
             description: |-
               Allows the caller to store additional type information not supported by standard JSON Schema keywords.
               This can be used by frontends to preserve field type information for visualizations.
+              Purely a rendering hint that UniCore stores as given and never validates against the
+              schema or the issued values.
     PublicOfferStatusDto:
       type: object
       required:

--- a/agent_api_http/openapi-generated.yaml
+++ b/agent_api_http/openapi-generated.yaml
@@ -1475,6 +1475,10 @@ components:
           value:
             type: string
             description: Absolute datetime in ISO 8601 format, e.g. `"2026-12-31T23:59:59Z"`.
+    FormFieldType:
+      type: string
+      enum:
+      - country
     GetConnectionsEndpointRequest:
       type: object
       properties:
@@ -1774,6 +1778,13 @@ components:
             Defaults to `false`.
         selectivelyDisclosable:
           type: boolean
+        type:
+          oneOf:
+          - type: 'null'
+          - $ref: '#/components/schemas/FormFieldType'
+            description: |-
+              Allows the caller to store additional type information not supported by standard JSON Schema keywords.
+              This can be used by frontends to preserve field type information for visualizations.
     PublicOfferStatusDto:
       type: object
       required:

--- a/agent_api_http/src/v0/library/error.rs
+++ b/agent_api_http/src/v0/library/error.rs
@@ -41,6 +41,11 @@ impl IntoApiErrorExt for TemplateError {
                 .type_url(type_url("library#invalid-required-property-type"))
                 .source(self)
                 .finish(),
+            TemplateError::InvalidOpenBadgesPropertyType(_) => ApiError::builder(StatusCode::BAD_REQUEST)
+                .title("Invalid OpenBadges Property Type")
+                .type_url(type_url("library#invalid-open-badges-property-type"))
+                .source(self)
+                .finish(),
             TemplateError::MissingTitle => ApiError::builder(StatusCode::BAD_REQUEST)
                 .title("Missing Title")
                 .type_url(type_url("library#missing-title"))

--- a/agent_api_http/src/v0/templates/mod.rs
+++ b/agent_api_http/src/v0/templates/mod.rs
@@ -1056,4 +1056,67 @@ mod tests {
 
         assert_eq!(response.status(), StatusCode::NOT_FOUND);
     }
+
+    #[tokio::test]
+    async fn schema_properties_attributes_type_survives_api_round_trip() {
+        // Verifies that `schemaPropertiesAttributes[*].type` (a caller-supplied rendering hint)
+        // is preserved end-to-end: create template → retrieve via get endpoint → field still present.
+        use agent_library::template::aggregate::FormFieldType;
+
+        let state = Arc::new(library_state(&InMemory, Default::default(), Default::default()).await);
+
+        let response = create_template(
+            State(state.clone()),
+            RequestActor(None),
+            Json(CreateNewTemplateRequestBody {
+                title: "Country Template".to_string(),
+                display: None,
+                data_model: DataModel::W3CVcDataModelV2_0,
+                holder_type: HolderType::Individual,
+                tags: None,
+                status: Status::Draft,
+                visibility: Visibility::Private,
+                credential_expiration: None,
+                description: None,
+                r#type: vec![],
+                schema: Some(json!({
+                    "type": "object",
+                    "properties": {
+                        "nationality": { "type": "string" }
+                    }
+                })),
+                schema_properties_attributes: Some(HashMap::from([(
+                    "/nationality".to_string(),
+                    PropertyAttribute {
+                        selectively_disclosable: false,
+                        non_removable: false,
+                        r#type: Some(FormFieldType::Country),
+                    },
+                )])),
+                holder_authorization: Authorization::default(),
+            }),
+        )
+        .await
+        .unwrap();
+
+        assert_eq!(response.status(), StatusCode::CREATED);
+
+        let body = to_bytes(response.into_body(), usize::MAX).await.unwrap();
+        let created: serde_json::Value = serde_json::from_slice(&body).unwrap();
+        let template_id = created["id"].as_str().unwrap().to_string();
+
+        let response = get_template(State(state), RequestActor(None), Path(template_id))
+            .await
+            .unwrap();
+
+        assert_eq!(response.status(), StatusCode::OK);
+
+        let body = to_bytes(response.into_body(), usize::MAX).await.unwrap();
+        let retrieved: serde_json::Value = serde_json::from_slice(&body).unwrap();
+
+        assert_eq!(
+            retrieved["schemaPropertiesAttributes"]["/nationality"]["type"],
+            json!("country")
+        );
+    }
 }

--- a/agent_library/src/json_schema_validation.rs
+++ b/agent_library/src/json_schema_validation.rs
@@ -243,30 +243,34 @@ mod tests {
     lazy_static! {
         static ref EXAMPLE_BASIC_OB3: Value = json!({
             "@context": [
-              "https://www.w3.org/ns/credentials/v2",
-              "https://purl.imsglobal.org/spec/ob/v3p0/context-3.0.3.json"
+                "https://www.w3.org/ns/credentials/v2",
+                "https://purl.imsglobal.org/spec/ob/v3p0/context-3.0.3.json"
             ],
             "id": "http://example.com/credentials/3527",
             "type": ["VerifiableCredential", "AchievementCredential"],
             "issuer": {
-              "id": "https://example.com/issuers/876543",
-              "type": ["Profile"],
-              "name": "Example Corp"
+                "id": "https://example.com/issuers/876543",
+                "type": ["Profile"],
+                "name": "Example Corp"
             },
             "validFrom": "2010-01-01T00:00:00Z",
             "name": "Teamwork Badge",
             "credentialSubject": {
-              "id": "did:example:ebfeb1f712ebc6f1c276e12ec21",
-              "type": ["AchievementSubject"],
-              "achievement": {
-                        "id": "https://example.com/achievements/21st-century-skills/teamwork",
-                        "type": ["Achievement"],
-                        "criteria": {
-                            "narrative": "Team members are nominated for this badge by their peers and recognized upon review by Example Corp management."
-                        },
-                        "description": "This badge recognizes the development of the capacity to collaborate within a group environment.",
-                        "name": "Teamwork"
-                    }
+                "id": "did:example:ebfeb1f712ebc6f1c276e12ec21",
+                "type": ["AchievementSubject"],
+                "activityStartDate": "2020-01-01T00:00:00Z",
+                "activityEndDate": "2020-06-01T00:00:00Z",
+                "achievement": {
+                "id": "https://example.com/achievements/21st-century-skills/teamwork",
+                "type": ["Achievement"],
+                "criteria": {
+                    "narrative": "Team members are nominated for this badge by their peers and recognized upon review by Example Corp management."
+                },
+                "description": "This badge recognizes the development of the capacity to collaborate within a group environment.",
+                "name": "Teamwork",
+                "fieldOfStudy": "Business",
+                "specialization": "Team Leadership"
+                }
             }
         });
         static ref EXAMPLE_BASIC_ELM_EDC: Value = json!({

--- a/agent_library/src/json_schema_validation.rs
+++ b/agent_library/src/json_schema_validation.rs
@@ -261,15 +261,15 @@ mod tests {
                 "activityStartDate": "2020-01-01T00:00:00Z",
                 "activityEndDate": "2020-06-01T00:00:00Z",
                 "achievement": {
-                "id": "https://example.com/achievements/21st-century-skills/teamwork",
-                "type": ["Achievement"],
-                "criteria": {
-                    "narrative": "Team members are nominated for this badge by their peers and recognized upon review by Example Corp management."
-                },
-                "description": "This badge recognizes the development of the capacity to collaborate within a group environment.",
-                "name": "Teamwork",
-                "fieldOfStudy": "Business",
-                "specialization": "Team Leadership"
+                    "id": "https://example.com/achievements/21st-century-skills/teamwork",
+                    "type": ["Achievement"],
+                    "criteria": {
+                        "narrative": "Team members are nominated for this badge by their peers and recognized upon review by Example Corp management."
+                    },
+                    "description": "This badge recognizes the development of the capacity to collaborate within a group environment.",
+                    "name": "Teamwork",
+                    "fieldOfStudy": "Business",
+                    "specialization": "Team Leadership"
                 }
             }
         });

--- a/agent_library/src/template/aggregate.rs
+++ b/agent_library/src/template/aggregate.rs
@@ -87,6 +87,13 @@ impl Default for Expiration {
     }
 }
 
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, Eq, PartialEq, utoipa::ToSchema)]
+#[serde(rename_all = "kebab-case")]
+pub enum FormFieldType {
+    Country,
+}
+
+#[skip_serializing_none]
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, utoipa::ToSchema)]
 #[serde(rename_all = "camelCase")]
 pub struct PropertyAttribute {
@@ -97,6 +104,10 @@ pub struct PropertyAttribute {
     /// Defaults to `false`.
     #[serde(default)]
     pub non_removable: bool,
+    /// Allows the caller to store additional type information not supported by standard JSON Schema keywords.
+    /// This can be used by frontends to preserve field type information for visualizations.
+    #[serde(default)]
+    pub r#type: Option<FormFieldType>,
 }
 
 impl PropertyAttribute {
@@ -105,6 +116,7 @@ impl PropertyAttribute {
         Self {
             selectively_disclosable,
             non_removable,
+            r#type: None,
         }
     }
 
@@ -256,6 +268,7 @@ impl Aggregate for Template {
                             let attr = attrs.entry(key).or_insert(PropertyAttribute {
                                 selectively_disclosable: false,
                                 non_removable: false,
+                                r#type: None,
                             });
                             attr.non_removable = is_required;
                         }
@@ -1094,6 +1107,7 @@ pub mod test_utils {
             PropertyAttribute {
                 selectively_disclosable: true,
                 non_removable: false,
+                r#type: None,
             },
         );
         Some(config)

--- a/agent_library/src/template/aggregate.rs
+++ b/agent_library/src/template/aggregate.rs
@@ -87,6 +87,17 @@ impl Default for Expiration {
     }
 }
 
+// A rendering hint for a schema property, carrying type information that standard JSON Schema
+// keywords cannot express.
+//
+// This is metadata only: UniCore stores and returns it verbatim and never validates anything
+// against it. Marking a property as `country` does not make UniCore reject a non-string schema
+// or an issued value that is not a country code — keeping the hint, the schema and the values
+// consistent is the caller's responsibility.
+//
+// `country`: the property holds a country, expected to be a `string` carrying an ISO 3166-1
+// alpha-2 code (e.g. `"NL"`). Frontends can use this to render a flag or a country picker
+// instead of a plain text field.
 #[derive(Debug, Clone, Copy, Serialize, Deserialize, Eq, PartialEq, utoipa::ToSchema)]
 #[serde(rename_all = "kebab-case")]
 pub enum FormFieldType {
@@ -106,6 +117,8 @@ pub struct PropertyAttribute {
     pub non_removable: bool,
     /// Allows the caller to store additional type information not supported by standard JSON Schema keywords.
     /// This can be used by frontends to preserve field type information for visualizations.
+    /// Purely a rendering hint that UniCore stores as given and never validates against the
+    /// schema or the issued values.
     #[serde(default)]
     pub r#type: Option<FormFieldType>,
 }

--- a/agent_library/src/template/aggregate_tests.rs
+++ b/agent_library/src/template/aggregate_tests.rs
@@ -1585,6 +1585,131 @@ async fn test_create_open_badges_template_succeeds_with_required_properties(temp
 
 #[rstest]
 #[serial_test::serial]
+async fn test_create_open_badges_template_allows_profile_object_on_subject_root(template_id: String) {
+    // `AchievementSubject` declares `additionalProperties: true`, so UniCore permits a `profile`
+    // object on the subject root carrying the recipient's OB 3.0 `Profile` fields.
+    let schema = serde_json::json!({
+        "type": "object",
+        "properties": {
+            "profile": {
+                "type": "object",
+                "properties": {
+                    "givenName": { "type": "string" },
+                    "familyName": { "type": "string" },
+                    "email": { "type": "string" },
+                    "dateOfBirth": { "type": "string", "format": "date" }
+                }
+            },
+            "achievement": {
+                "type": "object",
+                "properties": {
+                    "name": { "type": "string" },
+                    "description": { "type": "string" },
+                    "criteria": {
+                        "type": "object",
+                        "properties": {
+                            "narrative": { "type": "string" }
+                        }
+                    }
+                }
+            }
+        }
+    });
+
+    let mut expected_attrs = HashMap::new();
+    for required_leaf in ["/achievement/name", "/achievement/description", "/achievement/criteria/narrative"] {
+        expected_attrs.insert(
+            required_leaf.to_string(),
+            PropertyAttribute {
+                selectively_disclosable: false,
+                non_removable: true,
+                r#type: None,
+            },
+        );
+    }
+    for profile_leaf in ["/profile/givenName", "/profile/familyName", "/profile/email", "/profile/dateOfBirth"] {
+        expected_attrs.insert(
+            profile_leaf.to_string(),
+            PropertyAttribute {
+                selectively_disclosable: false,
+                non_removable: false,
+                r#type: None,
+            },
+        );
+    }
+
+    let expected_schema = serde_json::json!({
+        "type": "object",
+        "required": ["achievement"],
+        "properties": {
+            "profile": {
+                "type": "object",
+                "properties": {
+                    "givenName": { "type": "string" },
+                    "familyName": { "type": "string" },
+                    "email": { "type": "string" },
+                    "dateOfBirth": { "type": "string", "format": "date" }
+                }
+            },
+            "achievement": {
+                "type": "object",
+                "required": ["criteria", "description", "name"],
+                "properties": {
+                    "name": { "type": "string" },
+                    "description": { "type": "string" },
+                    "criteria": {
+                        "type": "object",
+                        "required": ["narrative"],
+                        "properties": {
+                            "narrative": { "type": "string" }
+                        }
+                    }
+                }
+            }
+        }
+    });
+
+    TemplateTestFramework::with(())
+        .given_no_previous_events()
+        .when(TemplateCommand::CreateNewTemplate {
+            template_id: template_id.clone(),
+            source_template_id: None,
+            title: "Test".to_string(),
+            display: Box::new(None),
+            data_model: DataModel::OpenBadges3_0,
+            holder_type: HolderType::Individual,
+            tags: None,
+            status: Status::Draft,
+            visibility: Visibility::Private,
+            credential_expiration: None,
+            description: None,
+            r#type: vec![],
+            schema: Box::new(Some(schema)),
+            schema_properties_attributes: None,
+            holder_authorization: Authorization::default(),
+        })
+        .then_expect_events(vec![TemplateEvent::TemplateCreated {
+            template_id,
+            source_template_id: None,
+            title: "Test".to_string(),
+            display: Box::new(None),
+            data_model: DataModel::OpenBadges3_0,
+            holder_type: HolderType::Individual,
+            modified_at: test_utils::modified_at(),
+            tags: None,
+            status: Status::Draft,
+            visibility: Visibility::Private,
+            credential_expiration: Expiration::default(),
+            description: None,
+            r#type: vec!["VerifiableCredential".to_string(), "OpenBadgeCredential".to_string()],
+            schema: Box::new(Some(expected_schema)),
+            schema_properties_attributes: Some(expected_attrs),
+            holder_authorization: Authorization::default(),
+        }])
+}
+
+#[rstest]
+#[serial_test::serial]
 async fn test_create_open_badges_template_succeeds_with_const_required_properties(template_id: String) {
     let schema = serde_json::json!({
         "type": "object",

--- a/agent_library/src/template/aggregate_tests.rs
+++ b/agent_library/src/template/aggregate_tests.rs
@@ -1856,6 +1856,128 @@ async fn test_create_open_badges_template_rejects_profile_email_without_format(t
 }
 
 #[rstest]
+#[case::declared_as_string(serde_json::json!({ "type": "string" }))]
+#[case::type_omitted(serde_json::json!({ "properties": { "givenName": { "type": "string" } } }))]
+#[serial_test::serial]
+async fn test_create_open_badges_template_rejects_non_object_profile(
+    template_id: String,
+    #[case] profile: serde_json::Value,
+) {
+    // `profile` itself must be an object. Without checking the node's own type, a non-object
+    // `profile` would carry no children to validate and slip through untouched.
+    // (`"type": "array"` never reaches this check — arrays are rejected for every template
+    // schema, see `test_create_open_badges_template_rejects_array_profile`.)
+    let schema = serde_json::json!({
+        "type": "object",
+        "properties": {
+            "profile": profile,
+            "achievement": valid_ob_achievement()
+        }
+    });
+
+    TemplateTestFramework::with(())
+        .given_no_previous_events()
+        .when(TemplateCommand::CreateNewTemplate {
+            template_id,
+            source_template_id: None,
+            title: "Test".to_string(),
+            display: Box::new(None),
+            data_model: DataModel::OpenBadges3_0,
+            holder_type: HolderType::Individual,
+            tags: None,
+            status: Status::Draft,
+            visibility: Visibility::Private,
+            credential_expiration: None,
+            description: None,
+            r#type: vec![],
+            schema: Box::new(Some(schema)),
+            schema_properties_attributes: None,
+            holder_authorization: Authorization::default(),
+        })
+        .then_expect_error_message("Invalid type or format for OpenBadges 3.0 schema properties: The following fields do not match the required type/format: [/profile]")
+}
+
+#[rstest]
+#[serial_test::serial]
+async fn test_create_open_badges_template_rejects_array_profile(template_id: String) {
+    // An array `profile` is rejected too, but by the schema-wide array rule that runs before
+    // OpenBadges validation — hence the different error message.
+    let schema = serde_json::json!({
+        "type": "object",
+        "properties": {
+            "profile": { "type": "array", "items": { "type": "string" } },
+            "achievement": valid_ob_achievement()
+        }
+    });
+
+    TemplateTestFramework::with(())
+        .given_no_previous_events()
+        .when(TemplateCommand::CreateNewTemplate {
+            template_id,
+            source_template_id: None,
+            title: "Test".to_string(),
+            display: Box::new(None),
+            data_model: DataModel::OpenBadges3_0,
+            holder_type: HolderType::Individual,
+            tags: None,
+            status: Status::Draft,
+            visibility: Visibility::Private,
+            credential_expiration: None,
+            description: None,
+            r#type: vec![],
+            schema: Box::new(Some(schema)),
+            schema_properties_attributes: None,
+            holder_authorization: Authorization::default(),
+        })
+        .then_expect_error_message(
+            "Invalid JSON Schema: Array types are not supported in template schemas. Define only object and scalar fields.",
+        )
+}
+
+#[rstest]
+#[serial_test::serial]
+async fn test_create_open_badges_template_rejects_unsanctioned_format_on_profile_name(template_id: String) {
+    // The synthetic def is an exact pin: `givenName`/`familyName` are plain strings, so a
+    // caller-supplied `format` on them is rejected even though the type is right. `email` keeps
+    // the format its def declares and is accepted alongside them.
+    let schema = serde_json::json!({
+        "type": "object",
+        "properties": {
+            "profile": {
+                "type": "object",
+                "properties": {
+                    "givenName": { "type": "string", "format": "given-name" },
+                    "familyName": { "type": "string", "format": "family-name" },
+                    "email": { "type": "string", "format": "email" }
+                }
+            },
+            "achievement": valid_ob_achievement()
+        }
+    });
+
+    TemplateTestFramework::with(())
+        .given_no_previous_events()
+        .when(TemplateCommand::CreateNewTemplate {
+            template_id,
+            source_template_id: None,
+            title: "Test".to_string(),
+            display: Box::new(None),
+            data_model: DataModel::OpenBadges3_0,
+            holder_type: HolderType::Individual,
+            tags: None,
+            status: Status::Draft,
+            visibility: Visibility::Private,
+            credential_expiration: None,
+            description: None,
+            r#type: vec![],
+            schema: Box::new(Some(schema)),
+            schema_properties_attributes: None,
+            holder_authorization: Authorization::default(),
+        })
+        .then_expect_error_message("Invalid type or format for OpenBadges 3.0 schema properties: The following fields do not match the required type/format: [/profile/familyName, /profile/givenName]")
+}
+
+#[rstest]
 #[serial_test::serial]
 async fn test_create_open_badges_template_succeeds_with_const_required_properties(template_id: String) {
     let schema = serde_json::json!({
@@ -2636,4 +2758,65 @@ fn property_attribute_type_survives_serde_round_trip() {
         serde_json::json!({ "selectivelyDisclosable": false, "type": "not-a-real-type" }),
     );
     assert!(should_error.is_err());
+}
+
+#[rstest]
+#[serial_test::serial]
+async fn test_create_template_preserves_property_attribute_type(template_id: String) {
+    // The `country` field type is caller-supplied metadata the aggregate must carry through
+    // untouched: it has to survive command handling and land in the emitted event, alongside the
+    // system-controlled flags the aggregate derives itself.
+    let schema = serde_json::json!({
+        "type": "object",
+        "properties": {
+            "nationality": { "type": "string" }
+        }
+    });
+
+    let attributes = HashMap::from([(
+        "/nationality".to_string(),
+        PropertyAttribute {
+            selectively_disclosable: true,
+            non_removable: false,
+            r#type: Some(FormFieldType::Country),
+        },
+    )]);
+
+    TemplateTestFramework::with(())
+        .given_no_previous_events()
+        .when(TemplateCommand::CreateNewTemplate {
+            template_id: template_id.clone(),
+            source_template_id: None,
+            title: "Test".to_string(),
+            display: Box::new(None),
+            data_model: DataModel::W3CVcDataModelV2_0,
+            holder_type: HolderType::Individual,
+            tags: None,
+            status: Status::Draft,
+            visibility: Visibility::Private,
+            credential_expiration: None,
+            description: None,
+            r#type: vec![],
+            schema: Box::new(Some(schema.clone())),
+            schema_properties_attributes: Some(attributes.clone()),
+            holder_authorization: Authorization::default(),
+        })
+        .then_expect_events(vec![TemplateEvent::TemplateCreated {
+            template_id,
+            source_template_id: None,
+            title: "Test".to_string(),
+            display: Box::new(None),
+            data_model: DataModel::W3CVcDataModelV2_0,
+            holder_type: HolderType::Individual,
+            modified_at: test_utils::modified_at(),
+            tags: None,
+            status: Status::Draft,
+            visibility: Visibility::Private,
+            credential_expiration: Expiration::default(),
+            description: None,
+            r#type: vec!["VerifiableCredential".to_string()],
+            schema: Box::new(Some(schema)),
+            schema_properties_attributes: Some(attributes),
+            holder_authorization: Authorization::default(),
+        }])
 }

--- a/agent_library/src/template/aggregate_tests.rs
+++ b/agent_library/src/template/aggregate_tests.rs
@@ -1617,7 +1617,11 @@ async fn test_create_open_badges_template_allows_profile_object_on_subject_root(
     });
 
     let mut expected_attrs = HashMap::new();
-    for required_leaf in ["/achievement/name", "/achievement/description", "/achievement/criteria/narrative"] {
+    for required_leaf in [
+        "/achievement/name",
+        "/achievement/description",
+        "/achievement/criteria/narrative",
+    ] {
         expected_attrs.insert(
             required_leaf.to_string(),
             PropertyAttribute {
@@ -1627,7 +1631,12 @@ async fn test_create_open_badges_template_allows_profile_object_on_subject_root(
             },
         );
     }
-    for profile_leaf in ["/profile/givenName", "/profile/familyName", "/profile/email", "/profile/dateOfBirth"] {
+    for profile_leaf in [
+        "/profile/givenName",
+        "/profile/familyName",
+        "/profile/email",
+        "/profile/dateOfBirth",
+    ] {
         expected_attrs.insert(
             profile_leaf.to_string(),
             PropertyAttribute {

--- a/agent_library/src/template/aggregate_tests.rs
+++ b/agent_library/src/template/aggregate_tests.rs
@@ -1587,7 +1587,9 @@ async fn test_create_open_badges_template_succeeds_with_required_properties(temp
 #[serial_test::serial]
 async fn test_create_open_badges_template_allows_profile_object_on_subject_root(template_id: String) {
     // `AchievementSubject` declares `additionalProperties: true`, so UniCore permits a `profile`
-    // object on the subject root carrying the recipient's OB 3.0 `Profile` fields.
+    // object on the subject root carrying the recipient's OB 3.0 `Profile` fields. UniCore
+    // constrains it to exactly `givenName`/`familyName`/`email`/`dateOfBirth` with enforced types
+    // (all strings; `email` → `format: email`, `dateOfBirth` → `format: date`).
     let schema = serde_json::json!({
         "type": "object",
         "properties": {
@@ -1596,7 +1598,7 @@ async fn test_create_open_badges_template_allows_profile_object_on_subject_root(
                 "properties": {
                     "givenName": { "type": "string" },
                     "familyName": { "type": "string" },
-                    "email": { "type": "string" },
+                    "email": { "type": "string", "format": "email" },
                     "dateOfBirth": { "type": "string", "format": "date" }
                 }
             },
@@ -1656,7 +1658,7 @@ async fn test_create_open_badges_template_allows_profile_object_on_subject_root(
                 "properties": {
                     "givenName": { "type": "string" },
                     "familyName": { "type": "string" },
-                    "email": { "type": "string" },
+                    "email": { "type": "string", "format": "email" },
                     "dateOfBirth": { "type": "string", "format": "date" }
                 }
             },
@@ -1715,6 +1717,142 @@ async fn test_create_open_badges_template_allows_profile_object_on_subject_root(
             schema_properties_attributes: Some(expected_attrs),
             holder_authorization: Authorization::default(),
         }])
+}
+
+/// Reusable valid `achievement` block so profile-focused negative tests fail on the profile,
+/// not on missing required achievement fields.
+fn valid_ob_achievement() -> serde_json::Value {
+    serde_json::json!({
+        "type": "object",
+        "properties": {
+            "name": { "type": "string" },
+            "description": { "type": "string" },
+            "criteria": {
+                "type": "object",
+                "properties": {
+                    "narrative": { "type": "string" }
+                }
+            }
+        }
+    })
+}
+
+#[rstest]
+#[serial_test::serial]
+async fn test_create_open_badges_template_rejects_unknown_profile_property(template_id: String) {
+    // The `profile` object is constrained to the four supported fields; anything else is rejected.
+    let schema = serde_json::json!({
+        "type": "object",
+        "properties": {
+            "profile": {
+                "type": "object",
+                "properties": {
+                    "givenName": { "type": "string" },
+                    "phoneNumber": { "type": "string" }
+                }
+            },
+            "achievement": valid_ob_achievement()
+        }
+    });
+
+    TemplateTestFramework::with(())
+        .given_no_previous_events()
+        .when(TemplateCommand::CreateNewTemplate {
+            template_id,
+            source_template_id: None,
+            title: "Test".to_string(),
+            display: Box::new(None),
+            data_model: DataModel::OpenBadges3_0,
+            holder_type: HolderType::Individual,
+            tags: None,
+            status: Status::Draft,
+            visibility: Visibility::Private,
+            credential_expiration: None,
+            description: None,
+            r#type: vec![],
+            schema: Box::new(Some(schema)),
+            schema_properties_attributes: None,
+            holder_authorization: Authorization::default(),
+        })
+        .then_expect_error_message("Disallowed OpenBadges 3.0 schema properties: The following properties are not allowed for OpenBadges 3.0 templates at path `/profile`: [phoneNumber]")
+}
+
+#[rstest]
+#[serial_test::serial]
+async fn test_create_open_badges_template_rejects_profile_field_wrong_type(template_id: String) {
+    // Profile fields must be strings; a non-string type is rejected.
+    let schema = serde_json::json!({
+        "type": "object",
+        "properties": {
+            "profile": {
+                "type": "object",
+                "properties": {
+                    "givenName": { "type": "number" }
+                }
+            },
+            "achievement": valid_ob_achievement()
+        }
+    });
+
+    TemplateTestFramework::with(())
+        .given_no_previous_events()
+        .when(TemplateCommand::CreateNewTemplate {
+            template_id,
+            source_template_id: None,
+            title: "Test".to_string(),
+            display: Box::new(None),
+            data_model: DataModel::OpenBadges3_0,
+            holder_type: HolderType::Individual,
+            tags: None,
+            status: Status::Draft,
+            visibility: Visibility::Private,
+            credential_expiration: None,
+            description: None,
+            r#type: vec![],
+            schema: Box::new(Some(schema)),
+            schema_properties_attributes: None,
+            holder_authorization: Authorization::default(),
+        })
+        .then_expect_error_message("Invalid type or format for OpenBadges 3.0 schema properties: The following fields do not match the required type/format: [/profile/givenName]")
+}
+
+#[rstest]
+#[serial_test::serial]
+async fn test_create_open_badges_template_rejects_profile_email_without_format(template_id: String) {
+    // `email` must carry `format: "email"`; a plain string is rejected.
+    let schema = serde_json::json!({
+        "type": "object",
+        "properties": {
+            "profile": {
+                "type": "object",
+                "properties": {
+                    "email": { "type": "string" }
+                }
+            },
+            "achievement": valid_ob_achievement()
+        }
+    });
+
+    TemplateTestFramework::with(())
+        .given_no_previous_events()
+        .when(TemplateCommand::CreateNewTemplate {
+            template_id,
+            source_template_id: None,
+            title: "Test".to_string(),
+            display: Box::new(None),
+            data_model: DataModel::OpenBadges3_0,
+            holder_type: HolderType::Individual,
+            tags: None,
+            status: Status::Draft,
+            visibility: Visibility::Private,
+            credential_expiration: None,
+            description: None,
+            r#type: vec![],
+            schema: Box::new(Some(schema)),
+            schema_properties_attributes: None,
+            holder_authorization: Authorization::default(),
+        })
+        .then_expect_error_message("Invalid type or format for OpenBadges 3.0 schema properties: The following fields do not match the required type/format: [/profile/email]")
 }
 
 #[rstest]

--- a/agent_library/src/template/aggregate_tests.rs
+++ b/agent_library/src/template/aggregate_tests.rs
@@ -761,6 +761,7 @@ async fn test_create_template_with_invalid_schema_properties_attributes(template
         PropertyAttribute {
             selectively_disclosable: true,
             non_removable: false,
+            r#type: None,
         },
     );
 
@@ -795,6 +796,7 @@ async fn test_create_template_with_attributes_but_no_schema(template_id: String)
         PropertyAttribute {
             selectively_disclosable: true,
             non_removable: false,
+            r#type: None,
         },
     );
 
@@ -836,6 +838,7 @@ async fn test_create_template_rejects_schema_properties_attributes_for_vc_1_1(te
         PropertyAttribute {
             selectively_disclosable: true,
             non_removable: false,
+            r#type: None,
         },
     );
 
@@ -877,6 +880,7 @@ async fn test_update_field_attributes_with_invalid_keys(template_id: String) {
         PropertyAttribute {
             selectively_disclosable: true,
             non_removable: false,
+            r#type: None,
         },
     );
 
@@ -915,6 +919,7 @@ async fn test_update_field_attributes_with_no_schema(template_id: String) {
         PropertyAttribute {
             selectively_disclosable: true,
             non_removable: false,
+            r#type: None,
         },
     );
 
@@ -960,6 +965,7 @@ async fn test_update_field_attributes_rejected_for_vc_1_1(template_id: String) {
         PropertyAttribute {
             selectively_disclosable: true,
             non_removable: false,
+            r#type: None,
         },
     );
 
@@ -1005,6 +1011,7 @@ async fn test_update_field_attributes_rejects_duplicate_trimmed_keys(template_id
         PropertyAttribute {
             selectively_disclosable: true,
             non_removable: false,
+            r#type: None,
         },
     );
     attrs.insert(
@@ -1012,6 +1019,7 @@ async fn test_update_field_attributes_rejects_duplicate_trimmed_keys(template_id
         PropertyAttribute {
             selectively_disclosable: false,
             non_removable: false,
+            r#type: None,
         },
     );
 
@@ -1058,6 +1066,7 @@ async fn test_update_schema_prunes_attributes(template_id: String) {
         PropertyAttribute {
             selectively_disclosable: true,
             non_removable: false,
+            r#type: None,
         },
     );
     attrs.insert(
@@ -1065,6 +1074,7 @@ async fn test_update_schema_prunes_attributes(template_id: String) {
         PropertyAttribute {
             selectively_disclosable: false,
             non_removable: false,
+            r#type: None,
         },
     );
 
@@ -1081,6 +1091,7 @@ async fn test_update_schema_prunes_attributes(template_id: String) {
         PropertyAttribute {
             selectively_disclosable: true,
             non_removable: false,
+            r#type: None,
         },
     );
 
@@ -1140,6 +1151,7 @@ async fn test_update_schema_no_prune_needed(template_id: String) {
         PropertyAttribute {
             selectively_disclosable: true,
             non_removable: false,
+            r#type: None,
         },
     );
 
@@ -1208,6 +1220,7 @@ async fn test_update_schema_rejects_removal_of_immutable_property(template_id: S
         PropertyAttribute {
             selectively_disclosable: false,
             non_removable: true,
+            r#type: None,
         },
     );
     attrs.insert(
@@ -1215,6 +1228,7 @@ async fn test_update_schema_rejects_removal_of_immutable_property(template_id: S
         PropertyAttribute {
             selectively_disclosable: false,
             non_removable: false,
+            r#type: None,
         },
     );
 
@@ -1289,6 +1303,7 @@ async fn test_update_schema_allows_removal_of_non_immutable_property(template_id
         PropertyAttribute {
             selectively_disclosable: false,
             non_removable: true,
+            r#type: None,
         },
     );
     attrs.insert(
@@ -1296,6 +1311,7 @@ async fn test_update_schema_allows_removal_of_non_immutable_property(template_id
         PropertyAttribute {
             selectively_disclosable: false,
             non_removable: true,
+            r#type: None,
         },
     );
     attrs.insert(
@@ -1303,6 +1319,7 @@ async fn test_update_schema_allows_removal_of_non_immutable_property(template_id
         PropertyAttribute {
             selectively_disclosable: false,
             non_removable: true,
+            r#type: None,
         },
     );
     attrs.insert(
@@ -1310,6 +1327,7 @@ async fn test_update_schema_allows_removal_of_non_immutable_property(template_id
         PropertyAttribute {
             selectively_disclosable: false,
             non_removable: false,
+            r#type: None,
         },
     );
 
@@ -1339,6 +1357,7 @@ async fn test_update_schema_allows_removal_of_non_immutable_property(template_id
         PropertyAttribute {
             selectively_disclosable: false,
             non_removable: true,
+            r#type: None,
         },
     );
     expected_attrs.insert(
@@ -1346,6 +1365,7 @@ async fn test_update_schema_allows_removal_of_non_immutable_property(template_id
         PropertyAttribute {
             selectively_disclosable: false,
             non_removable: true,
+            r#type: None,
         },
     );
     expected_attrs.insert(
@@ -1353,6 +1373,7 @@ async fn test_update_schema_allows_removal_of_non_immutable_property(template_id
         PropertyAttribute {
             selectively_disclosable: false,
             non_removable: true,
+            r#type: None,
         },
     );
 
@@ -1481,6 +1502,7 @@ async fn test_create_open_badges_template_succeeds_with_required_properties(temp
         PropertyAttribute {
             selectively_disclosable: false,
             non_removable: true,
+            r#type: None,
         },
     );
     expected_attrs.insert(
@@ -1488,6 +1510,7 @@ async fn test_create_open_badges_template_succeeds_with_required_properties(temp
         PropertyAttribute {
             selectively_disclosable: false,
             non_removable: true,
+            r#type: None,
         },
     );
     expected_attrs.insert(
@@ -1495,6 +1518,7 @@ async fn test_create_open_badges_template_succeeds_with_required_properties(temp
         PropertyAttribute {
             selectively_disclosable: false,
             non_removable: true,
+            r#type: None,
         },
     );
 
@@ -1587,6 +1611,7 @@ async fn test_create_open_badges_template_succeeds_with_const_required_propertie
         PropertyAttribute {
             selectively_disclosable: false,
             non_removable: true,
+            r#type: None,
         },
     );
     expected_attrs.insert(
@@ -1594,6 +1619,7 @@ async fn test_create_open_badges_template_succeeds_with_const_required_propertie
         PropertyAttribute {
             selectively_disclosable: false,
             non_removable: true,
+            r#type: None,
         },
     );
     expected_attrs.insert(
@@ -1601,6 +1627,7 @@ async fn test_create_open_badges_template_succeeds_with_const_required_propertie
         PropertyAttribute {
             selectively_disclosable: false,
             non_removable: true,
+            r#type: None,
         },
     );
 
@@ -1681,6 +1708,7 @@ async fn test_update_attributes_cannot_change_immutable_flag(template_id: String
         PropertyAttribute {
             selectively_disclosable: false,
             non_removable: true,
+            r#type: None,
         },
     );
 
@@ -1691,6 +1719,7 @@ async fn test_update_attributes_cannot_change_immutable_flag(template_id: String
         PropertyAttribute {
             selectively_disclosable: true,
             non_removable: false, // User tries to change this
+            r#type: None,
         },
     );
 
@@ -1700,6 +1729,7 @@ async fn test_update_attributes_cannot_change_immutable_flag(template_id: String
         PropertyAttribute {
             selectively_disclosable: true,
             non_removable: true, // System preserves non_removable
+            r#type: None,
         },
     );
 
@@ -1813,6 +1843,7 @@ async fn test_update_schema_rejects_disallowed_open_badges_properties(template_i
         PropertyAttribute {
             selectively_disclosable: false,
             non_removable: true,
+            r#type: None,
         },
     );
     attrs.insert(
@@ -1820,6 +1851,7 @@ async fn test_update_schema_rejects_disallowed_open_badges_properties(template_i
         PropertyAttribute {
             selectively_disclosable: false,
             non_removable: true,
+            r#type: None,
         },
     );
     attrs.insert(
@@ -1827,6 +1859,7 @@ async fn test_update_schema_rejects_disallowed_open_badges_properties(template_i
         PropertyAttribute {
             selectively_disclosable: false,
             non_removable: true,
+            r#type: None,
         },
     );
 
@@ -1920,6 +1953,7 @@ async fn test_create_open_badges_template_allows_valid_optional_properties(templ
             PropertyAttribute {
                 selectively_disclosable: false,
                 non_removable: required_paths.contains(&key.to_string()),
+                r#type: None,
             },
         );
     }
@@ -2027,6 +2061,7 @@ async fn test_create_open_badges_template_preserves_dollar_schema_keyword(templa
             PropertyAttribute {
                 selectively_disclosable: false,
                 non_removable: required_paths.contains(&key.to_string()),
+                r#type: None,
             },
         );
     }
@@ -2186,6 +2221,7 @@ async fn test_create_template_with_nested_schema_and_jp_attribute_key(template_i
         PropertyAttribute {
             selectively_disclosable: true,
             non_removable: false,
+            r#type: None,
         },
     );
     attrs.insert(
@@ -2193,6 +2229,7 @@ async fn test_create_template_with_nested_schema_and_jp_attribute_key(template_i
         PropertyAttribute {
             selectively_disclosable: false,
             non_removable: false,
+            r#type: None,
         },
     );
 
@@ -2271,6 +2308,7 @@ async fn test_create_template_rejects_attribute_key_pointing_to_object_node(temp
         PropertyAttribute {
             selectively_disclosable: true,
             non_removable: false,
+            r#type: None,
         },
     );
 

--- a/agent_library/src/template/aggregate_tests.rs
+++ b/agent_library/src/template/aggregate_tests.rs
@@ -2333,3 +2333,35 @@ async fn test_create_template_rejects_attribute_key_pointing_to_object_node(temp
         })
         .then_expect_error_message("Invalid schema_properties_attributes key(s): The following keys do not match any field in schema.properties: [/address]")
 }
+
+#[rstest]
+fn property_attribute_type_survives_serde_round_trip() {
+    // The `country` field type is not recoverable from standard JSON Schema keywords, so the
+    // frontend persists it out-of-band in `schemaPropertiesAttributes[*].type`. Verify it is
+    // serialized under the `type` key and deserializes back unchanged.
+    let expected = PropertyAttribute {
+        selectively_disclosable: false,
+        non_removable: false,
+        r#type: Some(FormFieldType::Country),
+    };
+
+    let json = serde_json::to_value(&expected).unwrap();
+    assert_eq!(json["type"], serde_json::json!("country"));
+    // An absent `type` must not be emitted, and `non_removable` is not affected.
+    assert_eq!(json.get("nonRemovable"), Some(&serde_json::json!(false)));
+
+    let actual: PropertyAttribute = serde_json::from_value(json).unwrap();
+    assert_eq!(actual, expected);
+
+    // Omitting `type` on the wire deserializes to `None` (backward compatible).
+    let without_type: PropertyAttribute =
+        serde_json::from_value(serde_json::json!({ "selectivelyDisclosable": true })).unwrap();
+    assert_eq!(without_type.r#type, None);
+    assert!(serde_json::to_value(&without_type).unwrap().get("type").is_none());
+
+    // An unrecognized field type is rejected (constrained enum).
+    let should_error = serde_json::from_value::<PropertyAttribute>(
+        serde_json::json!({ "selectivelyDisclosable": false, "type": "not-a-real-type" }),
+    );
+    assert!(should_error.is_err());
+}

--- a/agent_library/src/template/error.rs
+++ b/agent_library/src/template/error.rs
@@ -18,6 +18,8 @@ pub enum TemplateError {
     MissingRequiredOpenBadgesProperties(String),
     #[error("Invalid type for required OpenBadges 3.0 schema properties: {0}")]
     InvalidRequiredPropertyType(String),
+    #[error("Invalid type or format for OpenBadges 3.0 schema properties: {0}")]
+    InvalidOpenBadgesPropertyType(String),
     #[error("A title is required when creating or updating a template")]
     MissingTitle,
     #[error("Archived templates are immutable except for status changes")]

--- a/agent_library/src/template/open_badges.rs
+++ b/agent_library/src/template/open_badges.rs
@@ -102,6 +102,16 @@ fn ob_opinionated_required_by_path() -> &'static [(&'static str, &'static [&'sta
     ]
 }
 
+/// Properties UniCore additionally permits per schema path, beyond the OB 3.0 `$def`.
+///
+/// Allows a `profile` object on the subject root to carry the recipient's OB 3.0 `Profile` data
+/// (givenName, familyName, email, dateOfBirth), all other homes for the recipient's profile seemed unsuitable.
+/// This is valid because `AchievementSubject` declares `"additionalProperties": true`. No `$def` governs
+/// the `profile` object, so its interior is unvalidated.
+fn ob_opinionated_allowed_by_path() -> &'static [(&'static str, &'static [&'static str])] {
+    &[("", &["profile"])]
+}
+
 /// Returns the combined required child keys per schema path: OB 3.0 spec + UniCore extras.
 fn ob_combined_required_by_path() -> std::collections::HashMap<String, Vec<String>> {
     let mut combined = ob_spec_required_by_path();
@@ -234,9 +244,20 @@ fn validate_ob_properties_recursive(
     };
 
     // Determine the set of allowed property names at this level from the current def.
-    let allowed: Option<std::collections::HashSet<&str>> = current_def
+    let mut allowed: Option<std::collections::HashSet<&str>> = current_def
         .and_then(|def| def.get("properties").and_then(|p| p.as_object()))
         .map(|props| props.keys().map(|k| k.as_str()).collect());
+
+    // Merge UniCore's opinionated extra-allowed properties for this path
+    // (see `ob_opinionated_allowed_by_path`).
+    if let Some(ref mut allowed_set) = allowed {
+        if let Some((_, extras)) = ob_opinionated_allowed_by_path()
+            .iter()
+            .find(|(p, _)| *p == current_path)
+        {
+            allowed_set.extend(extras.iter().copied());
+        }
+    }
 
     let mut disallowed: Vec<&str> = Vec::new();
 

--- a/agent_library/src/template/open_badges.rs
+++ b/agent_library/src/template/open_badges.rs
@@ -112,6 +112,11 @@ fn ob_opinionated_required_by_path() -> &'static [(&'static str, &'static [&'sta
 /// types: `givenName`/`familyName`/`email`/`dateOfBirth` are all strings, `email` carries
 /// `format: "email"` and `dateOfBirth` carries `format: "date"`.
 ///
+/// Each entry is an exact pin, not a lower bound: a field whose def declares no `format` must not
+/// carry one either. A caller-supplied format on `givenName`/`familyName` is therefore rejected —
+/// UniCore decides what these fields mean, and an unvetted `format` would let callers constrain
+/// them in ways UniCore never agreed to (e.g. `format: "email"` on `givenName`).
+///
 /// This is the single source of truth for both the allowed property set (its presence adds
 /// `profile` to the subject root's allowed keys, see [`validate_ob_properties_recursive`]) and
 /// the interior name/type validation ([`validate_ob_opinionated_types`]).
@@ -144,16 +149,23 @@ fn split_parent_path(path: &str) -> (&str, &str) {
     }
 }
 
+/// Navigates through `properties` segments to the schema node at `path`, i.e. the node that
+/// declares the `type` of the field itself, not its children. Returns `None` if the path is
+/// absent from the schema.
+fn node_at_path<'a>(schema: &'a serde_json::Value, path: &str) -> Option<&'a serde_json::Value> {
+    let mut current = schema;
+    for seg in path.split('/').filter(|s| !s.is_empty()) {
+        current = current.get("properties")?.as_object()?.get(seg)?;
+    }
+    Some(current)
+}
+
 /// Navigates through `properties` segments to the properties map at `path`.
 fn props_at_path<'a>(
     schema: &'a serde_json::Value,
     path: &str,
 ) -> Option<&'a serde_json::Map<String, serde_json::Value>> {
-    let mut current = schema.get("properties")?.as_object()?;
-    for seg in path.split('/').filter(|s| !s.is_empty()) {
-        current = current.get(seg)?.get("properties")?.as_object()?;
-    }
-    Some(current)
+    node_at_path(schema, path)?.get("properties")?.as_object()
 }
 
 /// Returns the combined required child keys per schema path: OB 3.0 spec + UniCore extras.
@@ -277,15 +289,34 @@ pub(crate) fn validate_open_badges_schema_properties(schema: &serde_json::Value)
     validate_ob_opinionated_types(schema)
 }
 
+/// Reports whether a schema node matches the `type`/`format` a synthetic def declares.
+/// Both are compared exactly: a def that declares no `format` requires the node to have none
+/// either, so callers cannot attach a format UniCore has not sanctioned.
+fn schema_matches_def(actual: &serde_json::Value, expected: &serde_json::Value) -> bool {
+    actual.get("type") == expected.get("type") && actual.get("format") == expected.get("format")
+}
+
 /// Enforces the declared `type`/`format` of UniCore-opinionated fields (e.g. the recipient
-/// `profile` object) that OB 3.0 leaves unvalidated. Each field that is present must match the
-/// synthetic def in [`ob_opinionated_defs`] exactly; absent (optional) fields are skipped.
+/// `profile` object) that OB 3.0 leaves unvalidated. Each node that is present must match the
+/// synthetic def in [`ob_opinionated_defs`]; absent (optional) nodes and fields are skipped.
+///
+/// The node at an opinionated path is checked before its children, so a `profile` declared as
+/// anything other than an object is rejected rather than silently skipped for lack of children.
 fn validate_ob_opinionated_types(schema: &serde_json::Value) -> Result<(), TemplateError> {
     let mut mismatched: Vec<String> = Vec::new();
 
     for (path, def) in ob_opinionated_defs() {
+        let Some(node) = node_at_path(schema, path) else {
+            continue; // Optional node — absence is fine; only the shape is constrained.
+        };
+
+        if !schema_matches_def(node, def) {
+            mismatched.push(format!("/{path}"));
+            continue; // Not the declared shape — its children are not meaningful to check.
+        }
+
         let (Some(actual), Some(expected)) = (
-            props_at_path(schema, path),
+            node.get("properties").and_then(|p| p.as_object()),
             def.get("properties").and_then(|p| p.as_object()),
         ) else {
             continue;
@@ -295,9 +326,7 @@ fn validate_ob_opinionated_types(schema: &serde_json::Value) -> Result<(), Templ
             let Some(actual_schema) = actual.get(field) else {
                 continue; // Optional field — absence is fine; only the shape is constrained.
             };
-            let type_matches = actual_schema.get("type") == expected_schema.get("type");
-            let format_matches = actual_schema.get("format") == expected_schema.get("format");
-            if !type_matches || !format_matches {
+            if !schema_matches_def(actual_schema, expected_schema) {
                 mismatched.push(format!("/{path}/{field}"));
             }
         }

--- a/agent_library/src/template/open_badges.rs
+++ b/agent_library/src/template/open_badges.rs
@@ -102,14 +102,58 @@ fn ob_opinionated_required_by_path() -> &'static [(&'static str, &'static [&'sta
     ]
 }
 
-/// Properties UniCore additionally permits per schema path, beyond the OB 3.0 `$def`.
+/// UniCore-opinionated synthetic `$def`s keyed by schema path, for object paths that OB 3.0
+/// itself leaves unvalidated.
 ///
-/// Allows a `profile` object on the subject root to carry the recipient's OB 3.0 `Profile` data
-/// (givenName, familyName, email, dateOfBirth), all other homes for the recipient's profile seemed unsuitable.
-/// This is valid because `AchievementSubject` declares `"additionalProperties": true`. No `$def` governs
-/// the `profile` object, so its interior is unvalidated.
-fn ob_opinionated_allowed_by_path() -> &'static [(&'static str, &'static [&'static str])] {
-    &[("", &["profile"])]
+/// `AchievementSubject` declares `"additionalProperties": true`, so a `profile` object is
+/// permitted on the subject root to carry the recipient's OB 3.0 `Profile` data — all other
+/// homes for the recipient's profile seemed unsuitable. No spec `$def` governs it, so instead
+/// of leaving its interior open, UniCore constrains it to exactly these four fields with enforced
+/// types: `givenName`/`familyName`/`email`/`dateOfBirth` are all strings, `email` carries
+/// `format: "email"` and `dateOfBirth` carries `format: "date"`.
+///
+/// This is the single source of truth for both the allowed property set (its presence adds
+/// `profile` to the subject root's allowed keys, see [`validate_ob_properties_recursive`]) and
+/// the interior name/type validation ([`validate_ob_opinionated_types`]).
+fn ob_opinionated_defs() -> &'static std::collections::HashMap<String, serde_json::Value> {
+    static DEFS: std::sync::OnceLock<std::collections::HashMap<String, serde_json::Value>> = std::sync::OnceLock::new();
+    DEFS.get_or_init(|| {
+        let mut defs = std::collections::HashMap::new();
+        defs.insert(
+            "profile".to_string(),
+            serde_json::json!({
+                "type": "object",
+                "properties": {
+                    "givenName": { "type": "string" },
+                    "familyName": { "type": "string" },
+                    "email": { "type": "string", "format": "email" },
+                    "dateOfBirth": { "type": "string", "format": "date" }
+                }
+            }),
+        );
+        defs
+    })
+}
+
+/// Splits a schema path into its parent path and final segment, e.g. `"profile"` → `("", "profile")`
+/// and `"profile/address"` → `("profile", "address")`.
+fn split_parent_path(path: &str) -> (&str, &str) {
+    match path.rfind('/') {
+        Some(i) => (&path[..i], &path[i + 1..]),
+        None => ("", path),
+    }
+}
+
+/// Navigates through `properties` segments to the properties map at `path`.
+fn props_at_path<'a>(
+    schema: &'a serde_json::Value,
+    path: &str,
+) -> Option<&'a serde_json::Map<String, serde_json::Value>> {
+    let mut current = schema.get("properties")?.as_object()?;
+    for seg in path.split('/').filter(|s| !s.is_empty()) {
+        current = current.get(seg)?.get("properties")?.as_object()?;
+    }
+    Some(current)
 }
 
 /// Returns the combined required child keys per schema path: OB 3.0 spec + UniCore extras.
@@ -229,7 +273,44 @@ pub(crate) fn validate_open_badges_schema_properties(schema: &serde_json::Value)
         None => return Ok(()), // Cannot validate without defs; pass through.
     };
     let root_def = defs.get("AchievementSubject");
-    validate_ob_properties_recursive(schema, "", root_def, defs)
+    validate_ob_properties_recursive(schema, "", root_def, defs)?;
+    validate_ob_opinionated_types(schema)
+}
+
+/// Enforces the declared `type`/`format` of UniCore-opinionated fields (e.g. the recipient
+/// `profile` object) that OB 3.0 leaves unvalidated. Each field that is present must match the
+/// synthetic def in [`ob_opinionated_defs`] exactly; absent (optional) fields are skipped.
+fn validate_ob_opinionated_types(schema: &serde_json::Value) -> Result<(), TemplateError> {
+    let mut mismatched: Vec<String> = Vec::new();
+
+    for (path, def) in ob_opinionated_defs() {
+        let (Some(actual), Some(expected)) = (
+            props_at_path(schema, path),
+            def.get("properties").and_then(|p| p.as_object()),
+        ) else {
+            continue;
+        };
+
+        for (field, expected_schema) in expected {
+            let Some(actual_schema) = actual.get(field) else {
+                continue; // Optional field — absence is fine; only the shape is constrained.
+            };
+            let type_matches = actual_schema.get("type") == expected_schema.get("type");
+            let format_matches = actual_schema.get("format") == expected_schema.get("format");
+            if !type_matches || !format_matches {
+                mismatched.push(format!("/{path}/{field}"));
+            }
+        }
+    }
+
+    if !mismatched.is_empty() {
+        mismatched.sort();
+        return Err(TemplateError::InvalidOpenBadgesPropertyType(format!(
+            "The following fields do not match the required type/format: [{}]",
+            mismatched.join(", ")
+        )));
+    }
+    Ok(())
 }
 
 fn validate_ob_properties_recursive(
@@ -248,14 +329,14 @@ fn validate_ob_properties_recursive(
         .and_then(|def| def.get("properties").and_then(|p| p.as_object()))
         .map(|props| props.keys().map(|k| k.as_str()).collect());
 
-    // Merge UniCore's opinionated extra-allowed properties for this path
-    // (see `ob_opinionated_allowed_by_path`).
+    // Merge in UniCore's opinionated synthetic defs that live directly under this path
+    // (e.g. `profile` under the root), so they are permitted alongside the spec properties.
     if let Some(ref mut allowed_set) = allowed {
-        if let Some((_, extras)) = ob_opinionated_allowed_by_path()
-            .iter()
-            .find(|(p, _)| *p == current_path)
-        {
-            allowed_set.extend(extras.iter().copied());
+        for opinionated_path in ob_opinionated_defs().keys() {
+            let (parent, key) = split_parent_path(opinionated_path);
+            if parent == current_path {
+                allowed_set.insert(key);
+            }
         }
     }
 
@@ -274,13 +355,16 @@ fn validate_ob_properties_recursive(
             format!("{}/{}", current_path, key)
         };
 
-        // Resolve the child def by following the $ref in the current def's properties.
+        // Resolve the child def by following the $ref in the current def's properties, falling
+        // back to a UniCore-opinionated synthetic def (e.g. `profile`) where the spec has none.
+        // This restricts the interior of opinionated objects to their declared property set.
         let child_def = current_def
             .and_then(|def| def.get("properties").and_then(|p| p.as_object()))
             .and_then(|props| props.get(key.as_str()))
             .and_then(|prop_schema| prop_schema.get("$ref").and_then(|r| r.as_str()))
             .and_then(|r| r.strip_prefix("#/$defs/"))
-            .and_then(|def_name| defs.get(def_name));
+            .and_then(|def_name| defs.get(def_name))
+            .or_else(|| ob_opinionated_defs().get(&child_path));
 
         validate_ob_properties_recursive(value, &child_path, child_def, defs)?;
     }
@@ -302,18 +386,6 @@ fn validate_ob_properties_recursive(
 /// Required fields are derived from `ob_combined_required_by_path()` so this function
 /// automatically reflects any changes to the spec JSON file or the opinionated extras list.
 pub(crate) fn validate_open_badges_required_properties(schema: &serde_json::Value) -> Result<(), TemplateError> {
-    // Navigate through `properties` segments to the properties map at `path`.
-    fn props_at_path<'a>(
-        schema: &'a serde_json::Value,
-        path: &str,
-    ) -> Option<&'a serde_json::Map<String, serde_json::Value>> {
-        let mut current = schema.get("properties")?.as_object()?;
-        for seg in path.split('/').filter(|s| !s.is_empty()) {
-            current = current.get(seg)?.get("properties")?.as_object()?;
-        }
-        Some(current)
-    }
-
     let combined = ob_combined_required_by_path();
     let required_reachable = ob_required_reachable_paths(&combined);
     let leaf_paths: std::collections::HashSet<String> = open_badges_required_leaf_paths().into_iter().collect();

--- a/agent_library/src/template/open_badges.rs
+++ b/agent_library/src/template/open_badges.rs
@@ -106,7 +106,7 @@ fn ob_opinionated_required_by_path() -> &'static [(&'static str, &'static [&'sta
 /// itself leaves unvalidated.
 ///
 /// `AchievementSubject` declares `"additionalProperties": true`, so a `profile` object is
-/// permitted on the subject root to carry the recipient's OB 3.0 `Profile` data — all other
+/// permitted on the subject root to carry the recipient's OB 3.0 `Profile` data - all other
 /// homes for the recipient's profile seemed unsuitable. No spec `$def` governs it, so instead
 /// of leaving its interior open, UniCore constrains it to exactly these four fields with enforced
 /// types: `givenName`/`familyName`/`email`/`dateOfBirth` are all strings, `email` carries

--- a/agent_library/src/template/open_badges.rs
+++ b/agent_library/src/template/open_badges.rs
@@ -143,21 +143,16 @@ fn ob_opinionated_defs() -> &'static std::collections::HashMap<String, serde_jso
 /// Splits a schema path into its parent path and final segment, e.g. `"profile"` → `("", "profile")`
 /// and `"profile/address"` → `("profile", "address")`.
 fn split_parent_path(path: &str) -> (&str, &str) {
-    match path.rfind('/') {
-        Some(i) => (&path[..i], &path[i + 1..]),
-        None => ("", path),
-    }
+    path.rsplit_once("/").unwrap_or(("", path))
 }
 
 /// Navigates through `properties` segments to the schema node at `path`, i.e. the node that
 /// declares the `type` of the field itself, not its children. Returns `None` if the path is
 /// absent from the schema.
 fn node_at_path<'a>(schema: &'a serde_json::Value, path: &str) -> Option<&'a serde_json::Value> {
-    let mut current = schema;
-    for seg in path.split('/').filter(|s| !s.is_empty()) {
-        current = current.get("properties")?.as_object()?.get(seg)?;
-    }
-    Some(current)
+    path.is_empty()
+        .then_some(schema)
+        .or_else(|| schema.pointer(&format!("/properties/{}", path.replace('/', "/properties/"))))
 }
 
 /// Navigates through `properties` segments to the properties map at `path`.

--- a/docs/problem-details/library.md
+++ b/docs/problem-details/library.md
@@ -60,6 +60,10 @@ This error occurs when a template expiration value is malformed or unsupported.
 
 This error occurs when the template `type` content is invalid for the selected data model or constraints.
 
+## Invalid Open Badges Property Type
+
+This error occurs when an OpenBadges 3.0 template schema contains a property with an unsupported type.
+
 ## Invalid Status On Create
 
 This error occurs when a new template is created with a disallowed initial status.
@@ -76,16 +80,16 @@ This error occurs when `schemaPropertiesAttributes` contains duplicate keys afte
 
 This error occurs when a template in `Draft` stage is made public.
 
-# Catalogs 
+# Catalogs
 
-## Catalog Template Not Found 
+## Catalog Template Not Found
 
-A requested template was not found. 
+A requested template was not found.
 
 ## Missing Catalog Name
 
-This error occurs when a catalog does not have a name. Name is a required field in catalogs. 
+This error occurs when a catalog does not have a name. Name is a required field in catalogs.
 
 ## Catalog Not Found
 
-This error occurs when a catalog could not be found. 
+This error occurs when a catalog could not be found.


### PR DESCRIPTION
# Description of change

- Template creators can store types for additional UI information which are not natively supported by JSON Schema.
In this PR, the custom type `country` is introduced, which can be used to hint to the UI to render country flags instead of 2-digit ISO codes.
- Open Badge templates supporting storing a `profile` object in the `AchievementSubject`. This is not officially defined, but allowed through by "extending with additional properties". Other places that specify a `Profile` were not suitable for the recipient's information.

## Links to any relevant issues
Be sure to reference any related issues by adding `fixes issue #`.

## How the change has been tested
Describe the tests that you ran to verify your changes.
Make sure to provide instructions for the maintainer as well as any relevant configurations.

## Definition of Done checklist
Add an `x` to the boxes that are relevant to your changes.

- [x] I have followed the contribution guidelines for this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] I have successfully tested this change in a docker environment 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Templates created with field type hints now preserve the `country` metadata in `schemaPropertiesAttributes` when retrieved.
  * Enhanced Open Badges 3.0 `profile` handling with stricter validation of supported subfields, including required `type`/`format` constraints.
* **Bug Fixes**
  * Unsupported Open Badges property type hints now return a clearer `400 Bad Request` response.
* **Documentation**
  * Added documentation for the “Invalid Open Badges Property Type” error and cleaned up related catalog error formatting.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->