### PR TITLE
ci: run clippy on default features

### DIFF
--- a/.github/workflows/format-lint-test.yaml
+++ b/.github/workflows/format-lint-test.yaml
@@ -29,7 +29,10 @@ jobs:
       - name: Format
         run: cargo fmt --all -- --check
 
-      - name: Lint
+      - name: Lint (Default features)
+        run: cargo clippy --all -- -D warnings
+
+      - name: Lint (All features)
         run: cargo clippy --all-targets --all-features -- -D warnings
 
       - name: Test (Default features)

--- a/.github/workflows/format-lint-test.yaml
+++ b/.github/workflows/format-lint-test.yaml
@@ -30,10 +30,10 @@ jobs:
         run: cargo fmt --all -- --check
 
       - name: Lint (Default features)
-        run: cargo clippy --all -- -D warnings
+        run: cargo clippy --workspace -- -D warnings
 
       - name: Lint (All features)
-        run: cargo clippy --all-targets --all-features -- -D warnings
+        run: cargo clippy --workspace --all-targets --all-features -- -D warnings
 
       - name: Test (Default features)
         run: cargo test --workspace

--- a/agent_secret_manager/src/lib.rs
+++ b/agent_secret_manager/src/lib.rs
@@ -23,18 +23,21 @@ pub async fn stronghold_storage() -> StrongholdExtStorage {
     info!("Initializing Stronghold storage");
 
     let stronghold_password = config().secret_manager.stronghold_password.clone();
-    let mut stronghold_path = config().secret_manager.stronghold_path.clone();
-
     #[cfg(feature = "test_utils")]
-    {
+    let stronghold_path = {
         // Manifest-relative test stronghold path ensures tests find the test keys
         // regardless of the current working directory across workspaces.
         // See `docs/adr/0003-hermetic-test-architecture-and-config-decoupling.md` for context.
         let manifest_relative = concat!(env!("CARGO_MANIFEST_DIR"), "/tests/res/test.stronghold.dat");
         if std::path::Path::new(manifest_relative).exists() {
-            stronghold_path = manifest_relative.to_string();
+            manifest_relative.to_string()
+        } else {
+            config().secret_manager.stronghold_path.clone()
         }
-    }
+    };
+
+    #[cfg(not(feature = "test_utils"))]
+    let stronghold_path = config().secret_manager.stronghold_path.clone();
 
     info!("Stronghold path: {stronghold_path}");
 


### PR DESCRIPTION
# Description of change
Adds a `cargo clippy --workspace -- -D warnings` step to `.github/workflows/format-lint-test.yaml`.

## Links to any relevant issues
Be sure to reference any related issues by adding `fixes issue #`.

## How the change has been tested
Describe the tests that you ran to verify your changes.
Make sure to provide instructions for the maintainer as well as any relevant configurations.

## Definition of Done checklist
Add an `x` to the boxes that are relevant to your changes.

- [ ] I have followed the contribution guidelines for this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] I have successfully tested this change in a docker environment 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Stronghold path selection in test environments, with a reliable fallback to the configured path when test assets are unavailable.

* **Tests**
  * Updated CI linting to run Clippy in two stages: one for default features and another for all targets and all features.
  * Lint warnings are treated as errors in both stages to strengthen build validation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->