### PR TITLE
fix: fall back to template title when display name is empty

### DIFF
--- a/agent_api_http/src/v0/templates/mod.rs
+++ b/agent_api_http/src/v0/templates/mod.rs
@@ -881,6 +881,41 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn create_template_defaults_empty_display_name_to_title() {
+        let state = Arc::new(library_state(&InMemory, Default::default(), Default::default()).await);
+
+        let response = create_template(
+            State(state),
+            RequestActor(None),
+            Json(CreateNewTemplateRequestBody {
+                title: "Created Template".to_string(),
+                display: Some(Display {
+                    name: String::new(),
+                    logo: None,
+                }),
+                data_model: DataModel::W3CVcDataModelV1_1,
+                holder_type: HolderType::Individual,
+                tags: None,
+                status: Status::Draft,
+                visibility: Visibility::Private,
+                credential_expiration: Some(Expiration::Never),
+                description: None,
+                r#type: vec![],
+                schema: None,
+                schema_properties_attributes: None,
+                holder_authorization: Authorization::default(),
+            }),
+        )
+        .await
+        .unwrap();
+
+        let body = to_bytes(response.into_body(), usize::MAX).await.unwrap();
+        let body: serde_json::Value = serde_json::from_slice(&body).unwrap();
+
+        assert_eq!(body["display"]["name"], "Created Template");
+    }
+
+    #[tokio::test]
     async fn update_template_requires_id() {
         let state = Arc::new(library_state(&InMemory, Default::default(), Default::default()).await);
 
@@ -998,6 +1033,109 @@ mod tests {
             template.r#type,
             vec!["VerifiableCredential".to_string(), "EmployeeCredential".to_string(),]
         );
+    }
+
+    #[tokio::test]
+    async fn update_template_defaults_empty_display_name_to_updated_title() {
+        let state = Arc::new(library_state(&InMemory, Default::default(), Default::default()).await);
+        create_source_template(&state, "template-to-update", Visibility::Private).await;
+
+        let response = update_template(
+            State(state.clone()),
+            RequestActor(None),
+            Json(UpdateTemplateEndpointRequest {
+                template_id: "template-to-update".to_string(),
+                title: Some("Updated title".to_string()),
+                display: Some(Display {
+                    name: String::new(),
+                    logo: None,
+                }),
+                tags: None,
+                status: None,
+                visibility: None,
+                credential_expiration: None,
+                description: None,
+                r#type: None,
+                schema: None,
+                schema_properties_attributes: None,
+                holder_authorization: None,
+            }),
+        )
+        .await
+        .unwrap();
+
+        assert_eq!(response.status(), StatusCode::NO_CONTENT);
+
+        let template = query_handler("template-to-update", &state.query.template)
+            .await
+            .unwrap()
+            .unwrap();
+        assert_eq!(template.display.unwrap().name, "Updated title");
+    }
+
+    #[tokio::test]
+    async fn update_template_keeps_title_and_display_name_independent() {
+        let state = Arc::new(library_state(&InMemory, Default::default(), Default::default()).await);
+        create_source_template(&state, "template-to-update", Visibility::Private).await;
+
+        update_template(
+            State(state.clone()),
+            RequestActor(None),
+            Json(UpdateTemplateEndpointRequest {
+                template_id: "template-to-update".to_string(),
+                title: None,
+                display: Some(Display {
+                    name: "Custom display name".to_string(),
+                    logo: None,
+                }),
+                tags: None,
+                status: None,
+                visibility: None,
+                credential_expiration: None,
+                description: None,
+                r#type: None,
+                schema: None,
+                schema_properties_attributes: None,
+                holder_authorization: None,
+            }),
+        )
+        .await
+        .unwrap();
+
+        let template = query_handler("template-to-update", &state.query.template)
+            .await
+            .unwrap()
+            .unwrap();
+        assert_eq!(template.title, "Source Template");
+        assert_eq!(template.display.unwrap().name, "Custom display name");
+
+        update_template(
+            State(state.clone()),
+            RequestActor(None),
+            Json(UpdateTemplateEndpointRequest {
+                template_id: "template-to-update".to_string(),
+                title: Some("Updated title".to_string()),
+                display: None,
+                tags: None,
+                status: None,
+                visibility: None,
+                credential_expiration: None,
+                description: None,
+                r#type: None,
+                schema: None,
+                schema_properties_attributes: None,
+                holder_authorization: None,
+            }),
+        )
+        .await
+        .unwrap();
+
+        let template = query_handler("template-to-update", &state.query.template)
+            .await
+            .unwrap()
+            .unwrap();
+        assert_eq!(template.title, "Updated title");
+        assert_eq!(template.display.unwrap().name, "Custom display name");
     }
 
     #[tokio::test]

--- a/agent_api_http/src/v0/templates/mod.rs
+++ b/agent_api_http/src/v0/templates/mod.rs
@@ -48,10 +48,24 @@ pub struct TemplateDto {
 
 impl From<Template> for TemplateDto {
     fn from(value: Template) -> Self {
+        // An empty `display.name` means no explicit display name has been set: fall back to the
+        // current title so the API always surfaces a usable name, without baking the title into
+        // the stored template (which would stop later title updates from being reflected here).
+        let display = value.display.map(|display| {
+            if display.name.trim().is_empty() {
+                Display {
+                    name: value.title.clone(),
+                    logo: display.logo,
+                }
+            } else {
+                display
+            }
+        });
+
         Self {
             template_id: value.template_id,
             title: value.title,
-            display: value.display,
+            display,
             data_model: value.data_model,
             holder_type: value.holder_type,
             modified_at: value.modified_at,

--- a/agent_issuance/src/application/credential_configuration_projection.rs
+++ b/agent_issuance/src/application/credential_configuration_projection.rs
@@ -108,7 +108,12 @@ impl CredentialConfigurationProjection {
 
 /// Derives a `CredentialConfiguration` from a `Template`.
 ///
-/// The display name is taken from `template.display.name` if present, falling back to `template.title`.
+/// The display name is taken from `template.display.name` if set, falling back to `template.title`.
+/// An empty (or whitespace-only) `display.name` counts as unset: `Display.name` cannot currently
+/// express "not provided", so clients that submit a `display` object before a title is known (for
+/// instance when uploading a logo first) end up storing `""`. Resolving the fallback here rather
+/// than materializing it into the aggregate keeps the link live: as long as no explicit display
+/// name was given, later title updates keep flowing into the issuer metadata.
 /// When the format is "vc+sd-jwt", claims are derived from `schema.properties` merged with
 /// `schema_properties_attributes.selectivelyDisclosable`.
 ///
@@ -146,8 +151,13 @@ fn credential_configuration_from_template(template: &Template) -> CredentialConf
                     alt_text: logo.alt_text.clone(),
                 })
             });
+            let name = if d.name.trim().is_empty() {
+                template.title.clone()
+            } else {
+                d.name.clone()
+            };
             vec![CredentialConfigurationsSupportedDisplay {
-                name: d.name.clone(),
+                name,
                 locale: None,
                 logo,
                 description: None,
@@ -392,7 +402,7 @@ impl Query<Template> for CredentialConfigurationProjection {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use agent_library::template::aggregate::{DataModel, Display};
+    use agent_library::template::aggregate::{DataModel, Display, Logo};
 
     #[test]
     fn test_v1_data_model_produces_jwt_vc_json_format() {
@@ -461,6 +471,33 @@ mod tests {
             .name
             .clone();
         assert_eq!(name, "My Title");
+    }
+
+    #[test]
+    fn test_title_used_as_fallback_when_display_name_is_empty() {
+        for name in ["", "   "] {
+            let template = Template {
+                template_id: "t6".to_string(),
+                display: Some(Display {
+                    name: name.to_string(),
+                    logo: Some(Logo {
+                        uri: "https://example.com/logo.png".to_string(),
+                        alt_text: None,
+                    }),
+                }),
+                title: "My Title".to_string(),
+                ..Default::default()
+            };
+            let config = credential_configuration_from_template(&template);
+            let display = config.credential_metadata.display.as_ref().unwrap().first().unwrap();
+
+            assert_eq!(display.name, "My Title");
+            // The rest of the display object is unaffected by the fallback.
+            assert_eq!(
+                display.logo.as_ref().map(|logo| logo.uri.to_string()),
+                Some("https://example.com/logo.png".to_string())
+            );
+        }
     }
 
     #[test]

--- a/agent_issuance/src/application/credential_configuration_projection.rs
+++ b/agent_issuance/src/application/credential_configuration_projection.rs
@@ -151,11 +151,13 @@ fn credential_configuration_from_template(template: &Template) -> CredentialConf
                     alt_text: logo.alt_text.clone(),
                 })
             });
+
             let name = if d.name.trim().is_empty() {
                 template.title.clone()
             } else {
                 d.name.clone()
             };
+
             vec![CredentialConfigurationsSupportedDisplay {
                 name,
                 locale: None,

--- a/agent_issuance/tests/credential_configuration_projection.rs
+++ b/agent_issuance/tests/credential_configuration_projection.rs
@@ -873,3 +873,129 @@ async fn test_schema_properties_attributes_updated_refreshes_credential_configur
         .expect("claim should be present after schema attribute update");
     assert!(!claim.mandatory);
 }
+
+#[tokio::test]
+async fn test_logo_first_draft_then_title_then_publish_uses_title_as_display_name() {
+    let (issuance, library_for_query, projection) = setup().await;
+
+    let template_id = "logo-first-template";
+    let logo = agent_library::template::aggregate::Logo {
+        uri: "https://example.com/logo.png".to_string(),
+        alt_text: None,
+    };
+
+    // 1. Uploading the logo creates a Draft template with an as-yet-unknown display name.
+    command_handler(
+        template_id,
+        &library_for_query.command.template,
+        TemplateCommand::CreateNewTemplate {
+            template_id: template_id.to_string(),
+            source_template_id: None,
+            title: "Placeholder".to_string(),
+            display: Box::new(Some(Display {
+                name: String::new(),
+                logo: Some(logo.clone()),
+            })),
+            data_model: DataModel::W3CVcDataModelV2_0,
+            holder_type: HolderType::Individual,
+            tags: None,
+            status: Status::Draft,
+            visibility: Visibility::Private,
+            credential_expiration: None,
+            description: None,
+            r#type: vec!["VerifiableCredential".to_string()],
+            schema: Box::new(None),
+            schema_properties_attributes: None,
+            holder_authorization: Authorization::default(),
+        },
+    )
+    .await
+    .unwrap();
+    let create_event = create_test_event_template_created(
+        template_id,
+        vec!["VerifiableCredential".to_string()],
+        DataModel::W3CVcDataModelV2_0,
+        "Placeholder".to_string(),
+        Some(Display {
+            name: String::new(),
+            logo: Some(logo.clone()),
+        }),
+        Status::Draft,
+    );
+    projection.dispatch(template_id, &[create_event]).await;
+
+    // 2. The user enters the actual title. `display.name` is left untouched by the UI.
+    command_handler(
+        template_id,
+        &library_for_query.command.template,
+        TemplateCommand::UpdateTitle {
+            template_id: template_id.to_string(),
+            title: "Cooking Course 101".to_string(),
+        },
+    )
+    .await
+    .unwrap();
+    projection
+        .dispatch(
+            template_id,
+            &[EventEnvelope {
+                aggregate_id: template_id.to_string(),
+                sequence: 2,
+                payload: TemplateEvent::TitleUpdated {
+                    template_id: template_id.to_string(),
+                    title: "Cooking Course 101".to_string(),
+                    modified_at: "2024-01-01T00:01:00Z".to_string(),
+                },
+                metadata: HashMap::new(),
+            }],
+        )
+        .await;
+
+    // 3. Publishing registers the credential configuration in the issuer metadata.
+    command_handler(
+        template_id,
+        &library_for_query.command.template,
+        TemplateCommand::UpdateStatus {
+            template_id: template_id.to_string(),
+            status: Status::Published,
+        },
+    )
+    .await
+    .unwrap();
+    projection
+        .dispatch(
+            template_id,
+            &[EventEnvelope {
+                aggregate_id: template_id.to_string(),
+                sequence: 3,
+                payload: TemplateEvent::StatusUpdated {
+                    template_id: template_id.to_string(),
+                    status: Status::Published,
+                    modified_at: "2024-01-01T00:02:00Z".to_string(),
+                },
+                metadata: HashMap::new(),
+            }],
+        )
+        .await;
+
+    let server_config = query_handler(SERVER_CONFIG_ID, &issuance.query.server_config)
+        .await
+        .unwrap()
+        .unwrap();
+    let (_, config_obj, _) = server_config.credential_configurations.get(template_id).unwrap();
+    let display = config_obj
+        .credential_metadata
+        .as_ref()
+        .unwrap()
+        .display
+        .as_ref()
+        .unwrap()
+        .first()
+        .unwrap();
+
+    assert_eq!(display.name, "Cooking Course 101");
+    assert_eq!(
+        display.logo.as_ref().map(|logo| logo.uri.to_string()),
+        Some("https://example.com/logo.png".to_string())
+    );
+}

--- a/agent_library/src/template/aggregate.rs
+++ b/agent_library/src/template/aggregate.rs
@@ -222,6 +222,8 @@ impl Aggregate for Template {
                     return Err(TemplateError::MissingTitle);
                 }
 
+                let display = Box::new((*display).map(|display| default_empty_display_name(display, &title)));
+
                 // Normalize type (defaults, canonical order, dedup).
                 let r#type = normalize_and_validate_type(r#type, &data_model)?;
 
@@ -342,6 +344,8 @@ impl Aggregate for Template {
             }
             UpdateDisplay { template_id, display } => {
                 ensure_template_editable(&self.status)?;
+
+                let display = default_empty_display_name(display, &self.title);
 
                 #[cfg(not(test))]
                 let modified_at = chrono::Utc::now().to_rfc3339();
@@ -865,6 +869,13 @@ fn normalize_tags(tags: Option<Vec<String>>) -> Option<Vec<String>> {
     } else {
         Some(normalized)
     }
+}
+
+fn default_empty_display_name(mut display: Display, title: &str) -> Display {
+    if display.name.trim().is_empty() {
+        display.name = title.to_string();
+    }
+    display
 }
 
 fn ensure_template_editable(status: &Status) -> Result<(), TemplateError> {

--- a/agent_library/src/template/aggregate.rs
+++ b/agent_library/src/template/aggregate.rs
@@ -222,8 +222,6 @@ impl Aggregate for Template {
                     return Err(TemplateError::MissingTitle);
                 }
 
-                let display = Box::new((*display).map(|display| default_empty_display_name(display, &title)));
-
                 // Normalize type (defaults, canonical order, dedup).
                 let r#type = normalize_and_validate_type(r#type, &data_model)?;
 


### PR DESCRIPTION
# Description of change

## Links to any relevant issues

- closes https://github.com/impierce/ssi-agent/issues/392

## How the change has been tested
Describe the tests that you ran to verify your changes.
Make sure to provide instructions for the maintainer as well as any relevant configurations.

## Definition of Done checklist
Add an `x` to the boxes that are relevant to your changes.

- [ ] I have followed the contribution guidelines for this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] I have successfully tested this change in a docker environment 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Credential configurations and API responses now use the template title when the display name is empty or contains only whitespace.
  - Existing non-empty display names remain unchanged when the template title is updated.
  - Existing logo information is preserved when the title is used as the display name.

- **Tests**
  - Added coverage for template creation, updates, and publication with empty display names, confirming title fallback and logo preservation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->