### PR TITLE
fix(test): use `CARGO_MANIFEST_DIR` for test config & stronghold paths

### DIFF
--- a/agent_secret_manager/src/lib.rs
+++ b/agent_secret_manager/src/lib.rs
@@ -23,7 +23,18 @@ pub async fn stronghold_storage() -> StrongholdExtStorage {
     info!("Initializing Stronghold storage");
 
     let stronghold_password = config().secret_manager.stronghold_password.clone();
-    let stronghold_path = config().secret_manager.stronghold_path.clone();
+    let mut stronghold_path = config().secret_manager.stronghold_path.clone();
+
+    #[cfg(feature = "test_utils")]
+    {
+        // Manifest-relative test stronghold path ensures tests find the test keys
+        // regardless of the current working directory across workspaces.
+        // See `docs/adr/0003-hermetic-test-architecture-and-config-decoupling.md` for context.
+        let manifest_relative = concat!(env!("CARGO_MANIFEST_DIR"), "/tests/res/test.stronghold.dat");
+        if std::path::Path::new(manifest_relative).exists() {
+            stronghold_path = manifest_relative.to_string();
+        }
+    }
 
     info!("Stronghold path: {stronghold_path}");
 

--- a/agent_shared/src/config/provisioned.rs
+++ b/agent_shared/src/config/provisioned.rs
@@ -6,7 +6,10 @@ pub fn load_provisioned_config() -> Result<config::Config, config::ConfigError> 
 
     let config_file_path_str = std::env::var("UNICORE__CONFIG_FILE").unwrap_or_else(|_| {
         if cfg!(feature = "test_utils") {
-            "../agent_shared/tests/test.config.yaml".to_string()
+            // Uses compile-time CARGO_MANIFEST_DIR to ensure tests locate test.config.yaml
+            // regardless of the working directory across workspaces.
+            // See `docs/adr/0003-hermetic-test-architecture-and-config-decoupling.md` for context.
+            concat!(env!("CARGO_MANIFEST_DIR"), "/tests/test.config.yaml").to_string()
         } else {
             "./config.yaml".to_string()
         }

--- a/docs/adr/0003-hermetic-test-architecture-and-config-decoupling.md
+++ b/docs/adr/0003-hermetic-test-architecture-and-config-decoupling.md
@@ -1,0 +1,42 @@
+# ADR 0003: Hermetic Test Architecture and Configuration Decoupling
+
+**Status**: Accepted  
+**Date**: 2026-07-30  
+**Context**: Establishing guidelines for hermetic, thread-safe unit and integration testing without global static state or CWD-dependent file I/O.
+
+---
+
+## Context
+
+The application test suite previously relied heavily on global static configuration (`agent_shared::config::CONFIG`) and disk-based test fixtures (`test.config.yaml` and `test.stronghold.dat`).
+
+This created several operational and architectural challenges:
+
+1. **Working Directory Sensitivity**: Test configurations and secret manager binaries relied on relative paths (e.g. `../agent_shared/tests/test.config.yaml` and `../agent_secret_manager/tests/res/test.stronghold.dat`). When running tests from outer workspace roots or nested bounded contexts, the current working directory (CWD) differed, causing file lookup failures (`Config file not found: ./config.yaml`).
+2. **Static Cell Poisoning**: Initializing `CONFIG` via `once_cell::sync::Lazy` would panic if environment variables or default config files were missing. Once a `Lazy` initializer panics, `once_cell` poisons the static instance, causing every subsequent test in the process that accesses `config()` to panic with `Lazy instance has previously been poisoned`.
+3. **Parallel Test Race Conditions**: Concurrent test threads calling `Subject::test_subject().await` ran against a shared `./stronghold.dat` file on disk. This led to file lock contention and password mismatch panics (`InvalidPassword`).
+4. **Coupling Application Logic to Infrastructure**: Unit tests for application-layer components (such as `PublicVerificationContextBuilder`) implicitly invoked `Subject::test_subject().await`, forcing pure domain/application unit tests to perform crypto disk I/O and configuration parsing.
+
+---
+
+## Decision
+
+We have established the following standards and path resolution rules for the codebase:
+
+### 1. Compile-Time Manifest Path Resolution (Short-Term Compatibility)
+Where test fixtures or configuration files must be referenced from source, paths must be resolved at compile-time using `concat!(env!("CARGO_MANIFEST_DIR"), ...)` rather than CWD-relative strings (`../...`). This guarantees that tests resolve identical file paths whether executed from `ssi-agent`, outer workspace roots, or any subcrate directory.
+
+### 2. Hermetic & In-Memory Unit Testing (Target Architecture)
+- **Unit tests** must operate strictly in memory using mock/fake adapters (e.g., `InMemoryStore`, `MockSubject`) and must not perform disk I/O or trigger global configuration loading.
+- Unit tests for builders and application services must test validation and logic branches directly without instantiating heavy infrastructure components.
+
+### 3. Explicit Dependency Injection
+- Domain and application services should accept configuration explicitly rather than calling global static getters like `agent_shared::config::config()`.
+
+---
+
+## Rationale
+
+- **Robustness**: Prevents test suite failures caused by static `once_cell` poisoning and CWD changes across workspaces.
+- **Speed & Parallelism**: Eliminates disk contention, allowing tests to run in parallel without file locks or password collisions.
+- **Clean Layering**: Maintains a clear boundary between pure domain/application logic and infrastructure/I/O concerns.


### PR DESCRIPTION
# Description of change
Uses `CARGO_MANIFEST_DIR` to resolve `test.config.yaml` and `test.stronghold.dat` paths at compile time. This fixes test lookup failures when running unit tests from outer workspace roots or nested subcrates where current working directories differ. Also added ADR 0003 documenting test path resolution standards.

## Links to any relevant issues
N/A

## How the change has been tested
- Ran unit & integration tests from `_core/ssi-agent` root (`UNICORE__PROFILE=development cargo test --all`).
- Ran unit tests from outer workspace

## Definition of Done checklist
Add an `x` to the boxes that are relevant to your changes.

- [x] I have followed the contribution guidelines for this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] I have successfully tested this change in a docker environment


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved test reliability by resolving test configuration and secret-storage fixtures from stable project paths rather than the current working directory.

* **Documentation**
  * Added guidance for hermetic, thread-safe tests, including in-memory testing, explicit configuration, dependency injection, and avoiding shared disk fixtures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->