### PR TITLE
feat: expose public templates without authentication

### DIFF
--- a/agent_api_http/openapi-generated.yaml
+++ b/agent_api_http/openapi-generated.yaml
@@ -9,6 +9,22 @@ servers:
 - url: http://localhost:3033
   description: Local development
 paths:
+  /public/templates:
+    get:
+      tags:
+      - Public
+      summary: List all public templates
+      description: Lists every template that is publicly visible and published. No authentication is required.
+      operationId: get_public_templates
+      responses:
+        '200':
+          description: All public templates retrieved successfully
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/PublicTemplate'
   /v0/add-templates-to-catalog:
     post:
       tags:
@@ -1809,6 +1825,60 @@ components:
           - Inactive
         templateId:
           type: string
+    PublicTemplate:
+      type: object
+      description: |-
+        Data transfer object for publicly available Templates.
+
+        A reduced projection of a template, carrying only what is needed to understand and render it.
+        Templates carry no public identifier: a reader that imports one assigns its own, and can refer
+        to an entry by its position in the returned array in the meantime.
+      required:
+      - title
+      - dataModel
+      - holderType
+      - type
+      - credentialExpiration
+      properties:
+        credentialExpiration:
+          $ref: '#/components/schemas/Expiration'
+        dataModel:
+          $ref: '#/components/schemas/DataModel'
+        description:
+          type:
+          - string
+          - 'null'
+        display:
+          oneOf:
+          - type: 'null'
+          - $ref: '#/components/schemas/Display'
+        holderType:
+          $ref: '#/components/schemas/HolderType'
+        modifiedAt:
+          type:
+          - string
+          - 'null'
+        schema: {}
+        schemaPropertiesAttributes:
+          type:
+          - object
+          - 'null'
+          additionalProperties:
+            $ref: '#/components/schemas/PropertyAttribute'
+          propertyNames:
+            type: string
+        tags:
+          type:
+          - array
+          - 'null'
+          items:
+            type: string
+        title:
+          type: string
+        type:
+          type: array
+          items:
+            type: string
     RemoveConnectionRequest:
       type: object
       required:
@@ -2093,6 +2163,8 @@ tags:
   description: Create and manage templates which provide the structure for credentials to be issued.
 - name: Catalog
   description: Create and manage catalogs to organize and share your templates.
+- name: Public
+  description: Unauthenticated endpoints exposing publicly available information.
 externalDocs:
   url: https://docs.impierce.com/unicore
   description: Official UniCore documentation

--- a/agent_api_http/openapi-generated.yaml
+++ b/agent_api_http/openapi-generated.yaml
@@ -1827,12 +1827,6 @@ components:
           type: string
     PublicTemplate:
       type: object
-      description: |-
-        Data transfer object for publicly available Templates.
-
-        A reduced projection of a template, carrying only what is needed to understand and render it.
-        Templates carry no public identifier: a reader that imports one assigns its own, and can refer
-        to an entry by its position in the returned array in the meantime.
       required:
       - title
       - dataModel

--- a/agent_api_http/openapi-generated.yaml
+++ b/agent_api_http/openapi-generated.yaml
@@ -2158,7 +2158,7 @@ tags:
 - name: Catalog
   description: Create and manage catalogs to organize and share your templates.
 - name: Public
-  description: Unauthenticated endpoints exposing publicly available information.
+  description: Endpoints that are publicly reachable without authentication, used to expose publicly available information or communicate with external systems.
 externalDocs:
   url: https://docs.impierce.com/unicore
   description: Official UniCore documentation

--- a/agent_api_http/src/lib.rs
+++ b/agent_api_http/src/lib.rs
@@ -84,7 +84,7 @@ where
         )
         .merge(holder_state.map(v0::holder::router).unwrap_or_default())
         .merge(verification_state.map(v0::verification::router).unwrap_or_default())
-        .merge(public::router())
+        .merge(public::router(library_state))
         .layer(middleware::from_fn_with_state(actor_extractor, extract_actor::<E>))
         // Trace layers
         .layer(

--- a/agent_api_http/src/public/mod.rs
+++ b/agent_api_http/src/public/mod.rs
@@ -1,13 +1,30 @@
+use agent_library::state::LibraryState;
 use axum::{routing::get, Router};
+use std::sync::Arc;
 
+pub mod openapi;
 pub mod sponsoring_configuration;
+pub mod templates;
 
-pub fn router() -> Router {
+/// Build the router for the unauthenticated `/public` endpoints.
+///
+/// Routes that need a bounded context's state are only mounted when that state is available.
+pub fn router(library_state: Option<Arc<LibraryState>>) -> Router {
     Router::new().nest(
         "/public",
-        Router::new().route(
-            "/sponsoring-configuration",
-            get(sponsoring_configuration::sponsoring_configuration),
-        ),
+        Router::new()
+            .route(
+                "/sponsoring-configuration",
+                get(sponsoring_configuration::sponsoring_configuration),
+            )
+            .merge(
+                library_state
+                    .map(|library_state| {
+                        Router::new()
+                            .route("/templates", get(templates::get_public_templates))
+                            .with_state(library_state)
+                    })
+                    .unwrap_or_default(),
+            ),
     )
 }

--- a/agent_api_http/src/public/openapi.rs
+++ b/agent_api_http/src/public/openapi.rs
@@ -5,7 +5,7 @@ use utoipa::OpenApi;
 #[openapi(
     paths(get_public_templates),
     tags(
-        (name = "Public", description = "Unauthenticated endpoints exposing publicly available information.")
+        (name = "Public", description = "Endpoints that are publicly reachable without authentication, used to expose publicly available information or communicate with external systems.")
     )
 )]
 pub struct PublicApi;

--- a/agent_api_http/src/public/openapi.rs
+++ b/agent_api_http/src/public/openapi.rs
@@ -1,0 +1,11 @@
+use crate::public::templates::__path_get_public_templates;
+use utoipa::OpenApi;
+
+#[derive(OpenApi)]
+#[openapi(
+    paths(get_public_templates),
+    tags(
+        (name = "Public", description = "Unauthenticated endpoints exposing publicly available information.")
+    )
+)]
+pub struct PublicApi;

--- a/agent_api_http/src/public/templates.rs
+++ b/agent_api_http/src/public/templates.rs
@@ -18,11 +18,12 @@ use std::{collections::HashMap, sync::Arc};
 // well: every template returned here is by definition published and public, so both fields would be
 // constants. `modifiedAt` is kept because, absent a versioning system, it is the only signal a
 // reader has of how fresh a template is.
-/// Data transfer object for publicly available Templates.
-///
-/// A reduced projection of a template, carrying only what is needed to understand and render it.
-/// Templates carry no public identifier: a reader that imports one assigns its own, and can refer
-/// to an entry by its position in the returned array in the meantime.
+//
+// Data transfer object for publicly available Templates.
+//
+// A reduced projection of a template, carrying only what is needed to understand and render it.
+// Templates carry no public identifier: a reader that imports one assigns its own, and can refer
+// to an entry by its position in the returned array in the meantime.
 #[derive(Serialize, Deserialize, utoipa::ToSchema)]
 #[serde(rename_all = "camelCase")]
 #[schema(as = PublicTemplate)]

--- a/agent_api_http/src/public/templates.rs
+++ b/agent_api_http/src/public/templates.rs
@@ -1,0 +1,289 @@
+use crate::handlers::public_query_handler;
+use agent_library::state::LibraryState;
+use agent_library::template::aggregate::{
+    DataModel, Display, Expiration, HolderType, PropertyAttribute, Status, Visibility,
+};
+use axum::{
+    extract::State,
+    response::{IntoResponse, Response},
+    Json,
+};
+use http_api_problem::ApiError;
+use hyper::StatusCode;
+use serde::{Deserialize, Serialize};
+use std::{collections::HashMap, sync::Arc};
+
+// Compared to the internal `TemplateDto` this omits the identifiers (`id` and `sourceTemplateId`)
+// and `holderAuthorization` (issuance-side configuration). `status` and `visibility` are omitted as
+// well: every template returned here is by definition published and public, so both fields would be
+// constants. `modifiedAt` is kept because, absent a versioning system, it is the only signal a
+// reader has of how fresh a template is.
+/// Data transfer object for publicly available Templates.
+///
+/// A reduced projection of a template, carrying only what is needed to understand and render it.
+/// Templates carry no public identifier: a reader that imports one assigns its own, and can refer
+/// to an entry by its position in the returned array in the meantime.
+#[derive(Serialize, Deserialize, utoipa::ToSchema)]
+#[serde(rename_all = "camelCase")]
+#[schema(as = PublicTemplate)]
+pub struct PublicTemplateDto {
+    pub title: String,
+    pub description: Option<String>,
+    pub display: Option<Display>,
+    pub data_model: DataModel,
+    pub holder_type: HolderType,
+    pub r#type: Vec<String>,
+    pub tags: Option<Vec<String>>,
+    pub credential_expiration: Expiration,
+    pub schema: Option<serde_json::Value>,
+    pub schema_properties_attributes: Option<HashMap<String, PropertyAttribute>>,
+    pub modified_at: Option<String>,
+}
+
+impl From<agent_library::template::views::TemplateView> for PublicTemplateDto {
+    fn from(value: agent_library::template::views::TemplateView) -> Self {
+        Self {
+            title: value.title,
+            description: value.description,
+            display: value.display,
+            data_model: value.data_model,
+            holder_type: value.holder_type,
+            r#type: value.r#type,
+            tags: value.tags,
+            credential_expiration: value.credential_expiration,
+            schema: *value.schema,
+            schema_properties_attributes: value.schema_properties_attributes,
+            modified_at: value.modified_at,
+        }
+    }
+}
+
+/// List all public templates
+///
+/// Lists every template that is publicly visible and published. No authentication is required.
+#[utoipa::path(
+    get,
+    path = "/templates",
+    operation_id = "get_public_templates",
+    tags = ["Public"],
+    responses(
+        (status = 200, description = "All public templates retrieved successfully", body = [PublicTemplateDto])
+    )
+)]
+// TODO: Read a dedicated `PublicTemplatesView` here once in-memory views built via event replay
+// exist as a general facility. Deriving from `all_templates` makes every request deserialize the
+// full template set — private and draft ones included — just to discard most of it. See
+// `docs/adr/0004-public-templates-view-derived-at-query-time.md` for why that refactor was deferred
+// and what it entails.
+#[axum_macros::debug_handler]
+pub(crate) async fn get_public_templates(State(state): State<Arc<LibraryState>>) -> Result<Response, ApiError> {
+    let public_templates = public_query_handler("all_templates", &state.query.all_templates)
+        .await?
+        .map(|all_templates_view| {
+            let mut public_templates: Vec<_> = all_templates_view
+                .templates
+                .into_values()
+                .filter(|template| template.visibility == Visibility::Public && template.status == Status::Published)
+                .collect();
+
+            // Sort by most recently modified first (RFC 3339 strings are lexicographically comparable).
+            public_templates.sort_by(|a, b| b.modified_at.cmp(&a.modified_at));
+
+            public_templates
+                .into_iter()
+                .map(PublicTemplateDto::from)
+                .collect::<Vec<PublicTemplateDto>>()
+        })
+        .unwrap_or_default();
+
+    Ok((StatusCode::OK, Json(public_templates)).into_response())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use agent_library::template::views::{all_templates::AllTemplatesView, TemplateView};
+    use agent_store::{in_memory::InMemory, library_state};
+    use axum::body::Body;
+    use cqrs_es::persist::ViewContext;
+    use http::Request;
+    use tower::ServiceExt as _;
+
+    fn template(template_id: &str, status: Status, visibility: Visibility, modified_at: &str) -> TemplateView {
+        TemplateView {
+            template_id: template_id.to_string(),
+            title: format!("Title of {template_id}"),
+            status,
+            visibility,
+            modified_at: Some(modified_at.to_string()),
+            ..Default::default()
+        }
+    }
+
+    /// Seeds the `all_templates` view directly so that each template's status, visibility and
+    /// `modified_at` are fully controlled by the test.
+    async fn app(templates: Vec<TemplateView>) -> axum::Router {
+        let state = Arc::new(library_state(&InMemory, Default::default(), vec![]).await);
+
+        let view = AllTemplatesView {
+            templates: templates
+                .into_iter()
+                .map(|template| (template.template_id.clone(), template))
+                .collect(),
+        };
+        state
+            .query
+            .all_templates
+            .update_view(view, ViewContext::new("all_templates".to_string(), 0))
+            .await
+            .unwrap();
+
+        crate::public::router(Some(state))
+    }
+
+    /// Templates have no public identifier, so tests identify them by their (unique) title.
+    fn titles(body: &serde_json::Value) -> Vec<&str> {
+        body.as_array()
+            .unwrap()
+            .iter()
+            .map(|template| template["title"].as_str().unwrap())
+            .collect()
+    }
+
+    async fn get_public_templates(app: axum::Router) -> (StatusCode, serde_json::Value) {
+        let response = app
+            .oneshot(Request::builder().uri("/public/templates").body(Body::empty()).unwrap())
+            .await
+            .unwrap();
+
+        let status = response.status();
+        let body = axum::body::to_bytes(response.into_body(), usize::MAX).await.unwrap();
+
+        (status, serde_json::from_slice(&body).unwrap())
+    }
+
+    #[tokio::test]
+    async fn returns_only_public_and_published_templates() {
+        let app = app(vec![
+            template(
+                "public-published",
+                Status::Published,
+                Visibility::Public,
+                "2026-01-01T00:00:00Z",
+            ),
+            template(
+                "public-draft",
+                Status::Draft,
+                Visibility::Public,
+                "2026-01-01T00:00:00Z",
+            ),
+            template(
+                "public-archived",
+                Status::Archived,
+                Visibility::Public,
+                "2026-01-01T00:00:00Z",
+            ),
+            template(
+                "public-deleted",
+                Status::Deleted,
+                Visibility::Public,
+                "2026-01-01T00:00:00Z",
+            ),
+            template(
+                "private-published",
+                Status::Published,
+                Visibility::Private,
+                "2026-01-01T00:00:00Z",
+            ),
+        ])
+        .await;
+
+        let (status, body) = get_public_templates(app).await;
+
+        assert_eq!(status, StatusCode::OK);
+        assert_eq!(titles(&body), vec!["Title of public-published"]);
+    }
+
+    #[tokio::test]
+    async fn returns_an_empty_list_when_no_templates_are_public() {
+        let app = app(vec![template(
+            "private-published",
+            Status::Published,
+            Visibility::Private,
+            "2026-01-01T00:00:00Z",
+        )])
+        .await;
+
+        let (status, body) = get_public_templates(app).await;
+
+        assert_eq!(status, StatusCode::OK);
+        assert_eq!(body, serde_json::json!([]));
+    }
+
+    #[tokio::test]
+    async fn returns_an_empty_list_when_the_view_does_not_exist_yet() {
+        let state = Arc::new(library_state(&InMemory, Default::default(), vec![]).await);
+
+        let (status, body) = get_public_templates(crate::public::router(Some(state))).await;
+
+        assert_eq!(status, StatusCode::OK);
+        assert_eq!(body, serde_json::json!([]));
+    }
+
+    #[tokio::test]
+    async fn sorts_by_most_recently_modified_first() {
+        let app = app(vec![
+            template("oldest", Status::Published, Visibility::Public, "2026-01-01T00:00:00Z"),
+            template("newest", Status::Published, Visibility::Public, "2026-03-01T00:00:00Z"),
+            template("middle", Status::Published, Visibility::Public, "2026-02-01T00:00:00Z"),
+        ])
+        .await;
+
+        let (_, body) = get_public_templates(app).await;
+
+        assert_eq!(
+            titles(&body),
+            vec!["Title of newest", "Title of middle", "Title of oldest"]
+        );
+    }
+
+    #[tokio::test]
+    async fn does_not_expose_internal_fields() {
+        let app = app(vec![TemplateView {
+            source_template_id: Some("the-source-template".to_string()),
+            holder_authorization: agent_shared::config::Authorization {
+                pre_authorized: false,
+                tx_code_constraints: None,
+            },
+            description: Some("A description".to_string()),
+            r#type: vec!["VerifiableCredential".to_string()],
+            schema: Box::new(Some(serde_json::json!({ "type": "object" }))),
+            ..template(
+                "public-published",
+                Status::Published,
+                Visibility::Public,
+                "2026-01-01T00:00:00Z",
+            )
+        }])
+        .await;
+
+        let (_, body) = get_public_templates(app).await;
+
+        let template = &body.as_array().unwrap()[0];
+        let keys: Vec<&String> = template.as_object().unwrap().keys().collect();
+
+        for internal_field in ["id", "sourceTemplateId", "status", "visibility", "holderAuthorization"] {
+            assert!(
+                !keys.contains(&&internal_field.to_string()),
+                "`{internal_field}` must not be exposed publicly, got: {keys:?}"
+            );
+        }
+
+        // `modifiedAt` is deliberately public: it is the only freshness signal a reader has.
+        assert_eq!(template["modifiedAt"], "2026-01-01T00:00:00Z");
+        assert_eq!(template["title"], "Title of public-published");
+        assert_eq!(template["description"], "A description");
+        assert_eq!(template["type"], serde_json::json!(["VerifiableCredential"]));
+        assert_eq!(template["schema"], serde_json::json!({ "type": "object" }));
+    }
+}

--- a/agent_api_http/src/v0/openapi.rs
+++ b/agent_api_http/src/v0/openapi.rs
@@ -17,6 +17,7 @@ use utoipa::OpenApi;
         (path = "/v0", api = crate::v0::issuance::openapi::IssuanceApi),
         (path = "/v0", api = crate::v0::templates::openapi::TemplatesApi),
         (path = "/v0", api = crate::v0::library::catalog::openapi::CatalogsApi),
+        (path = "/public", api = crate::public::openapi::PublicApi),
     )
 )]
 pub struct ApiDoc;

--- a/docs/adr/0004-public-templates-view-derived-at-query-time.md
+++ b/docs/adr/0004-public-templates-view-derived-at-query-time.md
@@ -1,0 +1,93 @@
+# ADR 0004: Derive the Public Templates View at Query Time
+
+**Status**: Accepted  
+**Date**: 2026-08-21  
+**Context**: Read model backing the `GET /public/templates` endpoint  
+
+---
+
+## Context
+
+The `GET /public/templates` endpoint exposes every template that is both `visibility: public` and
+`status: published` to unauthenticated callers. This required deciding where the read model backing
+that endpoint should live.
+
+Three options were considered:
+
+1. **Derive at query time** from the existing `all_templates` view.
+2. **A dedicated in-memory view**, held in a `MemRepository` and reconstructed on every application
+   startup by replaying the `Template` event stream.
+3. **A dedicated persisted view**, written to its own MongoDB collection / Postgres table via the
+   normal `ListAllQuery` path.
+
+Option 3 was ruled out early: it means an additional collection to provision and operate, and it
+needs a backfill for templates that were already public before the endpoint was deployed.
+
+Option 2 was explored in some depth. The underlying primitive exists — cqrs-es 0.5 defines
+`PersistedEventRepository::stream_all_events::<A>()`, and both `mongo-es` and `postgres-es`
+implement it. It is not reachable from where it would be needed, however: the event repository is
+owned privately inside `AggregateHandler.cqrs`. Exposing it would mean changing the
+`CqrsComponentBuilder` trait and all three of its implementations (`in_memory`, `mongodb`,
+`postgres`), then `library_state()` in `agent_store`, and finally adding an await-before-serve
+startup phase in `agent_application::state()`.
+
+It would also be the first event replay in the codebase. Every view today is built incrementally by
+`ListAllQuery` as events are dispatched; nothing is ever reconstructed from the log. The closest
+precedent, `load_raw_events()`, reads the entire events collection at startup — but for event
+*verification*, not for building a view.
+
+---
+
+## Decision
+
+We derive the public templates list at query time from the existing `all_templates` view.
+
+The handler in `agent_api_http/src/public/templates.rs` loads that view through
+`public_query_handler`, filters it to `visibility == Public && status == Published`, sorts by
+`modified_at` descending, and maps the result to `PublicTemplateDto`. No new `View` implementation,
+no new view repository, no new collection, and no new startup phase.
+
+The exposed model is deliberately narrower than the internal `TemplateDto`. It omits both
+identifiers (`id`, `sourceTemplateId`) and `holderAuthorization`; `status` and `visibility` are
+omitted because every template in the response is by definition published and public, so both would
+be constants. `modifiedAt` is retained: absent a template versioning system, it is the only signal a
+reader has of how fresh a template is.
+
+---
+
+## Rationale
+
+This is the option with no structural cost. It introduces exactly one projection — the one that
+already exists — so there is no second read model that can drift from the aggregate, nothing extra
+to provision, and no change to application startup. It also matches the shape of the sibling
+handlers `get_templates` and `get_all_catalogs`, which filter the same way.
+
+---
+
+## Consequences
+
+Each request to `GET /public/templates` loads and deserializes the entire `all_templates` document,
+including private and draft templates that are then discarded. The per-request cost is therefore
+O(all templates) rather than O(public templates).
+
+This is not a new cost — `GET /v0/list-all-templates` already performs the same read — but this
+decision does place that read on an unauthenticated path for the first time.
+
+---
+
+## Future Work
+
+This should be revisited if `/public/templates` starts carrying meaningful traffic while the
+template set grows, since the O(all templates) read per request is the pressure point.
+
+The intended end state is option 2: a dedicated `PublicTemplatesView` that is pre-filtered and
+pre-shaped, held in memory, and reconstructed by event replay at startup. That refactor is
+deliberately deferred until in-memory views built via event replay exist as a general facility in
+this codebase, rather than being introduced for a single endpoint. When that facility lands, the
+handler should stop filtering `all_templates` and read the dedicated view instead.
+
+A related open question is identity: the public model intentionally carries no identifier, which
+makes the endpoint a snapshot feed rather than an addressable collection. A reader cannot ask
+whether a template it previously imported has since changed. If re-synchronisation ever becomes a
+use case, a stable opaque handle — not necessarily the internal aggregate id — would need to be
+added.


### PR DESCRIPTION
# Description of change

- https://github.com/impierce/ssi-agent-ext/pull/55

## Links to any relevant issues
Be sure to reference any related issues by adding `fixes issue #`.

## How the change has been tested
Describe the tests that you ran to verify your changes.
Make sure to provide instructions for the maintainer as well as any relevant configurations.

## Definition of Done checklist
Add an `x` to the boxes that are relevant to your changes.

- [ ] I have followed the contribution guidelines for this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] I have successfully tested this change in a docker environment 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an unauthenticated endpoint for retrieving public, published templates.
  * Templates are sorted by most recent modification and exclude internal details.
  * Added API documentation for the new public templates endpoint.

* **Documentation**
  * Documented the design and behavior of the public templates view.

* **Tests**
  * Added coverage for filtering, sorting, empty results, and exposed response fields.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->